### PR TITLE
chore: 🔧 use new checksum creation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -169,9 +169,9 @@
   "web-types": "./dist/web-types.json",
   "meta": {
     "checksums": {
-      "angular": "03e72b75bbadce795c01f535e61e9bc20d710897",
-      "react": "d64e473174a11c422b16a9d8778cd715c937a7d7",
-      "vue": "3474445ab6bd612ccc2cad15ef00a3e274f90518"
+      "angular": "3590f1e69d57dac5d865c6ad9e54d6c87c4088f5",
+      "react": "38a237a6bd1e322fa85db68df27b2c8f149a7f5d",
+      "vue": "09d274f770baf8c3cbad69d57c73287a66ee8c45"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the `package.json` file with the new checksums for the `angular`, `react`, and `vue` packages. The checksums are obtained by running `git rev-parse HEAD:packages/{project}` for each package. This ensures that the checksums are always up to date with the latest commit in each package and is hopefully more robust and performant in comparison to (p)npm publish.