### PR TITLE
chore: 🔧 Reduce chromatic load via bundled screenshot story

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -104,13 +104,9 @@
         "packages/components/tsconfig.prod.json": true,
         "packages/components/web-test-runner.config.js": true,
         "packages/docs/stories/components/alert.stories.ts": true,
-        "packages/docs/stories/components/button.stories.ts": true,
         "packages/react/src/**": true
     },
     "html.customData": [
         "packages/components/dist/vscode.html-custom-data.json"
-    ],
-    "files.readonlyExclude": {
-        "packages/docs/stories/components/button.stories.ts": true
-    }
+    ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ ICON and PREFIX are one of the following:
 Examples for valid PR titles:
 
 ```
-fix: 🐛 Fix accessibility in syn-button
+fix: 🤔 Fix accessibility in syn-button
 feat: ✨ Add syn-radio
 docs: 📚 Add installation instructions
 chore: 🔧 Improve build scripts

--- a/packages/docs/.eslintrc
+++ b/packages/docs/.eslintrc
@@ -11,6 +11,9 @@
     "import/no-extraneous-dependencies": 0,
 
     // We have to include our packages in a relative way to make autoreloads work
-    "import/no-relative-packages": 0
+    "import/no-relative-packages": 0,
+
+    // Disabled, because we need to use the name property to set the story name to generate the bundled screenshot story
+    "storybook/no-redundant-story-name": 0
   }
 }

--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -10,6 +10,9 @@ import { stopAnimation } from '../src/decorators/StopAnimation';
 const preview: Preview = {
   decorators: [stopAnimation],
   parameters: {
+    chromatic: { 
+      disableSnapshot: true
+    },
     docs: {
       stories: { inline: false }
     },

--- a/packages/docs/.storybook/preview.ts
+++ b/packages/docs/.storybook/preview.ts
@@ -18,6 +18,7 @@ const preview: Preview = {
     },
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {
+      disable: true,
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/,

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -8,4 +8,15 @@ This package provides interactive demos for each of the offered component in for
 
 ## Usage
 
-After installing all dependencies and building the project, execute `pnpm start`. A browser window will open on http://localhost:6006/ and show the Stoybook instance.
+After installing all dependencies and building the project, execute `pnpm start`. A browser window will open on http://localhost:6006/ and show the Storybook instance.
+
+## Development
+Storybook stories are not only used for documentation, but also for visual regression tests via Chromatic screenshots.
+The amount of screenshots in Chromatic is limited. To avoid running into this limit, we need to minimize the amount of screenshots.
+
+This is achieved via bundling all non interactive stories of one component into a single story, which will then be used as screenshot. There is a helper function _generateScreenshotStory_ under _src/helpers/component.ts_ to create a bundled story out of multiple ones.
+All interactive stories, this are stories with the _play_ functionality (e.g. focus stories or validation stories), need to remain as unique story.
+
+In order to ensure that stories are not accidentally taken as screenshot, the chromatic screenshot ability is disabled globally and needs to be explicitly allowed for each story. If the helper function is used it is not necessary, because it does this by itself.
+
+To make the helper function work correctly, all stories need to set the _name_ property with the story name, although it would not be necessary for storybook itself. The function needs this information, to be able to print the name of the story above each as headline.

--- a/packages/docs/src/helpers/component.ts
+++ b/packages/docs/src/helpers/component.ts
@@ -615,9 +615,6 @@ export const generateScreenshotStory = (stories: Array<StoryObj>, heightPx: numb
       chromatic: {
         disableSnapshot: false,
       },
-      controls: {
-        disable: true,
-      },
     },
     render: (args, context) => html`${stories.map((story) => html`
     <div style='height: ${heightPx}px; margin: var(--syn-spacing-small)'>

--- a/packages/docs/src/helpers/component.ts
+++ b/packages/docs/src/helpers/component.ts
@@ -6,7 +6,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { getWcStorybookHelpers } from '@mariohamann/wc-storybook-helpers';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import format from 'html-format';
-import { setCustomElementsManifest } from '@storybook/web-components';
+import { StoryObj, setCustomElementsManifest } from '@storybook/web-components';
 import docsTokens from '../../../tokens/src/figma-tokens/_docs.json';
 
 export default async function loadCustomElements() {
@@ -600,3 +600,30 @@ type AttributeDescription = {
 export const generateStoryDescription = <T extends Component>(component: T, attribute: Attribute<T>) => (
    (docsTokens?.components?.[component]?.[attribute] as AttributeDescription)?.description?.value ?? 'No Description'
 );
+
+
+/**
+ * Creates a bundled story for non-interactive stories, which does a chromatic screenshot
+ * 
+ * @param stories - all non-interactive stories which should be bundled
+ * @param heightPx - the height of each single story
+ * @returns the bundled story
+ */
+export const generateScreenshotStory = (stories: Array<StoryObj>, heightPx: number = 150): StoryObj => {
+  return {
+    parameters: {
+      chromatic: {
+        disableSnapshot: false,
+      },
+      controls: {
+        disable: true,
+      },
+    },
+    render: (args, context) => html`${stories.map((story) => html`
+    <div style='height: ${heightPx}px; margin: var(--syn-spacing-small)'>
+      <div style='margin-bottom: var(--syn-spacing-small)'>${story.name}</div>
+      ${story.render?.(args, context)}
+    </div>
+    `)}`,
+  };
+}

--- a/packages/docs/src/helpers/component.ts
+++ b/packages/docs/src/helpers/component.ts
@@ -615,10 +615,13 @@ export const generateScreenshotStory = (stories: Array<StoryObj>, heightPx: numb
       chromatic: {
         disableSnapshot: false,
       },
+      docs: {
+        disable: true
+      },
     },
     render: (args, context) => html`${stories.map((story) => html`
     <div style='height: ${heightPx}px; margin: var(--syn-spacing-small)'>
-      <div style='margin-bottom: var(--syn-spacing-small)'>${story.name}</div>
+      <h3>${story.name}</h3>
       ${story.render?.(args, context)}
     </div>
     `)}`,

--- a/packages/docs/stories/components/button.stories.ts
+++ b/packages/docs/stories/components/button.stories.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable import/no-relative-packages */
 
 import '../../../components/src/components/button/button';
 import type { Meta, StoryObj } from '@storybook/web-components';
@@ -37,6 +36,9 @@ type Story = StoryObj;
 
 export const Default = {
   parameters: {
+    controls: {
+      disable: false,
+    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'default'),
@@ -49,9 +51,6 @@ export const Default = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'variant'),
@@ -61,20 +60,12 @@ export const Variants: Story = {
   render: () => html`
   <syn-button variant="filled">Filled</syn-button>
   <syn-button variant="outline">Outline</syn-button>
-  <syn-button variant="text">Text</syn-button>
-  <style>
-    syn-button {
-      margin: 0.2rem;
-    }
-  </style>`,
+  <syn-button variant="text">Text</syn-button>`,
 };
 
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'size'),
@@ -84,12 +75,7 @@ export const Sizes: Story = {
   render: () => html`
   <syn-button size="small">Small</syn-button>
   <syn-button size="medium">Medium</syn-button>
-  <syn-button size="large">Large</syn-button>
-  <style>
-    syn-button {
-      margin: 0.2rem;
-    }
-  </style>`,
+  <syn-button size="large">Large</syn-button>`,
 };
 
 export const Focus: Story = {
@@ -97,9 +83,6 @@ export const Focus: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {
@@ -119,9 +102,6 @@ export const Focus: Story = {
 export const LinkButtons: Story = {
   name: 'Link buttons',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'link'),
@@ -132,20 +112,12 @@ export const LinkButtons: Story = {
   <syn-button href="https://example.com/">Link</syn-button>
   <syn-button href="https://example.com/" target="_blank">New Window</syn-button>
   <syn-button href="/assets/images/wordmark.svg" download="synergy.svg">Download</syn-button>
-  <syn-button href="https://example.com/" disabled>Disabled</syn-button>
-  <style>
-    syn-button {
-      margin: 0.2rem;
-    }
-  </style>`,
+  <syn-button href="https://example.com/" disabled>Disabled</syn-button>`,
 };
 
 export const SettingACustomWidth: Story = {
   name: 'Setting a custom width',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'width'),
@@ -161,9 +133,6 @@ export const SettingACustomWidth: Story = {
 export const PrefixAndSuffixIcons: Story = {
   name: 'Prefix and suffix icons',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'prefix-suffix'),
@@ -221,20 +190,12 @@ export const PrefixAndSuffixIcons: Story = {
     <syn-icon slot="prefix" name="link"></syn-icon>
     <syn-icon slot="suffix" name="launch"></syn-icon>
     Open
-  </syn-button>
-  <style>
-    syn-button {
-      margin: 0.2rem;
-    }
-  </style>`,
+  </syn-button>`,
 };
 
 export const Caret: Story = {
   name: 'Caret',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'caret'),
@@ -244,20 +205,12 @@ export const Caret: Story = {
   render: () => html`
   <syn-button size="small" caret>Small</syn-button>
   <syn-button size="medium" caret>Medium</syn-button>
-  <syn-button size="large" caret>Large</syn-button>
-  <style>
-    syn-button {
-      margin: 0.2rem;
-    }
-  </style>`,
+  <syn-button size="large" caret>Large</syn-button>`,
 };
 
 export const Loading: Story = {
   name: 'Loading',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'loading'),
@@ -267,20 +220,12 @@ export const Loading: Story = {
   render: () => html`
   <syn-button variant="filled" loading>Filled</syn-button>
   <syn-button variant="outline" loading>Outline</syn-button>
-  <syn-button variant="text" loading>Text</syn-button>
-  <style>
-    syn-button {
-      margin: 0.2rem;
-    }
-  </style>`,
+  <syn-button variant="text" loading>Text</syn-button>`,
 };
 
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('button', 'disabled'),

--- a/packages/docs/stories/components/button.stories.ts
+++ b/packages/docs/stories/components/button.stories.ts
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import type { SynButton } from '@synergy-design-system/components';
 import {
+  generateScreenshotStory,
   generateStoryDescription,
   storybookDefaults,
   storybookHelpers,
@@ -46,6 +47,7 @@ export const Default = {
 } as Story;
 
 export const Variants: Story = {
+  name: 'Variants',
   parameters: {
     controls: {
       disable: true,
@@ -68,6 +70,7 @@ export const Variants: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Sizes',
   parameters: {
     controls: {
       disable: true,
@@ -90,7 +93,11 @@ export const Sizes: Story = {
 };
 
 export const Focus: Story = {
+  name: 'Focus',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -110,6 +117,7 @@ export const Focus: Story = {
 };
 
 export const LinkButtons: Story = {
+  name: 'Link buttons',
   parameters: {
     controls: {
       disable: true,
@@ -133,6 +141,7 @@ export const LinkButtons: Story = {
 };
 
 export const SettingACustomWidth: Story = {
+  name: 'Setting a custom width',
   parameters: {
     controls: {
       disable: true,
@@ -150,6 +159,7 @@ export const SettingACustomWidth: Story = {
 };
 
 export const PrefixAndSuffixIcons: Story = {
+  name: 'Prefix and suffix icons',
   parameters: {
     controls: {
       disable: true,
@@ -220,6 +230,7 @@ export const PrefixAndSuffixIcons: Story = {
 };
 
 export const Caret: Story = {
+  name: 'Caret',
   parameters: {
     controls: {
       disable: true,
@@ -242,6 +253,7 @@ export const Caret: Story = {
 };
 
 export const Loading: Story = {
+  name: 'Loading',
   parameters: {
     controls: {
       disable: true,
@@ -264,6 +276,7 @@ export const Loading: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -279,3 +292,17 @@ export const Disabled: Story = {
   <syn-button variant="outline" disabled>Outline</syn-button>
   <syn-button variant="text" disabled>Text</syn-button>`,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Variants,
+  Sizes,
+  LinkButtons,
+  SettingACustomWidth,
+  PrefixAndSuffixIcons,
+  Caret,
+  Loading,
+  Disabled,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories, 280);

--- a/packages/docs/stories/components/button.stories.ts
+++ b/packages/docs/stories/components/button.stories.ts
@@ -60,7 +60,12 @@ export const Variants: Story = {
   render: () => html`
   <syn-button variant="filled">Filled</syn-button>
   <syn-button variant="outline">Outline</syn-button>
-  <syn-button variant="text">Text</syn-button>`,
+  <syn-button variant="text">Text</syn-button>
+  <style>
+    syn-button {
+      margin: 0.2rem;
+    }
+  </style>`,
 };
 
 export const Sizes: Story = {
@@ -75,7 +80,12 @@ export const Sizes: Story = {
   render: () => html`
   <syn-button size="small">Small</syn-button>
   <syn-button size="medium">Medium</syn-button>
-  <syn-button size="large">Large</syn-button>`,
+  <syn-button size="large">Large</syn-button>
+  <style>
+    syn-button {
+      margin: 0.2rem;
+    }
+  </style>`,
 };
 
 export const Focus: Story = {
@@ -112,7 +122,12 @@ export const LinkButtons: Story = {
   <syn-button href="https://example.com/">Link</syn-button>
   <syn-button href="https://example.com/" target="_blank">New Window</syn-button>
   <syn-button href="/assets/images/wordmark.svg" download="synergy.svg">Download</syn-button>
-  <syn-button href="https://example.com/" disabled>Disabled</syn-button>`,
+  <syn-button href="https://example.com/" disabled>Disabled</syn-button>
+  <style>
+    syn-button {
+      margin: 0.2rem;
+    }
+  </style>`,
 };
 
 export const SettingACustomWidth: Story = {
@@ -190,7 +205,12 @@ export const PrefixAndSuffixIcons: Story = {
     <syn-icon slot="prefix" name="link"></syn-icon>
     <syn-icon slot="suffix" name="launch"></syn-icon>
     Open
-  </syn-button>`,
+  </syn-button>
+  <style>
+    syn-button {
+      margin: 0.2rem;
+    }
+  </style>`,
 };
 
 export const Caret: Story = {
@@ -205,7 +225,12 @@ export const Caret: Story = {
   render: () => html`
   <syn-button size="small" caret>Small</syn-button>
   <syn-button size="medium" caret>Medium</syn-button>
-  <syn-button size="large" caret>Large</syn-button>`,
+  <syn-button size="large" caret>Large</syn-button>
+  <style>
+    syn-button {
+      margin: 0.2rem;
+    }
+  </style>`,
 };
 
 export const Loading: Story = {
@@ -220,7 +245,12 @@ export const Loading: Story = {
   render: () => html`
   <syn-button variant="filled" loading>Filled</syn-button>
   <syn-button variant="outline" loading>Outline</syn-button>
-  <syn-button variant="text" loading>Text</syn-button>`,
+  <syn-button variant="text" loading>Text</syn-button>
+  <style>
+    syn-button {
+      margin: 0.2rem;
+    }
+  </style>`,
 };
 
 export const Disabled: Story = {

--- a/packages/docs/stories/components/button.stories.ts
+++ b/packages/docs/stories/components/button.stories.ts
@@ -239,7 +239,7 @@ export const Disabled: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Variants,
   Sizes,
   LinkButtons,
@@ -248,6 +248,4 @@ const bundledStories: Array<Story> = [
   Caret,
   Loading,
   Disabled,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories, 280);
+], 280);

--- a/packages/docs/stories/components/checkbox.stories.ts
+++ b/packages/docs/stories/components/checkbox.stories.ts
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
 import {
+  generateScreenshotStory,
   generateStoryDescription,
   storybookDefaults,
   storybookHelpers,
@@ -45,6 +46,7 @@ export const Default = {
 } as Story;
 
 export const Checked: Story = {
+  name: 'Checked',
   parameters: {
     controls: {
       disable: true,
@@ -59,6 +61,7 @@ export const Checked: Story = {
 };
 
 export const Indeterminate: Story = {
+  name: 'Indeterminate',
   parameters: {
     controls: {
       disable: true,
@@ -73,6 +76,7 @@ export const Indeterminate: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -87,6 +91,7 @@ export const Disabled: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Sizes',
   parameters: {
     controls: {
       disable: true,
@@ -107,7 +112,11 @@ export const Sizes: Story = {
 };
 
 export const CustomValidity: Story = {
+  name: 'Custom validity',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -169,3 +178,13 @@ export const CustomValidity: Story = {
     </script>
   `,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Checked,
+  Indeterminate,
+  Disabled,
+  Sizes,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories);

--- a/packages/docs/stories/components/checkbox.stories.ts
+++ b/packages/docs/stories/components/checkbox.stories.ts
@@ -36,6 +36,9 @@ type Story = StoryObj;
 
 export const Default = {
   parameters: {
+    controls: {
+      disable: false,
+    },
     docs: {
       description: {
         story: generateStoryDescription('checkbox', 'default'),
@@ -48,9 +51,6 @@ export const Default = {
 export const Checked: Story = {
   name: 'Checked',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('checkbox', 'checked'),
@@ -63,9 +63,6 @@ export const Checked: Story = {
 export const Indeterminate: Story = {
   name: 'Indeterminate',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('checkbox', 'indeterminate'),
@@ -78,9 +75,6 @@ export const Indeterminate: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('checkbox', 'disabled'),
@@ -93,9 +87,6 @@ export const Disabled: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('checkbox', 'sizes'),
@@ -116,9 +107,6 @@ export const CustomValidity: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {

--- a/packages/docs/stories/components/checkbox.stories.ts
+++ b/packages/docs/stories/components/checkbox.stories.ts
@@ -168,11 +168,9 @@ export const CustomValidity: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Checked,
   Indeterminate,
   Disabled,
   Sizes,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories);
+]);

--- a/packages/docs/stories/components/default-icons.stories.ts
+++ b/packages/docs/stories/components/default-icons.stories.ts
@@ -16,9 +16,6 @@ type Story = StoryObj;
 
 const createIconPage = (letter: string): Story => ({
   parameters: {
-    chromatic: {
-      disableSnapshot: true,
-    },
     controls: {
       disable: true,
     },

--- a/packages/docs/stories/components/default-icons.stories.ts
+++ b/packages/docs/stories/components/default-icons.stories.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable import/no-relative-packages */
 
 import '../../../components/src/components/icon/icon.js';
 import { type Meta, type StoryObj } from '@storybook/web-components';
@@ -15,11 +14,6 @@ export default meta;
 type Story = StoryObj;
 
 const createIconPage = (letter: string): Story => ({
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
   render: () => {
     const regex = new RegExp(`^${letter}`);
     const iconKeys = Object.keys(defaultIcons);

--- a/packages/docs/stories/components/icon.stories.ts
+++ b/packages/docs/stories/components/icon.stories.ts
@@ -4,7 +4,9 @@
 import '../../../components/src/components/icon/icon';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
-import { storybookDefaults, storybookHelpers, storybookTemplate } from '../../src/helpers/component.js';
+import {
+  generateScreenshotStory, storybookDefaults, storybookHelpers, storybookTemplate,
+} from '../../src/helpers/component.js';
 import { registerIconLibrary } from '../../../components/src/utilities/icon-library.js';
 import { defaultIcons } from '../../../assets/src/default-icons.js';
 
@@ -151,6 +153,7 @@ export const Default = {
  * Icons inherit their color from the current text color. Thus, you can set the color property on the <syn-icon> element or an ancestor to change the color.
  */
 export const Colors: Story = {
+  name: 'Colors',
   render: () => html`<div style="color: var(--syn-color-primary-600);">
   <syn-icon name="warning"></syn-icon>
   <syn-icon name="inventory"></syn-icon>
@@ -175,6 +178,7 @@ export const Colors: Story = {
  * Icons are sized relative to the current font size. To change their size, set the font-size property on the icon itself or on a parent element as shown below.
  */
 export const Sizing: Story = {
+  name: 'Sizing',
   render: () => html`<div style="font-size: var(--syn-font-size-2x-large);">
   <syn-icon name="warning"></syn-icon>
   <syn-icon name="inventory"></syn-icon>
@@ -199,6 +203,7 @@ export const Sizing: Story = {
  * For non-decorative icons, use the label attribute to announce it to assistive devices.
  */
 export const Labels: Story = {
+  name: 'Labels',
   render: () => html`<syn-icon name="star" label="Add to favorites"></syn-icon>`,
 };
 
@@ -207,6 +212,7 @@ export const Labels: Story = {
  * If you're using more than one custom icon, it might make sense to register a custom icon library.
  */
 export const CustomIcons: Story = {
+  name: 'Custom icons',
   render: () => html`<syn-icon src="/logo-claim.svg" style="font-size: 10rem;"></syn-icon>`,
 };
 
@@ -256,6 +262,7 @@ export const CustomIcons: Story = {
  * to see how to handle this.
  */
 export const CDNIconLibrary: Story = {
+  name: 'CDN icon library',
   render: () => {
     registerIconLibrary('fa', {
       resolver: name => {
@@ -314,6 +321,7 @@ export const CDNIconLibrary: Story = {
 * ```
 */
 export const BundledIconLibrary: Story = {
+  name: 'Bundled icon library',
   render: () => {
     registerIconLibrary('bundled-default', {
       resolver: (name) => {
@@ -364,6 +372,7 @@ export const BundledIconLibrary: Story = {
 * ```
 */
 export const SpriteSheetUsage: Story = {
+  name: 'Sprite sheet usage',
   render: () => {
     registerIconLibrary('sprite', {
       resolver: name => `/sprite.svg#${name}`,
@@ -378,3 +387,15 @@ export const SpriteSheetUsage: Story = {
   },
 };
 
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Colors,
+  Sizing,
+  Labels,
+  CustomIcons,
+  CDNIconLibrary,
+  BundledIconLibrary,
+  SpriteSheetUsage,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories);

--- a/packages/docs/stories/components/icon.stories.ts
+++ b/packages/docs/stories/components/icon.stories.ts
@@ -1,5 +1,5 @@
-/* eslint-disable */
-/* eslint-disable import/no-relative-packages */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 
 import '../../../components/src/components/icon/icon';
 import { type Meta, type StoryObj } from '@storybook/web-components';
@@ -10,7 +10,7 @@ import {
 import { registerIconLibrary } from '../../../components/src/utilities/icon-library.js';
 import { defaultIcons } from '../../../assets/src/default-icons.js';
 
-const { args, argTypes } = storybookDefaults('syn-icon');
+const { args: defaultArgs, argTypes } = storybookDefaults('syn-icon');
 const { overrideArgs } = storybookHelpers('syn-icon');
 const { generateTemplate } = storybookTemplate('syn-icon');
 
@@ -120,15 +120,17 @@ Most of the magic behind assets is handled internally by Synergy, but if you nee
 `;
 
 const meta: Meta = {
-  component: 'icon',
-  args: overrideArgs({ type: 'attribute', value: 'wallpaper', name: 'name' }, args),
+  args: overrideArgs({ name: 'name', type: 'attribute', value: 'wallpaper' }, defaultArgs),
   argTypes,
+  component: 'icon',
   parameters: {
     docs: {
       description: {
-        // The documentation has to be added like this as template string and not as block comment above, because otherwise the example of the angular+webpack glob pattern would not work.
+        // The docu has to be added like this as template string and not as block comment above,
+        //  because otherwise the example of the angular+webpack glob pattern would not work.
         // The "*/" of "glob": "**/*" would close the block comment.
-        // It could be escaped by doing "glob": "**\/*" but then the users would see the backslash and also would copy it with the example.
+        // It could be escaped by doing "glob": "**\/*" but then the users would see the backslash
+        // and also would copy it with the example.
         component: iconDocumentation,
       },
     },
@@ -143,14 +145,17 @@ type Story = StoryObj;
  * This shows the syn-icon in its default state
  */
 export const Default = {
-  render: (args: any) => {
-    return generateTemplate({ args });
+  parameters: {
+    controls: {
+      disable: false,
+    },
   },
+  render: (args: unknown) => generateTemplate({ args }),
 } as Story;
 
-
 /**
- * Icons inherit their color from the current text color. Thus, you can set the color property on the <syn-icon> element or an ancestor to change the color.
+ * Icons inherit their color from the current text color.
+ * Thus, you can set the color property on the <syn-icon> element or an ancestor to change color.
  */
 export const Colors: Story = {
   name: 'Colors',
@@ -175,7 +180,9 @@ export const Colors: Story = {
 };
 
 /**
- * Icons are sized relative to the current font size. To change their size, set the font-size property on the icon itself or on a parent element as shown below.
+ * Icons are sized relative to the current font size.
+ * To change their size, set the font-size property on the icon itself
+ * or on a parent element as shown below.
  */
 export const Sizing: Story = {
   name: 'Sizing',
@@ -208,7 +215,8 @@ export const Labels: Story = {
 };
 
 /**
- * Custom icons can be loaded individually with the src attribute. Only SVGs on a local or CORS-enabled endpoint are supported.
+ * Custom icons can be loaded individually with the src attribute.
+ * Only SVGs on a local or CORS-enabled endpoint are supported.
  * If you're using more than one custom icon, it might make sense to register a custom icon library.
  */
 export const CustomIcons: Story = {
@@ -221,9 +229,11 @@ export const CustomIcons: Story = {
  *
  * The following example demonstrates how to register the open source icon library [Font Awesome](https://fontawesome.com/) using the jsDelivr CDN.
  * Icons in this library are licensed under the [Font Awesome Free License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt).
- * Some of the icons that appear on the Font Awesome website require a license and are therefore not available in the CDN.
+ * Some of the icons that appear on the Font Awesome website require a license
+ * and are therefore not available in the CDN.
  *
- * This library has three variations: regular (far-*), solid (fas-*), and brands (fab-*). A mutator function is required to set the SVG’s fill to currentColor. 
+ * This library has three variations: regular (far-*), solid (fas-*), and brands (fab-*).
+ * A mutator function is required to set the SVG’s fill to currentColor.
  *
  * Feel free to adapt the code as you see fit to use your own origin or naming conventions.
  *
@@ -257,7 +267,8 @@ export const CustomIcons: Story = {
  *    <syn-icon library="fa" name="fab-edge"></syn-icon>
  *  </div>
  * ```
- * If an icon is used before registration occurs, it will be empty initially but shown when registered.
+ * If an icon is used before registration occurs, it will be empty initially,
+ * but shown when registered.
  * Check out the example below or the [Shoelace Docs](https://shoelace.style/components/icon?id=icon-libraries)
  * to see how to handle this.
  */
@@ -293,7 +304,8 @@ export const CDNIconLibrary: Story = {
 /**
 * The package [@synergy-design-system/assets](https://github.com/synergy-design-system/synergy-design-system/tree/main/packages/assets) provides the possibility to get all default icons via a bundled file.
 *
-* > **Warning:** Please keep in mind that via this way of using icons **all** icons will be bundled into your application and it will create larger bundle sizes!
+* > **Warning:** Please keep in mind that via this way of using icons **all** icons
+* will be bundled into your application and it will create larger bundle sizes!
 *
 * ```html
 * <script type="module">
@@ -324,6 +336,7 @@ export const BundledIconLibrary: Story = {
   name: 'Bundled icon library',
   render: () => {
     registerIconLibrary('bundled-default', {
+      mutator: svg => svg.setAttribute('fill', 'currentColor'),
       resolver: (name) => {
         if (name in defaultIcons) {
           const defaultName = name as keyof typeof defaultIcons;
@@ -331,7 +344,6 @@ export const BundledIconLibrary: Story = {
         }
         return '';
       },
-      mutator: svg => svg.setAttribute('fill', 'currentColor'),
     });
 
     return html`<div style="font-size: var(--syn-font-size-x-large);">
@@ -345,13 +357,18 @@ export const BundledIconLibrary: Story = {
 
 /**
 * To improve performance you can use a SVG sprites to avoid multiple trips for each SVG.
-* The browser will load the sprite sheet once and then you reference the particular SVG within the sprite sheet using hash selector.
+* The browser will load the sprite sheet once and
+* then you reference the particular SVG within the sprite sheet using hash selector.
 *
-* As always, make sure to benchmark these changes. When using HTTP/2, it may in fact be more bandwidth-friendly to use multiple small requests instead of 1 large sprite sheet.
+* As always, make sure to benchmark these changes. When using HTTP/2, it may in fact be more
+* bandwidth-friendly to use multiple small requests instead of 1 large sprite sheet.
 *
 * > **Warning:** When using sprite sheets, the syn-load and syn-error events will not fire.
 *
-* > **Warning:** For security reasons, browsers may apply the same-origin policy on <use> elements located in the <syn-icon> shadow DOM and may refuse to load a cross-origin URL. There is currently no defined way to set a cross-origin policy for <use> elements. For this reason, sprite sheets should only be used if you’re self-hosting them.
+* > **Warning:** For security reasons, browsers may apply the same-origin policy on <use> elements
+* located in the <syn-icon> shadow DOM and may refuse to load a cross-origin URL.
+* There is currently no defined way to set a cross-origin policy for <use> elements.
+* For this reason, sprite sheets should only be used if you’re self-hosting them.
 *
 * ```html
 * <script type="module">
@@ -375,9 +392,9 @@ export const SpriteSheetUsage: Story = {
   name: 'Sprite sheet usage',
   render: () => {
     registerIconLibrary('sprite', {
-      resolver: name => `/sprite.svg#${name}`,
       mutator: svg => svg.setAttribute('fill', 'currentColor'),
-      spriteSheet: true
+      resolver: name => `/sprite.svg#${name}`,
+      spriteSheet: true,
     });
 
     return html`<div style="font-size: var(--syn-font-size-x-large);">

--- a/packages/docs/stories/components/icon.stories.ts
+++ b/packages/docs/stories/components/icon.stories.ts
@@ -126,8 +126,9 @@ const meta: Meta = {
   parameters: {
     docs: {
       description: {
-        // The docu has to be added like this as template string and not as block comment above,
-        //  because otherwise the example of the angular+webpack glob pattern would not work.
+        // The documentation has to be added like this as template string
+        // and not as block comment above, because otherwise the example of the
+        // angular+webpack glob pattern would not work.
         // The "*/" of "glob": "**/*" would close the block comment.
         // It could be escaped by doing "glob": "**\/*" but then the users would see the backslash
         // and also would copy it with the example.
@@ -405,7 +406,7 @@ export const SpriteSheetUsage: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Colors,
   Sizing,
   Labels,
@@ -413,6 +414,4 @@ const bundledStories: Array<Story> = [
   CDNIconLibrary,
   BundledIconLibrary,
   SpriteSheetUsage,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories);
+]);

--- a/packages/docs/stories/components/input.stories.ts
+++ b/packages/docs/stories/components/input.stories.ts
@@ -295,7 +295,7 @@ export const CustomizingLabelPosition: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Labels,
   HelpText,
   Placeholders,
@@ -307,6 +307,4 @@ const bundledStories: Array<Story> = [
   InputTypes,
   PrefixSuffixIcons,
   CustomizingLabelPosition,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories, 360);
+], 360);

--- a/packages/docs/stories/components/input.stories.ts
+++ b/packages/docs/stories/components/input.stories.ts
@@ -4,7 +4,9 @@ import '../../../components/src/components/input/input';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
-import { generateStoryDescription, storybookDefaults, storybookTemplate } from '../../src/helpers/component.js';
+import {
+  generateScreenshotStory, generateStoryDescription, storybookDefaults, storybookTemplate,
+} from '../../src/helpers/component.js';
 
 const { args, argTypes } = storybookDefaults('syn-input');
 const { generateTemplate } = storybookTemplate('syn-input');
@@ -37,6 +39,7 @@ export const Default = {
 } as Story;
 
 export const Labels: Story = {
+  name: 'Labels',
   parameters: {
     controls: {
       disable: true,
@@ -51,6 +54,7 @@ export const Labels: Story = {
 };
 
 export const HelpText: Story = {
+  name: 'Help text',
   parameters: {
     controls: {
       disable: true,
@@ -65,6 +69,7 @@ export const HelpText: Story = {
 };
 
 export const Placeholders: Story = {
+  name: 'Placeholder',
   parameters: {
     controls: {
       disable: true,
@@ -79,6 +84,7 @@ export const Placeholders: Story = {
 };
 
 export const Clearable: Story = {
+  name: 'Clearable',
   parameters: {
     controls: {
       disable: true,
@@ -93,6 +99,7 @@ export const Clearable: Story = {
 };
 
 export const TogglePassword: Story = {
+  name: 'Toggle password',
   parameters: {
     controls: {
       disable: true,
@@ -107,6 +114,7 @@ export const TogglePassword: Story = {
 };
 
 export const ReadonlyInputs: Story = {
+  name: 'Readonly inputs',
   parameters: {
     controls: {
       disable: true,
@@ -126,7 +134,11 @@ export const Focus: Story = {
     label: 'Label',
     placeholder: 'Insert text here...',
   },
+  name: 'Focus',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -150,6 +162,7 @@ export const Focus: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -168,6 +181,7 @@ export const Disabled: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Sizes',
   parameters: {
     controls: {
       disable: true,
@@ -190,7 +204,11 @@ export const Invalid: Story = {
     label: 'Label',
     placeholder: 'Insert text here...',
   },
+  name: 'Invalid',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -245,6 +263,7 @@ export const Invalid: Story = {
  * The type attribute controls the type of input the browser renders.
  */
 export const InputTypes: Story = {
+  name: 'Input types',
   render: () => html`
   <syn-input type="email" placeholder="Email"></syn-input><br/>
   <syn-input type="number" placeholder="Number"></syn-input><br/>
@@ -252,6 +271,7 @@ export const InputTypes: Story = {
 };
 
 export const PrefixSuffixIcons: Story = {
+  name: 'Prefix and suffix icons',
   parameters: {
     controls: {
       disable: true,
@@ -286,6 +306,7 @@ export const PrefixSuffixIcons: Story = {
  * The same technique works for inputs, textareas, radio groups, and similar form controls.
  */
 export const CustomizingLabelPosition: Story = {
+  name: 'Customizing label position',
   render: () => html`
   <syn-input class="label-on-left" label="Name" help-text="Enter your name"></syn-input>
   <syn-input class="label-on-left" label="Email" type="email" help-text="Enter your email"></syn-input>
@@ -317,3 +338,20 @@ export const CustomizingLabelPosition: Story = {
     }
   </style>`,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Labels,
+  HelpText,
+  Placeholders,
+  Clearable,
+  TogglePassword,
+  ReadonlyInputs,
+  Disabled,
+  Sizes,
+  InputTypes,
+  PrefixSuffixIcons,
+  CustomizingLabelPosition,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories, 360);

--- a/packages/docs/stories/components/input.stories.ts
+++ b/packages/docs/stories/components/input.stories.ts
@@ -29,6 +29,9 @@ type Story = StoryObj;
 
 export const Default = {
   parameters: {
+    controls: {
+      disable: false,
+    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'default'),
@@ -41,9 +44,6 @@ export const Default = {
 export const Labels: Story = {
   name: 'Labels',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'label'),
@@ -56,9 +56,6 @@ export const Labels: Story = {
 export const HelpText: Story = {
   name: 'Help text',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'help-text'),
@@ -71,9 +68,6 @@ export const HelpText: Story = {
 export const Placeholders: Story = {
   name: 'Placeholder',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'placeholder'),
@@ -86,24 +80,18 @@ export const Placeholders: Story = {
 export const Clearable: Story = {
   name: 'Clearable',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'clearable'),
       },
     },
   },
-  render: () => html`<syn-input placeholder="Clearable" clearable></syn-input>`,
+  render: () => html`<syn-input value="Clearable" placeholder="Clearable" clearable></syn-input>`,
 };
 
 export const TogglePassword: Story = {
   name: 'Toggle password',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'password-toggle'),
@@ -116,9 +104,6 @@ export const TogglePassword: Story = {
 export const ReadonlyInputs: Story = {
   name: 'Readonly inputs',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'readonly'),
@@ -129,18 +114,10 @@ export const ReadonlyInputs: Story = {
 };
 
 export const Focus: Story = {
-  args: {
-    helpText: 'This input is focused.',
-    label: 'Label',
-    placeholder: 'Insert text here...',
-  },
   name: 'Focus',
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: generateStoryDescription('input', 'focus'),
@@ -154,9 +131,7 @@ export const Focus: Story = {
   },
   render: () => html`
       <form>
-        ${generateTemplate({
-    args,
-  })}
+        <syn-input help-text="This input is focused." label="Label" placeholder="Insert text here..."></syn-input>
       </form>
     `,
 };
@@ -164,9 +139,6 @@ export const Focus: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'disabled'),
@@ -183,9 +155,6 @@ export const Disabled: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'size'),
@@ -199,18 +168,10 @@ export const Sizes: Story = {
 };
 
 export const Invalid: Story = {
-  args: {
-    helpText: 'This input is required.',
-    label: 'Label',
-    placeholder: 'Insert text here...',
-  },
   name: 'Invalid',
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: generateStoryDescription('input', 'invalid'),
@@ -236,14 +197,7 @@ export const Invalid: Story = {
   },
   render: () => html`
     <form class="custom-validity">
-  ${generateTemplate({
-    args,
-    constants: [{
-      name: 'required',
-      type: 'attribute',
-      value: true,
-    }],
-  })}
+      <syn-input help-text="This input is required." label="Label" placeholder="Insert text here..." required></syn-input>
       <syn-button type="submit" variant="filled">Submit</syn-button>
     </form>
     <style>
@@ -273,9 +227,6 @@ export const InputTypes: Story = {
 export const PrefixSuffixIcons: Story = {
   name: 'Prefix and suffix icons',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('input', 'prefix-suffix'),

--- a/packages/docs/stories/components/input.stories.ts
+++ b/packages/docs/stories/components/input.stories.ts
@@ -120,7 +120,9 @@ export const Focus: Story = {
       disableSnapshot: false,
     },
     docs: {
-      description: generateStoryDescription('input', 'focus'),
+      description: {
+        story: generateStoryDescription('input', 'focus'),
+      },
     },
   },
   play: ({ canvasElement }) => {
@@ -174,7 +176,9 @@ export const Invalid: Story = {
       disableSnapshot: false,
     },
     docs: {
-      description: generateStoryDescription('input', 'invalid'),
+      description: {
+        story: generateStoryDescription('input', 'invalid'),
+      },
     },
   },
   play: async ({ canvasElement }) => {

--- a/packages/docs/stories/components/radio-group.stories.ts
+++ b/packages/docs/stories/components/radio-group.stories.ts
@@ -34,7 +34,9 @@ export const Default = {
       disable: false,
     },
     docs: {
-      description: generateStoryDescription('radio-group', 'default'),
+      description: {
+        story: generateStoryDescription('radio-group', 'default'),
+      },
     },
   },
   render: () => html`
@@ -49,7 +51,9 @@ export const Labels: Story = {
   name: 'Labels',
   parameters: {
     docs: {
-      description: generateStoryDescription('radio-group', 'labels'),
+      description: {
+        story: generateStoryDescription('radio-group', 'labels'),
+      },
     },
   },
   render: () => html`
@@ -64,7 +68,9 @@ export const HelpText: Story = {
   name: 'Help text',
   parameters: {
     docs: {
-      description: generateStoryDescription('radio-group', 'help-text'),
+      description: {
+        story: generateStoryDescription('radio-group', 'help-text'),
+      },
     },
   },
   render: () => html`
@@ -79,7 +85,9 @@ export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
     docs: {
-      description: generateStoryDescription('radio-group', 'disabled'),
+      description: {
+        story: generateStoryDescription('radio-group', 'disabled'),
+      },
     },
   },
   render: () => html`
@@ -107,7 +115,9 @@ export const Invalid: Story = {
       disableSnapshot: false,
     },
     docs: {
-      description: generateStoryDescription('radio-group', 'required'),
+      description: {
+        story: generateStoryDescription('radio-group', 'invalid'),
+      },
     },
   },
   play: async ({ canvasElement }) => {
@@ -149,7 +159,9 @@ export const CustomValidity: Story = {
       disableSnapshot: false,
     },
     docs: {
-      description: generateStoryDescription('radio-group', 'setCustomValidity'),
+      description: {
+        story: generateStoryDescription('radio-group', 'setCustomValidity'),
+      },
     },
   },
   play: async ({ canvasElement }) => {

--- a/packages/docs/stories/components/radio-group.stories.ts
+++ b/packages/docs/stories/components/radio-group.stories.ts
@@ -137,7 +137,7 @@ export const Invalid: Story = {
     }
   },
   render: () => html`
-  <form>
+  <form class="custom-validity">
     <syn-radio-group label="Select an option" name="a" help-text="This is required" required>
       <syn-radio value="1">Option 1</syn-radio>
       <syn-radio value="2">Option 2</syn-radio>
@@ -146,8 +146,13 @@ export const Invalid: Story = {
     <syn-button type="submit" variant="filled">Submit</syn-button>
   </form>
   <style>
+  .custom-validity {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
   syn-button {
-    margin-top: 1rem;
+    align-self: flex-start;
   }
 </style>`,
 };
@@ -215,11 +220,9 @@ export const CustomValidity: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Labels,
   HelpText,
   Disabled,
   Checked,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories, 230);
+], 230);

--- a/packages/docs/stories/components/radio-group.stories.ts
+++ b/packages/docs/stories/components/radio-group.stories.ts
@@ -31,7 +31,7 @@ type Story = StoryObj;
 export const Default = {
   parameters: {
     controls: {
-      disable: true,
+      disable: false,
     },
     docs: {
       description: generateStoryDescription('radio-group', 'default'),
@@ -48,9 +48,6 @@ export const Default = {
 export const Labels: Story = {
   name: 'Labels',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: generateStoryDescription('radio-group', 'labels'),
     },
@@ -66,9 +63,6 @@ export const Labels: Story = {
 export const HelpText: Story = {
   name: 'Help text',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: generateStoryDescription('radio-group', 'help-text'),
     },
@@ -84,9 +78,6 @@ export const HelpText: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: generateStoryDescription('radio-group', 'disabled'),
     },
@@ -115,9 +106,6 @@ export const Invalid: Story = {
     chromatic: {
       disableSnapshot: false,
     },
-    controls: {
-      disable: true,
-    },
     docs: {
       description: generateStoryDescription('radio-group', 'required'),
     },
@@ -139,7 +127,7 @@ export const Invalid: Story = {
     }
   },
   render: () => html`
-  <form class="custom-validity">
+  <form>
     <syn-radio-group label="Select an option" name="a" help-text="This is required" required>
       <syn-radio value="1">Option 1</syn-radio>
       <syn-radio value="2">Option 2</syn-radio>
@@ -148,13 +136,8 @@ export const Invalid: Story = {
     <syn-button type="submit" variant="filled">Submit</syn-button>
   </form>
   <style>
-  .custom-validity {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
   syn-button {
-    align-self: flex-start;
+    margin-top: 1rem;
   }
 </style>`,
 };
@@ -164,9 +147,6 @@ export const CustomValidity: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: generateStoryDescription('radio-group', 'setCustomValidity'),
@@ -211,7 +191,7 @@ export const CustomValidity: Story = {
   },
 
   render: () => html`
-  <form class="custom-validity">
+  <form>
     <syn-radio-group label="Select an option" name="a" value="1">
       <syn-radio value="1">Not me</syn-radio>
       <syn-radio value="2">Me neither</syn-radio>

--- a/packages/docs/stories/components/radio-group.stories.ts
+++ b/packages/docs/stories/components/radio-group.stories.ts
@@ -7,7 +7,7 @@ import '../../../components/src/components/radio-group/radio-group.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
-import { generateStoryDescription, storybookDefaults } from '../../src/helpers/component.js';
+import { generateScreenshotStory, generateStoryDescription, storybookDefaults } from '../../src/helpers/component.js';
 
 const { args, argTypes } = storybookDefaults('syn-radio-group');
 
@@ -46,6 +46,7 @@ export const Default = {
 } as Story;
 
 export const Labels: Story = {
+  name: 'Labels',
   parameters: {
     controls: {
       disable: true,
@@ -63,6 +64,7 @@ export const Labels: Story = {
 };
 
 export const HelpText: Story = {
+  name: 'Help text',
   parameters: {
     controls: {
       disable: true,
@@ -80,6 +82,7 @@ export const HelpText: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -97,6 +100,7 @@ export const Disabled: Story = {
 };
 
 export const Checked: Story = {
+  name: 'Checked',
   render: () => html`
   <syn-radio-group label="This is a label" help-text="This is checked" name="a" value="2">
     <syn-radio value="1">Option</syn-radio>
@@ -106,7 +110,11 @@ export const Checked: Story = {
 };
 
 export const Invalid: Story = {
+  name: 'Invalid',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -152,7 +160,11 @@ export const Invalid: Story = {
 };
 
 export const CustomValidity: Story = {
+  name: 'Custom validity',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -209,3 +221,13 @@ export const CustomValidity: Story = {
     <syn-button type="submit" variant="filled">Submit</syn-button>
   </form>`,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Labels,
+  HelpText,
+  Disabled,
+  Checked,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories, 230);

--- a/packages/docs/stories/components/radio.stories.ts
+++ b/packages/docs/stories/components/radio.stories.ts
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable import/no-relative-packages */
 
 import '../../../components/src/components/radio/radio.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
 import {
-  generateScreenshotStory, generateStoryDescription,
-  storybookDefaults, storybookHelpers, storybookTemplate,
+  generateScreenshotStory,
+  generateStoryDescription, storybookDefaults, storybookHelpers, storybookTemplate,
 } from '../../src/helpers/component.js';
 
 const { args, argTypes } = storybookDefaults('syn-radio');
@@ -34,6 +33,9 @@ type Story = StoryObj;
 
 export const Default = {
   parameters: {
+    controls: {
+      disable: false,
+    },
     docs: {
       description: {
         story: generateStoryDescription('radio', 'default'),
@@ -41,16 +43,11 @@ export const Default = {
     },
   },
   render: (storyArgs: unknown) => generateTemplate({ args: storyArgs }),
-  // render: () => html`
-  // <syn-radio value="1" size="medium">Option</syn-radio>`,
 } as Story;
 
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('radio', 'disabled'),
@@ -67,9 +64,6 @@ export const Focus: Story = {
     chromatic: {
       disableSnapshot: false,
     },
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('radio', 'focus'),
@@ -77,7 +71,7 @@ export const Focus: Story = {
     },
   },
   play: ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    const radio = canvasElement.querySelector('syn-radio') as unknown as HTMLInputElement;
+    const radio = canvasElement.querySelector('syn-radio');
     if (radio) {
       radio.focus();
     }
@@ -91,9 +85,6 @@ export const Invalid: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {
@@ -119,20 +110,15 @@ export const Invalid: Story = {
     }
   },
   render: () => html`
-  <form class="custom-validity">
+  <form>
     <syn-radio-group required>
       <syn-radio value="1">Option</syn-radio>
     </syn-radio-group>
     <syn-button type="submit" variant="filled">Submit</syn-button>
   </form>
   <style>
-  .custom-validity {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
   syn-button {
-    align-self: flex-start;
+    margin-top: 1rem;
   }
   </style>`,
 };
@@ -140,9 +126,6 @@ export const Invalid: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('radio', 'sizes'),

--- a/packages/docs/stories/components/radio.stories.ts
+++ b/packages/docs/stories/components/radio.stories.ts
@@ -7,7 +7,8 @@ import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
 import {
-  generateStoryDescription, storybookDefaults, storybookHelpers, storybookTemplate,
+  generateScreenshotStory, generateStoryDescription,
+  storybookDefaults, storybookHelpers, storybookTemplate,
 } from '../../src/helpers/component.js';
 
 const { args, argTypes } = storybookDefaults('syn-radio');
@@ -45,6 +46,7 @@ export const Default = {
 } as Story;
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -60,7 +62,11 @@ export const Disabled: Story = {
 };
 
 export const Focus: Story = {
+  name: 'Focus',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -81,7 +87,11 @@ export const Focus: Story = {
 };
 
 export const Invalid: Story = {
+  name: 'Invalid',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -128,6 +138,7 @@ export const Invalid: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Sizes',
   parameters: {
     controls: {
       disable: true,
@@ -143,3 +154,11 @@ export const Sizes: Story = {
     <syn-radio value="2" size="medium">Option</syn-radio>
     <syn-radio value="3" size="large">Option</syn-radio>`,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Disabled,
+  Sizes,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories);

--- a/packages/docs/stories/components/radio.stories.ts
+++ b/packages/docs/stories/components/radio.stories.ts
@@ -110,15 +110,20 @@ export const Invalid: Story = {
     }
   },
   render: () => html`
-  <form>
+  <form class="custom-validity">
     <syn-radio-group required>
       <syn-radio value="1">Option</syn-radio>
     </syn-radio-group>
     <syn-button type="submit" variant="filled">Submit</syn-button>
   </form>
   <style>
+  .custom-validity {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
   syn-button {
-    margin-top: 1rem;
+    align-self: flex-start;
   }
   </style>`,
 };
@@ -139,9 +144,7 @@ export const Sizes: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Disabled,
   Sizes,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories);
+]);

--- a/packages/docs/stories/components/switch.stories.ts
+++ b/packages/docs/stories/components/switch.stories.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable import/no-relative-packages */
 
 import '../../../components/src/components/switch/switch.js';
 import type { Meta, StoryObj } from '@storybook/web-components';
@@ -38,6 +37,9 @@ type Story = StoryObj;
 
 export const Default = {
   parameters: {
+    controls: {
+      disable: false,
+    },
     docs: {
       description: {
         story: generateStoryDescription('switch', 'default'),
@@ -50,9 +52,6 @@ export const Default = {
 export const Checked: Story = {
   name: 'Checked',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('switch', 'checked'),
@@ -65,9 +64,6 @@ export const Checked: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('switch', 'disabled'),
@@ -82,9 +78,6 @@ export const Focus: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {
@@ -108,9 +101,6 @@ export const Invalid: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {
@@ -153,9 +143,6 @@ export const Invalid: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('switch', 'sizes'),

--- a/packages/docs/stories/components/switch.stories.ts
+++ b/packages/docs/stories/components/switch.stories.ts
@@ -8,6 +8,7 @@ import type { SynButton, SynSwitch } from '@synergy-design-system/components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
 import {
+  generateScreenshotStory,
   generateStoryDescription,
   storybookDefaults,
   storybookHelpers,
@@ -47,6 +48,7 @@ export const Default = {
 } as Story;
 
 export const Checked: Story = {
+  name: 'Checked',
   parameters: {
     controls: {
       disable: true,
@@ -61,6 +63,7 @@ export const Checked: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -75,7 +78,11 @@ export const Disabled: Story = {
 };
 
 export const Focus: Story = {
+  name: 'Focus',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -97,7 +104,11 @@ export const Focus: Story = {
 };
 
 export const Invalid: Story = {
+  name: 'Invalid',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -140,10 +151,8 @@ export const Invalid: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Sizes',
   parameters: {
-    chromatic: {
-      disableSnapshot: true,
-    },
     controls: {
       disable: true,
     },
@@ -158,3 +167,11 @@ export const Sizes: Story = {
   <syn-switch size="medium">Medium</syn-switch><br>
   <syn-switch size="large">Large</syn-switch>`,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Disabled,
+  Sizes,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories);

--- a/packages/docs/stories/components/switch.stories.ts
+++ b/packages/docs/stories/components/switch.stories.ts
@@ -156,10 +156,8 @@ export const Sizes: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Checked,
   Disabled,
   Sizes,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories);
+]);

--- a/packages/docs/stories/components/switch.stories.ts
+++ b/packages/docs/stories/components/switch.stories.ts
@@ -157,6 +157,7 @@ export const Sizes: Story = {
 
 // Bundled screenshot story
 const bundledStories: Array<Story> = [
+  Checked,
   Disabled,
   Sizes,
 ];

--- a/packages/docs/stories/components/textarea.stories.ts
+++ b/packages/docs/stories/components/textarea.stories.ts
@@ -192,13 +192,18 @@ export const Invalid: Story = {
     }
   },
   render: () => html`
-    <form>
+    <form class="custom-validity">
       <syn-textarea placeholder="Type something" help-text="This textarea is required." required></syn-textarea>
       <syn-button type="submit" variant="filled">Submit</syn-button>
     </form>
     <style>
+    .custom-validity {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
     syn-button {
-      margin-top: 1rem;
+      align-self: flex-start;
     }
     </style>
   `,
@@ -229,7 +234,7 @@ export const ExpandWithContent: Story = {
 };
 
 // Bundled screenshot story
-const bundledStories: Array<Story> = [
+export const Screenshot: Story = generateScreenshotStory([
   Labels,
   HelpText,
   Rows,
@@ -239,6 +244,4 @@ const bundledStories: Array<Story> = [
   Sizes,
   PreventResizing,
   ExpandWithContent,
-];
-
-export const Screenshot: Story = generateScreenshotStory(bundledStories, 500);
+], 500);

--- a/packages/docs/stories/components/textarea.stories.ts
+++ b/packages/docs/stories/components/textarea.stories.ts
@@ -4,7 +4,9 @@ import '../../../components/src/components/textarea/textarea';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { userEvent } from '@storybook/testing-library';
-import { generateStoryDescription, storybookDefaults, storybookTemplate } from '../../src/helpers/component.js';
+import {
+  generateScreenshotStory, generateStoryDescription, storybookDefaults, storybookTemplate,
+} from '../../src/helpers/component.js';
 
 const { args, argTypes } = storybookDefaults('syn-textarea');
 const { generateTemplate } = storybookTemplate('syn-textarea');
@@ -37,6 +39,7 @@ export const Default = {
 } as Story;
 
 export const Labels: Story = {
+  name: 'Labels',
   parameters: {
     controls: {
       disable: true,
@@ -51,6 +54,7 @@ export const Labels: Story = {
 };
 
 export const HelpText: Story = {
+  name: 'Help text',
   parameters: {
     controls: {
       disable: true,
@@ -65,6 +69,7 @@ export const HelpText: Story = {
 };
 
 export const Rows: Story = {
+  name: 'Rows',
   parameters: {
     controls: {
       disable: true,
@@ -87,6 +92,7 @@ export const Rows: Story = {
 };
 
 export const Placeholders: Story = {
+  name: 'Placeholders',
   parameters: {
     controls: {
       disable: true,
@@ -101,6 +107,7 @@ export const Placeholders: Story = {
 };
 
 export const ReadonlyTextareas: Story = {
+  name: 'Readonly textareas',
   parameters: {
     controls: {
       disable: true,
@@ -118,7 +125,11 @@ export const Focus: Story = {
   args: {
     placeholder: 'This is in focus',
   },
+  name: 'Focus',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -144,6 +155,7 @@ export const Focus: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Disabled',
   parameters: {
     controls: {
       disable: true,
@@ -158,6 +170,7 @@ export const Disabled: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Sizes',
   parameters: {
     controls: {
       disable: true,
@@ -175,11 +188,11 @@ export const Sizes: Story = {
 };
 
 export const Invalid: Story = {
-  args: {
-    helpText: 'This textarea is required.',
-    placeholder: 'Type something',
-  },
+  name: 'Invalid',
   parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
     controls: {
       disable: true,
     },
@@ -233,6 +246,7 @@ export const Invalid: Story = {
 };
 
 export const PreventResizing: Story = {
+  name: 'Prevent resizing',
   parameters: {
     controls: {
       disable: true,
@@ -247,6 +261,7 @@ export const PreventResizing: Story = {
 };
 
 export const ExpandWithContent: Story = {
+  name: 'Expand with content',
   parameters: {
     controls: {
       disable: true,
@@ -259,3 +274,18 @@ export const ExpandWithContent: Story = {
   },
   render: () => html`<syn-textarea resize="auto" placeholder="Type something"></syn-textarea>`,
 };
+
+// Bundled screenshot story
+const bundledStories: Array<Story> = [
+  Labels,
+  HelpText,
+  Rows,
+  Placeholders,
+  ReadonlyTextareas,
+  Disabled,
+  Sizes,
+  PreventResizing,
+  ExpandWithContent,
+];
+
+export const Screenshot: Story = generateScreenshotStory(bundledStories, 500);

--- a/packages/docs/stories/components/textarea.stories.ts
+++ b/packages/docs/stories/components/textarea.stories.ts
@@ -29,6 +29,9 @@ type Story = StoryObj;
 
 export const Default = {
   parameters: {
+    controls: {
+      disable: false,
+    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'default'),
@@ -41,9 +44,6 @@ export const Default = {
 export const Labels: Story = {
   name: 'Labels',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'labels'),
@@ -56,9 +56,6 @@ export const Labels: Story = {
 export const HelpText: Story = {
   name: 'Help text',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'help-text'),
@@ -71,9 +68,6 @@ export const HelpText: Story = {
 export const Rows: Story = {
   name: 'Rows',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'rows'),
@@ -94,9 +88,6 @@ export const Rows: Story = {
 export const Placeholders: Story = {
   name: 'Placeholders',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'placeholder'),
@@ -109,9 +100,6 @@ export const Placeholders: Story = {
 export const ReadonlyTextareas: Story = {
   name: 'Readonly textareas',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'readonly'),
@@ -122,16 +110,10 @@ export const ReadonlyTextareas: Story = {
 };
 
 export const Focus: Story = {
-  args: {
-    placeholder: 'This is in focus',
-  },
   name: 'Focus',
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {
@@ -147,9 +129,7 @@ export const Focus: Story = {
   },
   render: () => html`
       <form>
-        ${generateTemplate({
-    args,
-  })}
+        <syn-textarea placeholder="This is in focus"></syn-textarea>
       </form>
     `,
 };
@@ -157,9 +137,6 @@ export const Focus: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'disabled'),
@@ -172,9 +149,6 @@ export const Disabled: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'size'),
@@ -192,9 +166,6 @@ export const Invalid: Story = {
   parameters: {
     chromatic: {
       disableSnapshot: false,
-    },
-    controls: {
-      disable: true,
     },
     docs: {
       description: {
@@ -221,25 +192,13 @@ export const Invalid: Story = {
     }
   },
   render: () => html`
-    <form class="custom-validity">
-  ${generateTemplate({
-    args,
-    constants: [{
-      name: 'required',
-      type: 'attribute',
-      value: true,
-    }],
-  })}
+    <form>
+      <syn-textarea placeholder="Type something" help-text="This textarea is required." required></syn-textarea>
       <syn-button type="submit" variant="filled">Submit</syn-button>
     </form>
     <style>
-    .custom-validity {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-    }
     syn-button {
-      align-self: flex-start;
+      margin-top: 1rem;
     }
     </style>
   `,
@@ -248,9 +207,6 @@ export const Invalid: Story = {
 export const PreventResizing: Story = {
   name: 'Prevent resizing',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'resize'),
@@ -263,9 +219,6 @@ export const PreventResizing: Story = {
 export const ExpandWithContent: Story = {
   name: 'Expand with content',
   parameters: {
-    controls: {
-      disable: true,
-    },
     docs: {
       description: {
         story: generateStoryDescription('textarea', 'resize-auto'),


### PR DESCRIPTION
# Pull Request

## 📖 Description

The amount of screenshots taken by chromatic needs to be limited to avoid running out of screenshots.

### 🎫 Issues

Closes [#55](https://github.com/synergy-design-system/Internal/issues/55)

## 👩‍💻 Reviewer Notes



## 📑 Test Plan


## ✅ DoD

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
