### PR TITLE
fix: 🤔 syn-header label uses wrong text color

### DIFF
--- a/packages/components/src/components/header/header.styles.ts
+++ b/packages/components/src/components/header/header.styles.ts
@@ -69,6 +69,7 @@ export default css`
    * The label section hosts the application name
    */
   .header__label {
+    color: var(--syn-typography-color-text);
     font: var(--syn-body-large-bold);
     padding: 0 var(--syn-spacing-2x-large);
     white-space: nowrap;


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a fixed color of `--syn-typography-color-text` to the `<syn-header>` label prop.

### 🎫 Issues

Closes #483 

## 👩‍💻 Reviewer Notes

Just have a look at storybook, nothing fancy here.

## 📑 Test Plan

Just have a look at storybook, nothing fancy here.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
