### PR TITLE
fix: 🤔 syn-text-area may throw an error when unmounted too quick

### DIFF
--- a/packages/components/scripts/vendorism/custom/textarea.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/textarea.vendorism.js
@@ -15,7 +15,6 @@ const FILES_TO_TRANSFORM = [
  */
 const transformComponent = (path, originalContent) => {
   let content = removeSection(originalContent, '/** Draws a filled', 'filled = false;');
-  content = replaceSection(['filled', 'readonly'], content);
 
   content = replaceSections([
     ['filled', 'readonly'],

--- a/packages/components/scripts/vendorism/custom/textarea.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/textarea.vendorism.js
@@ -16,6 +16,18 @@ const FILES_TO_TRANSFORM = [
 const transformComponent = (path, originalContent) => {
   let content = removeSection(originalContent, '/** Draws a filled', 'filled = false;');
   content = replaceSection(['filled', 'readonly'], content);
+
+  content = replaceSections([
+    ['filled', 'readonly'],
+    // Make sure we don't unobserve an undefined element
+    // @todo: Remove when shoelace ships this fix
+    ['this.resizeObserver.unobserve(this.input);', `
+    if (this.input) {
+      this.resizeObserver.unobserve(this.input);
+    }
+    `.trim()],
+  ], content);
+
   return {
     content,
     path,

--- a/packages/components/scripts/vendorism/replace-section.js
+++ b/packages/components/scripts/vendorism/replace-section.js
@@ -7,7 +7,7 @@
 export const replaceSection = ([search, replace], content) => content.replaceAll(search, replace);
 
 /**
- * Takes an array of section options and applies them via removeSection one by one
+ * Takes an array of section options and applies them via replaceSection one by one
  * @param {string[][]} sections The sections you want to replace
  * @param {string} initialContent The initial content
  * @returns {string} Output after all transforms ran

--- a/packages/components/scripts/vendorism/replace-section.js
+++ b/packages/components/scripts/vendorism/replace-section.js
@@ -1,0 +1,19 @@
+/**
+ * Replace a section of content with a new section
+ * @param {string[]} pair Tuple of search and replace strings
+ * @param {*} content The content to run the replacement in
+ * @returns {string} New content with replacements applied
+ */
+export const replaceSection = ([search, replace], content) => content.replaceAll(search, replace);
+
+/**
+ * Takes an array of section options and applies them via removeSection one by one
+ * @param {string[][]} sections The sections you want to replace
+ * @param {string} initialContent The initial content
+ * @returns {string} Output after all transforms ran
+ */
+export const replaceSections = (sections, initialContent) => sections.reduce(
+  // (prev, section) => replaceSection(prev, ...section),
+  (prev, section) => replaceSection(section, prev),
+  initialContent,
+);

--- a/packages/components/src/components/textarea/textarea.component.ts
+++ b/packages/components/src/components/textarea/textarea.component.ts
@@ -50,7 +50,7 @@ export default class SynTextarea extends SynergyElement implements SynergyFormCo
   private readonly formControlController = new FormControlController(this, {
     assumeInteractionOn: ['syn-blur', 'syn-input']
   });
-  private readonly hasSlotController = new HasSlotController(this, 'help-text', 'label', 'prefix', 'suffix');
+  private readonly hasSlotController = new HasSlotController(this, 'help-text', 'label');
   private resizeObserver: ResizeObserver;
 
   @query('.textarea__control') input: HTMLTextAreaElement;
@@ -304,8 +304,6 @@ export default class SynTextarea extends SynergyElement implements SynergyFormCo
   render() {
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
-    const hasPrefixSlot = this.hasSlotController.test('prefix');
-    const hasSuffixSlot = this.hasSlotController.test('suffix');
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
 
@@ -318,9 +316,7 @@ export default class SynTextarea extends SynergyElement implements SynergyFormCo
           'form-control--medium': this.size === 'medium',
           'form-control--large': this.size === 'large',
           'form-control--has-label': hasLabel,
-          'form-control--has-help-text': hasHelpText,
-          'form-control--has-prefix': hasPrefixSlot,
-          'form-control--has-suffix': hasSuffixSlot
+          'form-control--has-help-text': hasHelpText
         })}
       >
         <label

--- a/packages/components/src/components/textarea/textarea.component.ts
+++ b/packages/components/src/components/textarea/textarea.component.ts
@@ -168,7 +168,9 @@ export default class SynTextarea extends SynergyElement implements SynergyFormCo
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.resizeObserver.unobserve(this.input);
+    if (this.input) {
+      this.resizeObserver.unobserve(this.input);
+    }
   }
 
   private handleBlur() {


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!--
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

This PR prevents an error that may appear when removing the `<syn-textarea />` too fast from the DOM. This may especially happen in test frameworks (e.g. Karma), where the current behaviour lead to an error `Uncaught TypeError: Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element'. thrown`.

### 🎫 Issues

Closes #435

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

- I have opted to rewrite the vendorism script in the new style and also add two new utility functions to make it easier in the future: `replaceSection` will replace a section with the same syntax as `removeSection`, whereas `replaceSections` will do the same given an array of replacements.
- There where some dangling css classes that where copied left overs from the input vendorism (prefix and suffix). Those are removed
- The fix is applied, too ;)

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

Unfortunately, I was not able to reproduce this problem on my local machine. However, I have already tested the implementation on a project where the issue arose and can say for sure it does not break after applying the fix.

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
