### PR TITLE
fix: 🤔 syn-icon-button has a border-radius

### DIFF
--- a/packages/components/src/components/icon-button/icon-button.custom.styles.ts
+++ b/packages/components/src/components/icon-button/icon-button.custom.styles.ts
@@ -2,6 +2,7 @@ import { css } from 'lit';
 
 export default css`
   .icon-button {
+    border-radius: 0;
     color: currentColor;
     font-size: inherit;
   }


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR removes the `border-radius` from the `<syn-icon-button />` component.

### 🎫 Issues

Closes #341 

## 👩‍💻 Reviewer Notes

Just have a look at the chromatic stories. Everything else is unchanged.

## 📑 Test Plan

Look into current chromatic stories and see if there are any visual changes:

- IconButton stories (all)
- Drawer (The close icon is a `<syn-icon-button />`
- Header (`<syn-icon-button />` is used in Meta-Navigation examples)
- Tags (`<syn-icon-button />` is used for the "remove tag" close icon)

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
