### PR TITLE
fix: 🤔 chevron of syn-nav-item using wrong symbol

### DIFF
--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -348,6 +348,7 @@ export default class SynNavItem extends SynergyElement {
           'nav-item--has-prefix': this.hasSlotController.test('prefix'),
           'nav-item--has-suffix': this.hasSlotController.test('suffix'),
           'nav-item--horizontal': this.horizontal,
+          'nav-item--is-link': isLink,
           'nav-item--multi-line': this.isMultiLine,
           'nav-item--show-prefix-only': this.showPrefixOnly,
           'nav-item--vertical': !this.horizontal,

--- a/packages/components/src/components/nav-item/nav-item.styles.ts
+++ b/packages/components/src/components/nav-item/nav-item.styles.ts
@@ -145,7 +145,7 @@ export default css`
   }
 
   /**
-   * The chevron indicates the use as a <details /> element
+   * The chevron indicates the use as a <details /> element OR a link
    */
   .nav-item__chevron {
     font-size: var(--syn-font-size-x-large);
@@ -156,6 +156,13 @@ export default css`
 
   .nav-item__chevron-open {
     rotate: -180deg;
+  }
+
+  /**
+   * Links should always show a chevron pointing to the right
+   */
+  .nav-item--is-link .nav-item__chevron {
+    rotate: -90deg;
   }
 
   /**

--- a/packages/components/src/components/nav-item/nav-item.styles.ts
+++ b/packages/components/src/components/nav-item/nav-item.styles.ts
@@ -159,9 +159,9 @@ export default css`
   }
 
   /**
-   * Links should always show a chevron pointing to the right
+   * Items that have the chevron attribute set and are NOT accordions should always show a chevron pointing to the right
    */
-  .nav-item--is-link .nav-item__chevron {
+  .nav-item:not(.nav-item-is-accordion) .nav-item__chevron {
     rotate: -90deg;
   }
 
@@ -185,6 +185,7 @@ export default css`
   /**
    * Show prefix only
    */
+  /* stylelint-disable-next-line no-descending-specificity */
   .nav-item--show-prefix-only .nav-item__content-container,
   .nav-item--show-prefix-only .nav-item__suffix,
   .nav-item--show-prefix-only .nav-item__chevron {
@@ -208,12 +209,14 @@ export default css`
   /**
    * Multi line content
    */
+  /* stylelint-disable-next-line no-descending-specificity */
   .nav-item--multi-line .nav-item__suffix,
   .nav-item--multi-line .nav-item__prefix,
   .nav-item--multi-line .nav-item__chevron {
     align-self: flex-start;
   }
 
+  /* stylelint-disable-next-line no-descending-specificity */
   .nav-item--multi-line .nav-item__suffix::slotted(syn-icon),
   :not(.nav-item--show-prefix-only).nav-item--multi-line .nav-item__prefix::slotted(syn-icon),
   .nav-item--multi-line .nav-item__chevron {


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that showed the wrong chevron position was used for `<syn-nav-items>` when having both a `href` and `chevron` attribute set.

Old behavior:

<img width="956" alt="old" src="https://github.com/synergy-design-system/synergy-design-system/assets/141909690/2fe26414-9c64-4bcc-b267-b5d6beb0b667">

New behavior:

<img width="959" alt="new" src="https://github.com/synergy-design-system/synergy-design-system/assets/141909690/af4a05b3-69e9-4e57-b2dc-529db16ffe5e">


### 🎫 Issues

Closes #432 

## 👩‍💻 Reviewer Notes

The change does not have an associated story.

## 📑 Test Plan

- Check out this branch
- Build world and start storybook
- Move to the docs page of `<syn-nav-item>`
- Set a `href` attribute and set `chevron` to true

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
