### PR TITLE
fix: 🤔 Syn-Checkbox uses wrong line-height when in multi-line mode

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.custom.styles.ts
+++ b/packages/components/src/components/checkbox/checkbox.custom.styles.ts
@@ -29,7 +29,21 @@ export default css`
   }
 
   .checkbox__label {
+    line-height: var(--syn-line-height-normal);
     margin-inline-start: var(--syn-spacing-x-small);
+    position: relative;
+  }
+
+  .checkbox--small .checkbox__label {
+    top: -3px;
+  }
+
+  .checkbox--medium .checkbox__label {
+    top: -3px;
+  }
+
+  .checkbox--large .checkbox__label {
+    top: -2px;
   }
 
   /* Disabled */


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that lead to broken line-heights for the label of `<syn-checkboxes>` when the label was displayed in multiple lines.

### 🎫 Issues

Closes #298 

## 👩‍💻 Reviewer Notes

The issue stems from the fact that Shoelace uses a fixed line-height value for the label that is set to the size of the checkboxes checkmark icon. When using a checkbox that has a multi-line label, this lead to the problem that spacing between the lines was too narrow.

A word on tokens: I was not able to use our token values for this as the margins are too narrow to tackle them this way.

## 📑 Test Plan

1. Verify the bug exists in the current version of Synergy (e.g. in our own form-template at https://synergy-design-system.github.io/?path=/story/templates-forms--contact-form&globals=viewport:default)
2. Have a look at the storybook version of this PR. It should show a line-height of `1.4`.

## ✅ DoD

<!-- Please review the list and make sure every item is fullfilled. Place a check (x) for each fullfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
