### PR TITLE
feat: ✨ add border-radius and roundings to syn-tag

### DIFF
--- a/packages/components/src/components/tag/tag.custom.styles.ts
+++ b/packages/components/src/components/tag/tag.custom.styles.ts
@@ -4,6 +4,7 @@ export default css`
   .tag {
     background-color: var(--syn-color-neutral-0);
     border-color: var(--syn-color-neutral-400);
+    border-radius: var(--syn-border-radius-small);
     color: var(--syn-input-color);
   }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds support for the border radius values included in https://github.com/synergy-design-system/synergy-design-system/pull/338. It sets the `border-radius` property for `<syn-tag />` to a default of `--syn-border-radius-small` for all sizes.

### 🎫 Issues

Closes #340 

## 👩‍💻 Reviewer Notes

Just have a look at the stories for `<syn-tag />` and `<syn-select />` with multiple.

## 📑 Test Plan

- Check the changes in Chromatic.

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
