### PR TITLE
chore: 🔧 Reduce chromatic load via draft pull requests

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,6 +1,8 @@
 name: Quality Gate
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   quality-gate:
@@ -91,6 +93,7 @@ jobs:
   chromatic-deployment:
     name: Validate Chromatic
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     needs: [quality-gate,test]
     steps:
         # 👇 Version 2 of the action


### PR DESCRIPTION
# Pull Request

## 📖 Description
The amount of screenshots taken by chromatic needs to be limited to avoid running out of screenshots.
To limit it, the github action for chromatic is no longer running when a pull request is in draft mode.

### 🎫 Issues
Closes https://github.com/synergy-design-system/Internal/issues/55

## 👩‍💻 Reviewer Notes
I created this PR with draft mode. With the changes to the ci cd, all jobs except the chromatic job were running.
After removing draft, all jobs were triggered again including the chromatic job.

**Draft mode:** 
![image](https://github.com/synergy-design-system/synergy-design-system/assets/115139104/9d1bc8e0-14f4-468b-ad10-8cc283f23301)
See checks: https://github.com/synergy-design-system/synergy-design-system/actions/runs/7420881861/job/20193168020?pr=237

**After removing draft mode:**
![image](https://github.com/synergy-design-system/synergy-design-system/assets/115139104/44c9c687-d936-4977-b88a-51135995d20a)
see checks: https://github.com/synergy-design-system/synergy-design-system/actions/runs/7420943445/job/20193342098?pr=237

## ✅ DoD

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
