### PR TITLE
Add ability to run test.watch with automatic builds

### DIFF
--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,4 +1,4 @@
 .env
 node_modules
 dist
-
+dist.testrunner

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "web-test-runner --group default",
+    "test.watch": "pnpm test -- --watch",
     "vendor": "node scripts/vendorism.js",
     "vendor.get": "node scripts/vendorism.js -g",
     "vendor.set": "node scripts/vendorism.js -s",

--- a/packages/components/scripts/build.js
+++ b/packages/components/scripts/build.js
@@ -1,11 +1,10 @@
 /**
  * Synergy Build Steps
  */
-import { readFileSync } from 'fs';
 import * as jobs from './jobs/index.js';
-import { getPath } from './jobs/shared.js';
+import { getPackageJSONAsObject, getPath } from './jobs/shared.js';
 
-const { version } = JSON.parse(readFileSync(getPath('../package.json')), 'utf-8');
+const { version } = getPackageJSONAsObject();
 
 // eslint-disable-next-line no-underscore-dangle
 const __PACKAGE_VERSION__ = JSON.stringify(version.toString());

--- a/packages/components/scripts/jobs/shared.js
+++ b/packages/components/scripts/jobs/shared.js
@@ -100,6 +100,12 @@ export const formatFile = async (filePath, parser) => {
 };
 
 /**
+ * Get the path to the components package.json file
+ * @returns {object} Contents of to package.json
+ */
+export const getPackageJSONAsObject = () => JSON.parse(fsSync.readFileSync(getPath('../package.json')), 'utf-8');
+
+/**
  * Sync the package.json version field located in outputPackageDir
  * with the one provided from componentsPackageDir
  * @param {string} label The label

--- a/packages/components/scripts/tests/index.js
+++ b/packages/components/scripts/tests/index.js
@@ -1,0 +1,64 @@
+import { execSync } from 'child_process';
+import * as jobs from '../jobs/index.js';
+import { getPackageJSONAsObject, getPath } from '../jobs/shared.js';
+
+const componentDir = getPath('../');
+const outDir = getPath('../dist');
+const temporaryOutDir = getPath('../dist.testrunner');
+
+const { version } = getPackageJSONAsObject();
+
+// eslint-disable-next-line no-underscore-dangle
+const __PACKAGE_VERSION__ = JSON.stringify(version.toString());
+
+const synRefreshComponentBundle = () => {
+  const name = 'syn-refresh-component-bundle';
+
+  const rebuildSynergy = async () => {
+    // Create the build in its own directory
+    await jobs.runPrepare(temporaryOutDir);
+    await jobs.runCreateEvents(componentDir);
+    await jobs.runCreateExports(componentDir);
+    await jobs.runTypeScript(temporaryOutDir, './tsconfig.prod.json');
+    await jobs.runEsBuildComponents(temporaryOutDir, __PACKAGE_VERSION__);
+
+    // Finally, remove the dist folder completely
+    // and move the contents of the temporary folder into it
+    await jobs.runPrepare(outDir);
+    execSync(`mv ${temporaryOutDir}/* ${outDir}`);
+  };
+
+  return {
+    name,
+    serverStart: async ({ fileWatcher }) => {
+      // Make sure we always have correct initial data by running the build
+      await rebuildSynergy();
+
+      // Whenever one of our component files has changed,
+      // make sure to recreate our bundle
+      fileWatcher.add('./src/components/**/!(*.(style|test)).ts');
+
+      // Make sure to only rebuild our components if a component and its associates did change
+      fileWatcher.on('change', async (changedFile) => {
+        const isATest = changedFile.endsWith('.test.ts');
+        const isADistFile = changedFile.includes('dist/');
+
+        // Skip the tests, they should do nothing here
+        // Make sure to skip the currently generated bundle.
+        // It will lead to recursive errors otherwise!
+        if (isATest || isADistFile) {
+          return;
+        }
+
+        await rebuildSynergy();
+      });
+    },
+    serverStop: async () => {
+      await jobs.runPrepare(temporaryOutDir);
+    },
+  };
+};
+
+export default {
+  plugins: [synRefreshComponentBundle()],
+};

--- a/packages/components/scripts/vendorism/custom/webTestRunner.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/webTestRunner.vendorism.js
@@ -11,9 +11,22 @@ export const vendorWebTestRunnerConfig = (path, content) => {
 
   // Adjust the path to the theme to make sure we always fetch
   // the latest version from the package
-  const nextContent = content.replaceAll(
+  let nextContent = content.replaceAll(
     'dist/themes/light.css',
     'node_modules/@synergy-design-system/tokens/dist/themes/light.css',
+  );
+
+  // Add the synergy test plugins to the mix
+  nextContent = nextContent.replaceAll(
+    "runner-playwright';",
+    `runner-playwright';
+import synTestPlugins from './scripts/tests/index.js';`,
+  );
+
+  nextContent = nextContent.replaceAll(
+    'esbuildPlugin({',
+    `...synTestPlugins.plugins,
+    esbuildPlugin({`,
   );
 
   return {

--- a/packages/components/web-test-runner.config.js
+++ b/packages/components/web-test-runner.config.js
@@ -7,6 +7,7 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { globbySync } from 'globby';
 import { playwrightLauncher } from '@web/test-runner-playwright';
+import synTestPlugins from './scripts/tests/index.js';
 
 export default {
   rootDir: '.',
@@ -20,6 +21,7 @@ export default {
     }
   },
   plugins: [
+    ...synTestPlugins.plugins,
     esbuildPlugin({
       ts: true,
       target: 'es2020'


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

This PR adds the ability to use the tests for components watch mode. A new command `pnpm test.watch` was implemented for this to work.

## 📖 Description

Until now, we did not provide watch mode for tests, making it necessary to build the components and run the tests again. This is now automatically included with the new watch mode.

### 🎫 Issues

Closes #141

## 👩‍💻 Reviewer Notes

- I had to create a simple plugin for the test server to make our changes available via chokidar.
- As I do not have access to the original bound listener, tests will run twice when changing a component. There was no simple way to avoid that unfortunately.
- Changes to the test files themselves will NOT trigger a rebuild.

## 📑 Test Plan

- Check out the branch and prepare it via `pnpm i -r && pnpm build`
- Move to `packages/components` and start the test server via `pnpm test.watch`.
- Change a test and validate that it breaks (e.g. changing an assertion in `components/button/button.custom.tests.ts`
- Change a default attribute of the button to some string or just hit save in `button.component.ts` (Make sure to remove it from the readonly files first!).
- The build will now recreate the bundle and run the tests again. The tests will echo out one to multiple 404 errors, which happen because the new listener and the original one run concurrently. After another run, the system should be back to normal.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
