### PR TITLE
fix: 🤔 Vue two way data binding does not honor the provided default value

### DIFF
--- a/packages/_private/vue-demo/src/DemoForm.vue
+++ b/packages/_private/vue-demo/src/DemoForm.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import type { SynChangeEvent } from '@synergy-design-system/components';
 import {
   SynVueButton,
   SynVueCheckbox,
@@ -17,19 +16,13 @@ import {
 import DemoFieldset from './DemoFieldset.vue';
 import { normalizeData } from './shared';
 
-type FormEnabledElements = HTMLElement & {
-  checked?: boolean;
-  name: string;
-  value?: string;
-};
-
 const initialFormData = {
   code: '',
   comment: '',
   date: '',
   email: '',
   gender: '',
-  name: '',
+  name: 'peter',
   newsletterAngular: false,
   newsletterBeta: false,
   newsletterReact: false,
@@ -67,26 +60,11 @@ const submit = (e: Event) => {
   }
 }
 
-const synChange = (e: SynChangeEvent) => {
-  const form = formRef.value;
-
-  const normalizedData = normalizeData(new FormData(form));
+const synChange = () => {
+  const normalizedData = normalizeData(new FormData(formRef.value));
 
   // Log the normalized data
   console.log(normalizedData);
-
-  // Set the field into state
-  const element = e.target as FormEnabledElements;
-  const { checked, name, value } = element;
-
-  const finalValue = typeof checked !== 'undefined'
-    ? !!checked
-    : value;
-
-  formData.value = {
-    ...formData.value,
-    [name]: finalValue,
-  }
 };
 </script>
 
@@ -204,7 +182,7 @@ const synChange = (e: SynChangeEvent) => {
     <SynVueDivider />
 
     <!-- Topics -->
-    <SynFieldset legend="Topics">
+    <DemoFieldset legend="Topics">
       <SynVueSelect
         clearable
         id="topics"
@@ -224,7 +202,7 @@ const synChange = (e: SynChangeEvent) => {
           <SynVueOption value="Python">Python</SynVueOption>
         </SynVueOptgroup>
       </SynVueSelect>
-    </SynFieldset>
+    </DemoFieldset>
     <!-- /Topics -->
 
     <SynVueDivider />

--- a/packages/_private/vue-demo/src/DemoForm.vue
+++ b/packages/_private/vue-demo/src/DemoForm.vue
@@ -22,7 +22,7 @@ const initialFormData = {
   date: '',
   email: '',
   gender: '',
-  name: 'peter',
+  name: '',
   newsletterAngular: false,
   newsletterBeta: false,
   newsletterReact: false,
@@ -142,6 +142,7 @@ const synChange = () => {
       <SynVueInput
         id="input-date"
         label="Date of birth"
+        name="date"
         placeholder="Please insert your E-mail address"
         v-model="formData.date"
         type="date"

--- a/packages/vue/src/components/SynVueButton.vue
+++ b/packages/vue/src/components/SynVueButton.vue
@@ -230,6 +230,7 @@ defineEmits<{
     v-bind="visibleProps"
     ref="element"
     @syn-blur="$emit('syn-blur', $event)"
+
     @syn-focus="$emit('syn-focus', $event)"
     @syn-invalid="$emit('syn-invalid', $event)"
   >

--- a/packages/vue/src/components/SynVueCheckbox.vue
+++ b/packages/vue/src/components/SynVueCheckbox.vue
@@ -191,6 +191,7 @@ defineEmits<{
   <syn-checkbox
     v-bind="visibleProps"
     ref="element"
+    :checked="typeof props.modelValue !== 'undefined' ? props.modelValue : typeof props.checked !== 'undefined' ? props.checked : undefined"
     @syn-blur="$emit('syn-blur', $event)"
     @syn-change="$emit('syn-change', $event)"
     @syn-focus="$emit('syn-focus', $event)"

--- a/packages/vue/src/components/SynVueIcon.vue
+++ b/packages/vue/src/components/SynVueIcon.vue
@@ -92,6 +92,7 @@ defineEmits<{
   <syn-icon
     v-bind="visibleProps"
     ref="element"
+
     @syn-load="$emit('syn-load', $event)"
     @syn-error="$emit('syn-error', $event)"
   />

--- a/packages/vue/src/components/SynVueIconButton.vue
+++ b/packages/vue/src/components/SynVueIconButton.vue
@@ -135,6 +135,7 @@ defineEmits<{
   <syn-icon-button
     v-bind="visibleProps"
     ref="element"
+
     @syn-blur="$emit('syn-blur', $event)"
     @syn-focus="$emit('syn-focus', $event)"
   />

--- a/packages/vue/src/components/SynVueInput.vue
+++ b/packages/vue/src/components/SynVueInput.vue
@@ -350,6 +350,7 @@ defineEmits<{
   <syn-input
     v-bind="visibleProps"
     ref="element"
+    :value="typeof props.modelValue !== 'undefined' ? props.modelValue : typeof props.value !== 'undefined' ? props.value : undefined"
     @syn-blur="$emit('syn-blur', $event)"
     @syn-change="$emit('syn-change', $event)"
     @syn-clear="$emit('syn-clear', $event)"

--- a/packages/vue/src/components/SynVueRadio.vue
+++ b/packages/vue/src/components/SynVueRadio.vue
@@ -90,6 +90,7 @@ defineEmits<{
   <syn-radio
     v-bind="visibleProps"
     ref="element"
+
     @syn-blur="$emit('syn-blur', $event)"
     @syn-focus="$emit('syn-focus', $event)"
   >

--- a/packages/vue/src/components/SynVueRadioButton.vue
+++ b/packages/vue/src/components/SynVueRadioButton.vue
@@ -99,6 +99,7 @@ defineEmits<{
   <syn-radio-button
     v-bind="visibleProps"
     ref="element"
+
     @syn-blur="$emit('syn-blur', $event)"
     @syn-focus="$emit('syn-focus', $event)"
   >

--- a/packages/vue/src/components/SynVueRadioGroup.vue
+++ b/packages/vue/src/components/SynVueRadioGroup.vue
@@ -159,6 +159,7 @@ defineEmits<{
   <syn-radio-group
     v-bind="visibleProps"
     ref="element"
+    :value="typeof props.modelValue !== 'undefined' ? props.modelValue : typeof props.value !== 'undefined' ? props.value : undefined"
     @syn-change="$emit('syn-change', $event)"
     @syn-input="$emit('update:modelValue', $event.target.value); $emit('syn-input', $event)"
     @syn-invalid="$emit('syn-invalid', $event)"

--- a/packages/vue/src/components/SynVueSelect.vue
+++ b/packages/vue/src/components/SynVueSelect.vue
@@ -296,9 +296,10 @@ defineEmits<{
 <template>
   <syn-select
     @syn-change="$emit('syn-change', $event)"
+    :value="typeof props.modelValue !== 'undefined' ? props.modelValue : typeof props.value !== 'undefined' ? props.value : undefined"
+    @syn-clear="$emit('syn-clear', $event)"
     v-bind="visibleProps"
     ref="element"
-    @syn-clear="$emit('syn-clear', $event)"
     @syn-input="$emit('update:modelValue', $event.target.value); $emit('syn-input', $event)"
     @syn-focus="$emit('syn-focus', $event)"
     @syn-blur="$emit('syn-blur', $event)"

--- a/packages/vue/src/components/SynVueSwitch.vue
+++ b/packages/vue/src/components/SynVueSwitch.vue
@@ -126,6 +126,11 @@ the same document or shadow root for this to work.
 * Makes the switch a required field.
  */
   'required'?: SynSwitch['required'];
+
+  /**
+* Support for two way data binding
+ */
+  modelValue?: SynSwitch['checked'];
 }>();
 
 // Make sure prop binding only forwards the props that are actually there.
@@ -164,6 +169,11 @@ defineEmits<{
 * Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  */
   'syn-invalid': [e: SynInvalidEvent];
+
+  /**
+* Support for two way data binding
+ */
+  'update:modelValue': [newValue: SynSwitch['checked']];
 }>();
 </script>
 
@@ -171,9 +181,10 @@ defineEmits<{
   <syn-switch
     v-bind="visibleProps"
     ref="element"
+    :checked="typeof props.modelValue !== 'undefined' ? props.modelValue : typeof props.checked !== 'undefined' ? props.checked : undefined"
     @syn-blur="$emit('syn-blur', $event)"
     @syn-change="$emit('syn-change', $event)"
-    @syn-input="$emit('syn-input', $event)"
+    @syn-input="$emit('update:modelValue', $event.target.checked); $emit('syn-input', $event)"
     @syn-focus="$emit('syn-focus', $event)"
     @syn-invalid="$emit('syn-invalid', $event)"
   >

--- a/packages/vue/src/components/SynVueTag.vue
+++ b/packages/vue/src/components/SynVueTag.vue
@@ -71,6 +71,7 @@ defineEmits<{
 <template>
   <syn-tag
     v-bind="visibleProps"
+
     ref="element"
     @syn-remove="$emit('syn-remove', $event)"
   >

--- a/packages/vue/src/components/SynVueTextarea.vue
+++ b/packages/vue/src/components/SynVueTextarea.vue
@@ -272,6 +272,7 @@ defineEmits<{
   <syn-textarea
     v-bind="visibleProps"
     ref="element"
+    :value="typeof props.modelValue !== 'undefined' ? props.modelValue : typeof props.value !== 'undefined' ? props.value : undefined"
     @syn-blur="$emit('syn-blur', $event)"
     @syn-change="$emit('syn-change', $event)"
     @syn-focus="$emit('syn-focus', $event)"


### PR DESCRIPTION
…nt component, fixed form handling in demo

<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that initial data was not loaded correctly when using two way databinding as defined in our current vue demo. The initial data would not be used for the state of a given component, for example a checkbox that **should** be checked per default in the form **was** unchecked initially. The problem happened because we did not provide the initial `value` or `checked` prop for the component, making the binding work, but not the initial data.

I also stumbled around another problem by accident. `<SynVueSwitch />` was not enabled for two way databinding and did not participate in the forms. I also opted to adjust the Demos `synChange` handler to make sure data would not be set in a non-reactive way as we would like to test the `v-model` bindings.

### 🎫 Issues

- Closes #300 

## 👩‍💻 Reviewer Notes

I did not get Form-Resetting to work for a 100%. The problem seems to be that `update:modelValue` is not triggering if you have the same value.

For example, when loading the application and clicking the "reset" button without changing everything, all fields will become empty. However, if you change the password field to another value, everything works fine and the field is prefilled again. Maybe you could have another look at this?

## 📑 Test Plan

- Just check out the branch and play around with it.
- When loading, it should now have default values filled for the password field and at "Newsletter Vue" checkbox

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
