### PR TITLE
feat: ✨ syn-divider in syn-dropdown should have a color syn-color-neutral-200

### DIFF
--- a/packages/components/src/components/menu/menu.custom.styles.ts
+++ b/packages/components/src/components/menu/menu.custom.styles.ts
@@ -13,4 +13,9 @@ export default css`
   ::slotted(syn-menu-label:first-of-type) {
     --display-divider: none;
   }
+
+  ::slotted(syn-divider) {
+    /* #369: Slotted syn-dividers should use a lighter color so they do not crash with the border visually */
+    --color: var(--syn-color-neutral-200);
+  }
 `;


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR changes the color of `<syn-divider />` elements that are slotted into `<syn-menu />`items.

### 🎫 Issues

Closes #369 

## 👩‍💻 Reviewer Notes

Just follow the regular procedure. Changed stories are `<syn-dropdown />` and `<syn-menu />`.

## 📑 Test Plan

- Verify that the stories for `<syn-dropdown />` are displayed correctly.
- Verify that the stories for `<syn-menu />` are displayed correctly.

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
