### PR TITLE
feat: ✨ upgrade shoelace to 2.15.0

### DIFF
--- a/packages/angular/src/components/dropdown.component.ts
+++ b/packages/angular/src/components/dropdown.component.ts
@@ -151,6 +151,18 @@ dropdowns that allow for multiple interactions.
     return this._el.hoist;
   }
 
+  /**
+* Syncs the popup width or height to that of the trigger element.
+ */
+  @Input()
+  set sync(v: SynDropdown['sync']) {
+    this._ngZone.runOutsideAngular(() => (this._el.sync = v));
+  }
+
+  get sync() {
+    return this._el.sync;
+  }
+
   @Input()
   callFocusOnTrigger(...args: Parameters<SynDropdown['focusOnTrigger']>) {
     return this._ngZone.runOutsideAngular(() => this._el.focusOnTrigger(...args));

--- a/packages/components/scripts/vendorism.js
+++ b/packages/components/scripts/vendorism.js
@@ -95,7 +95,7 @@ const otherIncludes = [
 
 const libraryPrefix = 'syn';
 const libraryName = 'synergy';
-const shoelaceVersion = '2.14.0';
+const shoelaceVersion = '2.15.0';
 
 // Command line options
 const optionDefinitions = [
@@ -234,15 +234,6 @@ const config = {
                   `import styles from './${component}.styles.js';\nimport customStyles from './${component}.custom.styles.js';`,
                 );
 
-              // TODO: Can be removed as soon as following bug is fixed in shoelace (https://github.com/shoelace-style/shoelace/issues/1896) (our issue https://github.com/synergy-design-system/synergy-design-system/issues/347)
-              if (component === 'checkbox') {
-                newContent = newContent
-                  .replace(
-                    `import styles from './${component}.styles.js';`,
-                    `import styles from './${component}.styles.js';\nimport formControlStyles from \'../../styles/form-control.styles.js\';`,
-                  );
-              }
-
               newContent = newContent
                 .replace(
                   'import formControlStyles from \'../../styles/form-control.styles.js\';',
@@ -254,10 +245,6 @@ const config = {
               const regex = /static styles: CSSResultGroup = \[([^\]]+)\]/;
               newContent = newContent.replace(regex, (_, value) => {
                 let styleValues = value;
-                // TODO: remove this if clause as soon as following bug is fixed in shoelace (https://github.com/shoelace-style/shoelace/issues/1896) (our issue https://github.com/synergy-design-system/synergy-design-system/issues/347)
-                if (component === 'checkbox') {
-                  styleValues += ', formControlStyles';
-                }
 
                 if (styleValues.includes('formControlStyles')) {
                   styleValues += ', formControlCustomStyles';

--- a/packages/components/scripts/vendorism/custom/button.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/button.vendorism.js
@@ -81,6 +81,10 @@ const transformStyles = (path, originalContent) => {
   // Fix button group
   content = content.replace("[variant='default']", "[variant='filled']");
 
+  // Fix invalid css
+  // TODO: can be removed as soon as following shoelace fix is released and integrated https://github.com/shoelace-style/shoelace/issues/1974 and https://github.com/shoelace-style/shoelace/pull/1975
+  content = content.replace(':host([data-syn-button-group__button[checked]]) {', ':host([data-syn-button-group__button][checked]) {');
+
   return {
     content,
     path,

--- a/packages/components/scripts/vendorism/custom/button.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/button.vendorism.js
@@ -1,30 +1,64 @@
-import { removeSection } from '../remove-section.js';
+import { removeSection, removeSections } from '../remove-section.js';
 
-export const vendorButton = (path, content) => {
-  const output = { content, path };
+const FILES_TO_TRANSFORM = [
+  'button.component.ts',
+  'button.styles.ts',
+  'button.test.ts',
+];
 
-  if (!path.includes('button.component.ts')
-    && !path.includes('button.styles.ts')
-    && !path.includes('button.test.ts')
-  ) {
-    return output;
-  }
-  // Remove unneeded modifiers from component's classMap
-  ['pill', 'circle', 'danger', 'warning', 'success', 'neutral', 'default'].forEach((modifier) => {
-    output.content = removeSection(output.content, `'button--${modifier}':`, ',');
-  });
+/**
+ * Transform the component code
+ * @param {String} path
+ * @param {String} originalContent
+ * @returns
+ */
+const transformComponent = (path, originalContent) => {
+  const unneededModifiers = ['pill', 'circle', 'danger', 'warning', 'success', 'neutral', 'default'].map((modifier) => [`'button--${modifier}':`, ',']);
 
-  // Remove pill and circle props from component
-  output.content = removeSection(output.content, '/** Draws a pill-style', ';');
-  output.content = removeSection(output.content, '/**\n   * Draws a circular', ';');
+  let content = removeSections([
+    // Remove unneeded modifiers from component's classMap
+    ...unneededModifiers,
+    // Remove pill prop
+    ['/** Draws a pill-style', ';'],
+    // Remove circle prop
+    ['/**\n   * Draws a circular', ';'],
+    // Remove outline prop to use variant prop for shape
+    ['/** Draws an outlined', ';'],
+    ['@property({ reflect: true }) variant:', ';', { preserveEnd: true, preserveStart: true, removePrecedingWhitespace: false }],
+  ], originalContent);
+
+  content = content.replace('variant:', "variant: 'filled' | 'outline' | 'text' = 'outline'");
+  content = content.replace('!this.outline', 'this.variant === \'filled\'');
+  content = content.replace('this.outline', 'this.variant === \'outline\'');
+
+  // Set "primary" as default color
+  // If we need more colors later, a "color" prop would have to be added
+  content = content.replace("this.variant === 'primary'", 'true');
+
+  // Rename "standard" class to default
+  content = content.replace(/button--standard/g, 'button--filled');
+  return {
+    content,
+    path,
+  };
+};
+
+/**
+ * Transform the components styles
+ * @param {String} path
+ * @param {String} originalContent
+ * @returns
+ */
+const transformStyles = (path, originalContent) => {
+  let content = originalContent;
 
   // Remove pill and circle from CSS
   ['Pill', 'Circle'].forEach((modifier) => {
-    output.content = removeSection(
-      output.content,
-      `  /*\n   * ${modifier} modifier`,
-      '  /*',
-      { preserveEnd: true, removePrecedingWhitespace: false },
+    content = removeSection(
+      content,
+        `  /*\n   * ${modifier} modifier`,
+        '  /*',
+        { preserveEnd: true, removePrecedingWhitespace: false },
     );
   });
 
@@ -32,38 +66,70 @@ export const vendorButton = (path, content) => {
   ['Success', 'Warning', 'Danger', 'Neutral', 'Default'].forEach((color) => {
     // They appear twice in the file
     [0, 1].forEach(() => {
-      output.content = removeSection(
-        output.content,
-        `/* ${color}`,
-        '/*',
-        { preserveEnd: true, removePrecedingWhitespace: false },
+      content = removeSection(
+        content,
+          `/* ${color}`,
+          '/*',
+          { preserveEnd: true, removePrecedingWhitespace: false },
       );
     });
   });
 
-  // Use variant prop for "shape"
-  output.content = removeSection(output.content, '@property({ reflect: true }) variant:', ';', { preserveEnd: true, preserveStart: true, removePrecedingWhitespace: false });
-  output.content = removeSection(output.content, '/** Draws an outlined', ';');
-  output.content = output.content.replace('variant:', "variant: 'filled' | 'outline' | 'text' = 'outline'");
-  output.content = output.content.replace('!this.outline', 'this.variant === \'filled\'');
-  output.content = output.content.replace('this.outline', 'this.variant === \'outline\'');
-
-  // Set "primary" as default color
-  // If we need more colors later, a "color" prop would have to be added
-  output.content = output.content.replace("this.variant === 'primary'", 'true');
+  // Rename "standard" class to default
+  content = content.replace(/button--standard/g, 'button--filled');
 
   // Fix button group
-  output.content = output.content.replace("[variant='default']", "[variant='filled']");
+  content = content.replace("[variant='default']", "[variant='filled']");
 
-  // Rename "standard" class to default
-  output.content = output.content.replace(/button--standard/g, 'button--filled');
+  return {
+    content,
+    path,
+  };
+};
 
-  // Fix tests
-  output.content = output.content.replace("const variants = ['default', 'primary', 'success', 'neutral', 'warning', 'danger'];", "const variants = ['filled', 'outline', 'text'];");
-  output.content = output.content.replace("expect(el.variant).to.equal('default');", "expect(el.variant).to.equal('outline');");
+/**
+ * Transform the components tests
+ * @param {String} path
+ * @param {String} originalContent
+ * @returns
+ */
+const transformTests = (path, originalContent) => {
+  let content = originalContent;
+
+  content = content.replace("const variants = ['default', 'primary', 'success', 'neutral', 'warning', 'danger'];", "const variants = ['filled', 'outline', 'text'];");
+  content = content.replace("expect(el.variant).to.equal('default');", "expect(el.variant).to.equal('outline');");
   ['outline', 'pill', 'circle'].forEach((prop) => {
-    output.content = removeSection(output.content, `expect(el.${prop})`, ';');
+    content = removeSection(content, `expect(el.${prop})`, ';');
   });
+
+  return {
+    content,
+    path,
+  };
+};
+
+// eslint-disable-next-line complexity
+export const vendorButton = (path, content) => {
+  const output = { content, path };
+
+  // Skip for non button
+  const isValidFile = !!FILES_TO_TRANSFORM.find(p => path.includes(p));
+
+  if (!isValidFile) {
+    return output;
+  }
+
+  if (path.endsWith('button.component.ts')) {
+    return transformComponent(path, content);
+  }
+
+  if (path.endsWith('button.styles.ts')) {
+    return transformStyles(path, content);
+  }
+
+  if (path.endsWith('button.test.ts')) {
+    return transformTests(path, content);
+  }
 
   return output;
 };

--- a/packages/components/scripts/vendorism/custom/webTestRunner.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/webTestRunner.vendorism.js
@@ -29,6 +29,15 @@ import synTestPlugins from './scripts/tests/index.js';`,
     esbuildPlugin({`,
   );
 
+  // Enable testing with firefox.
+  // TODO: As soon as shoelace enabled it on their side, this can be removed
+
+  nextContent = nextContent.replace(
+      `// Firefox started failing randomly so we're temporarily disabling it here. This could be a rogue test, not really
+    // sure what's happening.
+    // playwrightLauncher({ product: 'firefox' }),`,
+      'playwrightLauncher({ product: \'firefox\' }),',
+  );
   return {
     content: nextContent,
     path,

--- a/packages/components/src/components/button-group/button-group.component.ts
+++ b/packages/components/src/components/button-group/button-group.component.ts
@@ -36,22 +36,22 @@ export default class SynButtonGroup extends SynergyElement {
 
   private handleFocus(event: Event) {
     const button = findButton(event.target as HTMLElement);
-    button?.classList.add('syn-button-group__button--focus');
+    button?.toggleAttribute('data-syn-button-group__button--focus', true);
   }
 
   private handleBlur(event: Event) {
     const button = findButton(event.target as HTMLElement);
-    button?.classList.remove('syn-button-group__button--focus');
+    button?.toggleAttribute('data-syn-button-group__button--focus', false);
   }
 
   private handleMouseOver(event: Event) {
     const button = findButton(event.target as HTMLElement);
-    button?.classList.add('syn-button-group__button--hover');
+    button?.toggleAttribute('data-syn-button-group__button--hover', true);
   }
 
   private handleMouseOut(event: Event) {
     const button = findButton(event.target as HTMLElement);
-    button?.classList.remove('syn-button-group__button--hover');
+    button?.toggleAttribute('data-syn-button-group__button--hover', false);
   }
 
   private handleSlotChange() {
@@ -62,11 +62,14 @@ export default class SynButtonGroup extends SynergyElement {
       const button = findButton(el);
 
       if (button) {
-        button.classList.add('syn-button-group__button');
-        button.classList.toggle('syn-button-group__button--first', index === 0);
-        button.classList.toggle('syn-button-group__button--inner', index > 0 && index < slottedElements.length - 1);
-        button.classList.toggle('syn-button-group__button--last', index === slottedElements.length - 1);
-        button.classList.toggle('syn-button-group__button--radio', button.tagName.toLowerCase() === 'syn-radio-button');
+        button.toggleAttribute('data-syn-button-group__button', true);
+        button.toggleAttribute('data-syn-button-group__button--first', index === 0);
+        button.toggleAttribute('data-syn-button-group__button--inner', index > 0 && index < slottedElements.length - 1);
+        button.toggleAttribute('data-syn-button-group__button--last', index === slottedElements.length - 1);
+        button.toggleAttribute(
+          'data-syn-button-group__button--radio',
+          button.tagName.toLowerCase() === 'syn-radio-button'
+        );
       }
     });
   }

--- a/packages/components/src/components/button/button.styles.ts
+++ b/packages/components/src/components/button/button.styles.ts
@@ -316,30 +316,30 @@ export default css`
    * buttons and we style them here instead.
    */
 
-  :host(.syn-button-group__button--first:not(.syn-button-group__button--last)) .button {
+  :host([data-syn-button-group__button--first]:not([data-syn-button-group__button--last])) .button {
     border-start-end-radius: 0;
     border-end-end-radius: 0;
   }
 
-  :host(.syn-button-group__button--inner) .button {
+  :host([data-syn-button-group__button--inner]) .button {
     border-radius: 0;
   }
 
-  :host(.syn-button-group__button--last:not(.syn-button-group__button--first)) .button {
+  :host([data-syn-button-group__button--last]:not([data-syn-button-group__button--first])) .button {
     border-start-start-radius: 0;
     border-end-start-radius: 0;
   }
 
   /* All except the first */
-  :host(.syn-button-group__button:not(.syn-button-group__button--first)) {
+  :host([data-syn-button-group__button]:not([data-syn-button-group__button--first])) {
     margin-inline-start: calc(-1 * var(--syn-input-border-width));
   }
 
   /* Add a visual separator between solid buttons */
   :host(
-      .syn-button-group__button:not(
-          .syn-button-group__button--first,
-          .syn-button-group__button--radio,
+      [data-syn-button-group__button]:not(
+          [data-syn-button-group__button--first],
+          [data-syn-button-group__button--radio],
           [variant='filled']
         ):not(:hover)
     )
@@ -354,13 +354,13 @@ export default css`
   }
 
   /* Bump hovered, focused, and checked buttons up so their focus ring isn't clipped */
-  :host(.syn-button-group__button--hover) {
+  :host([data-syn-button-group__button--hover]) {
     z-index: 1;
   }
 
   /* Focus and checked are always on top */
-  :host(.syn-button-group__button--focus),
-  :host(.syn-button-group__button[checked]) {
+  :host([data-syn-button-group__button--focus]),
+  :host([data-syn-button-group__button[checked]]) {
     z-index: 2;
   }
 `;

--- a/packages/components/src/components/button/button.styles.ts
+++ b/packages/components/src/components/button/button.styles.ts
@@ -360,7 +360,7 @@ export default css`
 
   /* Focus and checked are always on top */
   :host([data-syn-button-group__button--focus]),
-  :host([data-syn-button-group__button[checked]]) {
+  :host([data-syn-button-group__button][checked]) {
     z-index: 2;
   }
 `;

--- a/packages/components/src/components/checkbox/checkbox.component.ts
+++ b/packages/components/src/components/checkbox/checkbox.component.ts
@@ -14,11 +14,11 @@ import { live } from 'lit/directives/live.js';
 import { property, query, state } from 'lit/decorators.js';
 import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
+import formControlStyles from '../../styles/form-control.styles.js';
+import formControlCustomStyles from '../../styles/form-control.custom.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
 import SynIcon from '../icon/icon.component.js';
 import styles from './checkbox.styles.js';
-import formControlStyles from '../../styles/form-control.styles.js';
-import formControlCustomStyles from '../../styles/form-control.custom.styles.js';
 import customStyles from './checkbox.custom.styles.js';
 import type { CSSResultGroup } from 'lit';
 import type { SynergyFormControl } from '../../internal/synergy-element.js';
@@ -50,7 +50,7 @@ import type { SynergyFormControl } from '../../internal/synergy-element.js';
  * @csspart form-control-help-text - The help text's wrapper.
  */
 export default class SynCheckbox extends SynergyElement implements SynergyFormControl {
-  static styles: CSSResultGroup = [componentStyles, styles, formControlStyles, formControlCustomStyles, customStyles];
+  static styles: CSSResultGroup = [componentStyles, formControlStyles, styles, formControlCustomStyles, customStyles];
   static dependencies = { 'syn-icon': SynIcon };
 
   private readonly formControlController = new FormControlController(this, {

--- a/packages/components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/components/src/components/checkbox/checkbox.styles.ts
@@ -122,6 +122,7 @@ export default css`
 
   :host([required]) .checkbox__label::after {
     content: var(--syn-input-required-content);
+    color: var(--syn-input-required-content-color);
     margin-inline-start: var(--syn-input-required-content-offset);
   }
 `;

--- a/packages/components/src/components/dropdown/dropdown.component.ts
+++ b/packages/components/src/components/dropdown/dropdown.component.ts
@@ -9,6 +9,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { getAnimation, setDefaultAnimation } from '../../utilities/animation-registry.js';
 import { getTabbableBoundary } from '../../internal/tabbable.js';
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import { property, query } from 'lit/decorators.js';
 import { waitForEvent } from '../../internal/event.js';
@@ -108,6 +109,11 @@ export default class SynDropdown extends SynergyElement {
    * `overflow: auto|scroll`. Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios.
    */
   @property({ type: Boolean }) hoist = false;
+
+  /**
+   * Syncs the popup width or height to that of the trigger element.
+   */
+  @property({ reflect: true }) sync: 'width' | 'height' | 'both' | undefined = undefined;
 
   connectedCallback() {
     super.connectedCallback();
@@ -416,6 +422,7 @@ export default class SynDropdown extends SynergyElement {
         shift
         auto-size="vertical"
         auto-size-padding="10"
+        sync=${ifDefined(this.sync ? this.sync : undefined)}
         class=${classMap({
           dropdown: true,
           'dropdown--open': this.open

--- a/packages/components/src/components/icon/icon.component.ts
+++ b/packages/components/src/components/icon/icon.component.ts
@@ -49,9 +49,21 @@ export default class SynIcon extends SynergyElement {
     let fileData: Response;
 
     if (library?.spriteSheet) {
-      return html`<svg part="svg">
+      this.svg = html`<svg part="svg">
         <use part="use" href="${url}"></use>
       </svg>`;
+
+      // Using a templateResult requires the SVG to be written to the DOM first before we can grab the SVGElement
+      // to be passed to the library's mutator function.
+      await this.updateComplete;
+
+      const svg = this.shadowRoot!.querySelector("[part='svg']")!;
+
+      if (typeof library.mutator === 'function') {
+        library.mutator(svg as SVGElement);
+      }
+
+      return this.svg;
     }
 
     try {

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -306,13 +306,16 @@ export default class SynInput extends SynergyElement implements SynergyFormContr
   }
 
   private handleClearClick(event: MouseEvent) {
-    this.value = '';
-    this.emit('syn-clear');
-    this.emit('syn-input');
-    this.emit('syn-change');
-    this.input.focus();
+    event.preventDefault();
 
-    event.stopPropagation();
+    if (this.value !== '') {
+      this.value = '';
+      this.emit('syn-clear');
+      this.emit('syn-input');
+      this.emit('syn-change');
+    }
+
+    this.input.focus();
   }
 
   private handleFocus() {
@@ -551,14 +554,11 @@ export default class SynInput extends SynergyElement implements SynergyFormContr
               @blur=${this.handleBlur}
             />
 
-            ${hasClearIcon
+            ${isClearIconVisible
               ? html`
                   <button
                     part="clear-button"
-                    class=${classMap({
-                      input__clear: true,
-                      'input__clear--visible': isClearIconVisible
-                    })}
+                    class="input__clear"
                     type="button"
                     aria-label=${this.localize.term('clearEntry')}
                     @click=${this.handleClearClick}

--- a/packages/components/src/components/input/input.styles.ts
+++ b/packages/components/src/components/input/input.styles.ts
@@ -238,10 +238,6 @@ export default css`
    * Clearable + Password Toggle
    */
 
-  .input__clear:not(.input__clear--visible) {
-    visibility: hidden;
-  }
-
   .input__clear,
   .input__password-toggle {
     display: inline-flex;
@@ -264,10 +260,6 @@ export default css`
   .input__clear:focus,
   .input__password-toggle:focus {
     outline: none;
-  }
-
-  .input--empty .input__clear {
-    visibility: hidden;
   }
 
   /* Don't show the browser's password toggle in Edge */

--- a/packages/components/src/components/menu-item/submenu-controller.ts
+++ b/packages/components/src/components/menu-item/submenu-controller.ts
@@ -235,6 +235,7 @@ export class SubmenuController implements ReactiveController {
   // newly opened menu.
   private enableSubmenu(delay = true) {
     if (delay) {
+      window.clearTimeout(this.enableSubmenuTimer);
       this.enableSubmenuTimer = window.setTimeout(() => {
         this.setSubmenuState(true);
       }, this.submenuOpenDelay);
@@ -244,7 +245,7 @@ export class SubmenuController implements ReactiveController {
   }
 
   private disableSubmenu() {
-    clearTimeout(this.enableSubmenuTimer);
+    window.clearTimeout(this.enableSubmenuTimer);
     this.setSubmenuState(false);
   }
 

--- a/packages/components/src/components/popup/popup.component.ts
+++ b/packages/components/src/components/popup/popup.component.ts
@@ -16,10 +16,16 @@ import type { CSSResultGroup } from 'lit';
 
 export interface VirtualElement {
   getBoundingClientRect: () => DOMRect;
+  contextElement?: Element;
 }
 
 function isVirtualElement(e: unknown): e is VirtualElement {
-  return e !== null && typeof e === 'object' && 'getBoundingClientRect' in e;
+  return (
+    e !== null &&
+    typeof e === 'object' &&
+    'getBoundingClientRect' in e &&
+    ('contextElement' in e ? e instanceof Element : true)
+  );
 }
 
 /**

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -225,7 +225,15 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     //
     // https://github.com/synergy-design-system/synergy/issues/1763
     //
-    const root = this.getRootNode();
+    document.addEventListener('focusin', this.handleDocumentFocusIn);
+    document.addEventListener('keydown', this.handleDocumentKeyDown);
+    document.addEventListener('mousedown', this.handleDocumentMouseDown);
+
+    // If the component is rendered in a shadow root, we need to attach the focusin listener there too
+    if (this.getRootNode() !== document) {
+      this.getRootNode().addEventListener('focusin', this.handleDocumentFocusIn);
+    }
+
     if ('CloseWatcher' in window) {
       this.closeWatcher?.destroy();
       this.closeWatcher = new CloseWatcher();
@@ -236,16 +244,17 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
         }
       };
     }
-    root.addEventListener('focusin', this.handleDocumentFocusIn);
-    root.addEventListener('keydown', this.handleDocumentKeyDown);
-    root.addEventListener('mousedown', this.handleDocumentMouseDown);
   }
 
   private removeOpenListeners() {
-    const root = this.getRootNode();
-    root.removeEventListener('focusin', this.handleDocumentFocusIn);
-    root.removeEventListener('keydown', this.handleDocumentKeyDown);
-    root.removeEventListener('mousedown', this.handleDocumentMouseDown);
+    document.removeEventListener('focusin', this.handleDocumentFocusIn);
+    document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    document.removeEventListener('mousedown', this.handleDocumentMouseDown);
+
+    if (this.getRootNode() !== document) {
+      this.getRootNode().removeEventListener('focusin', this.handleDocumentFocusIn);
+    }
+
     this.closeWatcher?.destroy();
   }
 
@@ -609,7 +618,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
         </div>`;
       } else if (index === this.maxOptionsVisible) {
         // Hit tag limit
-        return html`<syn-tag>+${this.selectedOptions.length - index}</syn-tag>`;
+        return html`<syn-tag size=${this.size}>+${this.selectedOptions.length - index}</syn-tag>`;
       }
       return html``;
     });

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -468,7 +468,7 @@ describe('<syn-select>', () => {
       await select.updateComplete;
       expect(select.value).to.equal('option-3');
 
-      setTimeout(() => clickOnElement(resetButton));
+      setTimeout(() => resetButton.click());
       await oneEvent(form, 'reset');
       await select.updateComplete;
       expect(select.value).to.equal('option-1');

--- a/packages/components/src/components/switch/switch.styles.ts
+++ b/packages/components/src/components/switch/switch.styles.ts
@@ -162,6 +162,7 @@ export default css`
 
   :host([required]) .switch__label::after {
     content: var(--syn-input-required-content);
+    color: var(--syn-input-required-content-color);
     margin-inline-start: var(--syn-input-required-content-offset);
   }
 

--- a/packages/components/src/internal/form.ts
+++ b/packages/components/src/internal/form.ts
@@ -78,9 +78,8 @@ export class FormControlController implements ReactiveController {
         const formId = input.form;
 
         if (formId) {
-          const root = input.getRootNode() as Document | ShadowRoot;
-
-          const form = root.getElementById(formId);
+          const root = input.getRootNode() as Document | ShadowRoot | HTMLElement;
+          const form = root.querySelector(`#${formId}`);
 
           if (form) {
             return form as HTMLFormElement;

--- a/packages/components/src/internal/scroll.ts
+++ b/packages/components/src/internal/scroll.ts
@@ -15,6 +15,19 @@ function getScrollbarWidth() {
 }
 
 /**
+ * Used in conjunction with `scrollbarWidth` to set proper body padding in case the user has padding already on the `<body>` element.
+ */
+function getExistingBodyPadding() {
+  const padding = Number(getComputedStyle(document.body).paddingRight.replace(/px/, ''));
+
+  if (isNaN(padding) || !padding) {
+    return 0;
+  }
+
+  return padding;
+}
+
+/**
  * Prevents body scrolling. Keeps track of which elements requested a lock so multiple levels of locking are possible
  * without premature unlocking.
  */
@@ -23,10 +36,11 @@ export function lockBodyScrolling(lockingEl: HTMLElement) {
 
   // When the first lock is created, set the scroll lock size to match the scrollbar's width to prevent content from
   // shifting. We only do this on the first lock because the scrollbar width will measure zero after overflow is hidden.
-  if (!document.body.classList.contains('syn-scroll-lock')) {
-    const scrollbarWidth = getScrollbarWidth(); // must be measured before the `syn-scroll-lock` class is applied
-    document.body.classList.add('syn-scroll-lock');
-    document.body.style.setProperty('--syn-scroll-lock-size', `${scrollbarWidth}px`);
+  if (!document.documentElement.classList.contains('syn-scroll-lock')) {
+    /** Scrollbar width + body padding calculation can go away once Safari has scrollbar-gutter support. */
+    const scrollbarWidth = getScrollbarWidth() + getExistingBodyPadding(); // must be measured before the `syn-scroll-lock` class is applied
+    document.documentElement.classList.add('syn-scroll-lock');
+    document.documentElement.style.setProperty('--syn-scroll-lock-size', `${scrollbarWidth}px`);
   }
 }
 
@@ -37,8 +51,8 @@ export function unlockBodyScrolling(lockingEl: HTMLElement) {
   locks.delete(lockingEl);
 
   if (locks.size === 0) {
-    document.body.classList.remove('syn-scroll-lock');
-    document.body.style.removeProperty('--syn-scroll-lock-size');
+    document.documentElement.classList.remove('syn-scroll-lock');
+    document.documentElement.style.removeProperty('--syn-scroll-lock-size');
   }
 }
 

--- a/packages/components/src/themes/utility.css
+++ b/packages/components/src/themes/utility.css
@@ -11,8 +11,9 @@
   }
 }
 
+/** This can go away once Safari has scrollbar-gutter support. */
 @supports not (scrollbar-gutter: stable) {
-  .syn-scroll-lock {
+  .syn-scroll-lock body {
     overflow: hidden !important;
     padding-right: var(--syn-scroll-lock-size) !important;
   }

--- a/packages/components/web-test-runner.config.js
+++ b/packages/components/web-test-runner.config.js
@@ -31,9 +31,7 @@ export default {
   ],
   browsers: [
     playwrightLauncher({ product: 'chromium' }),
-    // Firefox started failing randomly so we're temporarily disabling it here. This could be a rogue test, not really
-    // sure what's happening.
-    // playwrightLauncher({ product: 'firefox' }),
+    playwrightLauncher({ product: 'firefox' }),
     playwrightLauncher({ product: 'webkit' })
   ],
   testRunnerHtml: testFramework => `

--- a/packages/docs/.storybook/preview-head.html
+++ b/packages/docs/.storybook/preview-head.html
@@ -2,8 +2,18 @@
 /**
  * Make sure scroll lock is disabled for modals and the drawer
  */
-body.syn-scroll-lock:has(#storybook-docs) {
-  padding-right: unset !important;
-  overflow: unset !important;
+@supports (scrollbar-gutter: stable) {
+  html.syn-scroll-lock:has(#storybook-docs) {
+    overflow: unset !important;
+    scrollbar-gutter: unset !important;
+  }
+}
+
+/** This can go away once Safari has scrollbar-gutter support. */
+@supports not (scrollbar-gutter: stable) {
+  .syn-scroll-lock body:has(#storybook-docs) {
+    padding-right: unset !important;
+    overflow: unset !important;
+  }
 }
 </style>

--- a/packages/vue/src/components/SynVueDropdown.vue
+++ b/packages/vue/src/components/SynVueDropdown.vue
@@ -125,6 +125,11 @@ dropdowns that allow for multiple interactions.
 * Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios.
  */
   'hoist'?: SynDropdown['hoist'];
+
+  /**
+* Syncs the popup width or height to that of the trigger element.
+ */
+  'sync'?: SynDropdown['sync'];
 }>();
 
 // Make sure prop binding only forwards the props that are actually there.


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR updates Shoelace to the latest version 2.15.0.

### 🎫 Issues

<!--
* List and link relevant issues here.
-->
Closes #398 and #347 

## 👩‍💻 Reviewer Notes

The main changes from shoelace are:
- Added the `sync` property to <sl-dropdown> 
- Fixed a bug in <sl-icon> that did not properly apply mutators to spritesheets 
- Fixed a bug in .sl-scroll-lock causing layout shifts
- Fixed a bug in <sl-select> that caused the menu to not close when rendered in a shadow root
- Fixed a bug in the submenu controller that allowed two submenus to be open at the same time 
- Fixed a bug in <sl-select> where the tag size wouldn’t update with the control’s size 
- Fixed a bug in <sl-checkbox> and <sl-switch> where the color of the required content wasn’t applying correctly
- Fixed a bug in <sl-checkbox> where help text was incorrectly styled
- Fixed a bug in <sl-input> that prevented the control from receiving focus when clicking over the clear button
- Fixed a bug in <sl-button-group> that caused styles to stop working when using className on buttons in React 

The main changes for our repo:
- added a workaround in the the `button.vendorism.js` because with the new update a bug with invalid css was added

> Note that we will have to adjust the changelog manually after the release! This is handled in #398 .

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
