### PR TITLE
fix: 🤔 Nav-item has incorrect hover state when :focus

### DIFF
--- a/packages/components/src/components/nav-item/nav-item.styles.ts
+++ b/packages/components/src/components/nav-item/nav-item.styles.ts
@@ -253,7 +253,7 @@ export default css`
   }
 
   .nav-item--horizontal:hover .current-indicator--visible,
-  .nav-item--horizontal:focus .current-indicator--visible {
+  .nav-item--horizontal:focus-visible .current-indicator--visible {
     left: calc(var(--syn-spacing-x-small) * -1);
     right: calc(var(--syn-spacing-x-small) * -1);
   }


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!--
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
When a nav-item is clicked in a prio-nav, the hover effect does not longer get applied. The blue active line remains to its full length instead of shrinking (see gif).
![nav-item-focus](https://github.com/synergy-design-system/synergy-design-system/assets/115139104/55bad4b3-5cf1-404c-abc4-c3826125fb74)

### 🎫 Issues

<!--
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
