### PR TITLE
feat: ✨ icon-only button

### DIFF
--- a/packages/angular/src/components/radio-button.component.ts
+++ b/packages/angular/src/components/radio-button.component.ts
@@ -90,6 +90,18 @@ this attribute can typically be omitted.
     return this.nativeElement.size;
   }
 
+  /**
+* Draws a pill-style radio button with rounded edges.
+ */
+  @Input()
+  set pill(v: SynRadioButton['pill']) {
+    this._ngZone.runOutsideAngular(() => (this.nativeElement.pill = v));
+  }
+
+  get pill() {
+    return this.nativeElement.pill;
+  }
+
   @Input()
   callHandleDisabledChange(...args: Parameters<SynRadioButton['handleDisabledChange']>) {
     return this._ngZone.runOutsideAngular(() => this.nativeElement.handleDisabledChange(...args));

--- a/packages/components/scripts/vendorism/custom/button.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/button.vendorism.js
@@ -1,9 +1,10 @@
 import { removeSection, removeSections } from '../remove-section.js';
+import { addSectionAfter, replaceSections } from '../replace-section.js';
 
 const FILES_TO_TRANSFORM = [
-  'button.component.ts',
-  'button.styles.ts',
-  'button.test.ts',
+  'button/button.component.ts',
+  'button/button.styles.ts',
+  'button/button.test.ts',
 ];
 
 /**
@@ -27,16 +28,49 @@ const transformComponent = (path, originalContent) => {
     ['@property({ reflect: true }) variant:', ';', { preserveEnd: true, preserveStart: true, removePrecedingWhitespace: false }],
   ], originalContent);
 
-  content = content.replace('variant:', "variant: 'filled' | 'outline' | 'text' = 'outline'");
-  content = content.replace('!this.outline', 'this.variant === \'filled\'');
-  content = content.replace('this.outline', 'this.variant === \'outline\'');
+  content = replaceSections([
+    ['variant:', "variant: 'filled' | 'outline' | 'text' = 'outline'"],
+    ['!this.outline', 'this.variant === \'filled\''],
+    ['this.outline', 'this.variant === \'outline\''],
+    // Set "primary" as default color
+    // If we need more colors later, a "color" prop would have to be added
+    ["this.variant === 'primary'", 'true'],
+    // Rename "standard" class to default
+    ['button--standard', 'button--filled'],
 
-  // Set "primary" as default color
-  // If we need more colors later, a "color" prop would have to be added
-  content = content.replace("this.variant === 'primary'", 'true');
+    // Add default slot handling for icon-only buttons
+    ['import { HasSlotController', 'import { HasSlotController, getTextContent'],
+    [
+      '<slot part="label" class="button__label"></slot>',
+      // eslint-disable-next-line no-template-curly-in-string
+      '<slot part="label" class=${classMap({ \'button__label\': true, \'button__icon-only\': this.iconOnly })} @slotchange=${this.handleSlotChange}></slot>',
+    ],
+  ], content);
 
-  // Rename "standard" class to default
-  content = content.replace(/button--standard/g, 'button--filled');
+  // Add default slot handling for icon-only buttons
+  content = addSectionAfter(
+    content,
+    "@query('.button') button: HTMLButtonElement | HTMLLinkElement;",
+    `  @query('slot:not([name])') defaultSlot: HTMLSlotElement;
+
+  @state() private iconOnly = false;`,
+  );
+
+  content = addSectionAfter(
+    content,
+    `private isLink() {
+    return this.href ? true : false;
+  }`,
+    `  private handleSlotChange() {
+    const textContent = getTextContent(this.defaultSlot).trim();
+    const assignedElements = this.defaultSlot.assignedElements({flatten: true})
+    const iconOnlyElement = assignedElements.length === 1 && assignedElements[0].tagName.toLowerCase() === 'syn-icon';
+
+    this.iconOnly = iconOnlyElement && textContent === '';
+  }`,
+    { newslinesBeforeInsertion: 2 },
+  );
+
   return {
     content,
     path,

--- a/packages/components/src/components/button/button.component.ts
+++ b/packages/components/src/components/button/button.component.ts
@@ -6,7 +6,7 @@
 /* eslint-disable */
 import { classMap } from 'lit/directives/class-map.js';
 import { FormControlController, validValidityState } from '../../internal/form.js';
-import { HasSlotController } from '../../internal/slot.js';
+import { HasSlotController, getTextContent } from '../../internal/slot.js';
 import { html, literal } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeController } from '../../utilities/localize.js';
@@ -60,6 +60,9 @@ export default class SynButton extends SynergyElement implements SynergyFormCont
   private readonly localize = new LocalizeController(this);
 
   @query('.button') button: HTMLButtonElement | HTMLLinkElement;
+  @query('slot:not([name])') defaultSlot: HTMLSlotElement;
+
+  @state() private iconOnly = false;
 
   @state() private hasFocus = false;
   @state() invalid = false;
@@ -194,6 +197,14 @@ export default class SynButton extends SynergyElement implements SynergyFormCont
     return this.href ? true : false;
   }
 
+  private handleSlotChange() {
+    const textContent = getTextContent(this.defaultSlot).trim();
+    const assignedElements = this.defaultSlot.assignedElements({flatten: true})
+    const iconOnlyElement = assignedElements.length === 1 && assignedElements[0].tagName.toLowerCase() === 'syn-icon';
+
+    this.iconOnly = iconOnlyElement && textContent === '';
+  }
+
   @watch('disabled', { waitUntilFirstUpdate: true })
   handleDisabledChange() {
     if (this.isButton()) {
@@ -293,7 +304,7 @@ export default class SynButton extends SynergyElement implements SynergyFormCont
         @click=${this.handleClick}
       >
         <slot name="prefix" part="prefix" class="button__prefix"></slot>
-        <slot part="label" class="button__label"></slot>
+        <slot part="label" class=${classMap({ 'button__label': true, 'button__icon-only': this.iconOnly })} @slotchange=${this.handleSlotChange}></slot>
         <slot name="suffix" part="suffix" class="button__suffix"></slot>
         ${
           this.caret ? html` <syn-icon part="caret" class="button__caret" library="system" name="caret"></syn-icon> ` : ''

--- a/packages/components/src/components/button/button.custom.styles.ts
+++ b/packages/components/src/components/button/button.custom.styles.ts
@@ -29,6 +29,37 @@ export default css`
   }
 
   /**
+   * Icon-only buttons
+   */
+  .button--small .button__label.button__icon-only {
+    padding: 0 calc(var(--syn-spacing-x-small) + var(--syn-spacing-4x-small));
+  }
+
+  .button--small .button__label::slotted(syn-icon) {
+    font-size: var(--syn-font-size-medium);
+    vertical-align: -3px;
+  }
+
+  .button--medium .button__label.button__icon-only {
+    padding: 0 calc(var(--syn-spacing-small) - var(--syn-spacing-4x-small));
+  }
+
+  .button--medium .button__label::slotted(syn-icon) {
+    font-size: var(--syn-font-size-x-large);
+    vertical-align: -6px;
+  }
+
+  .button--large .button__label.button__icon-only {
+    padding: 0 calc(var(--syn-spacing-medium) - var(--syn-spacing-4x-small));
+  }
+
+  .button--large .button__label::slotted(syn-icon) {
+    font-size: var(--syn-font-size-2x-large);
+    vertical-align: -8px;
+  }
+
+
+  /**
    * Size modifiers
    */
   .button.button--medium.button--has-label .button__label {

--- a/packages/components/src/components/button/button.custom.test.ts
+++ b/packages/components/src/components/button/button.custom.test.ts
@@ -15,4 +15,31 @@ describe('<syn-button>', () => {
       expect(el.circle).to.equal(undefined);
     });
   });
+
+  describe('icon-only button', () => {
+
+    it('should add the className "button__icon-only" if a syn-icon is the only element in the default slot', async () => {
+      const el = await fixture<SynButton>(html` <syn-button><syn-icon name="wallpaper"></syn-icon></syn-button> `);
+      const defaultSlot = el.shadowRoot?.querySelector('[part="label"]');
+      expect(defaultSlot).to.have.class('button__icon-only');
+    });
+
+    it('should not add the className "button__icon-only" if another element is in default slot', async () => {
+      const el = await fixture<SynButton>(html` <syn-button>
+        <syn-icon name="wallpaper"></syn-icon>
+        <span>Button Label</span>
+      </syn-button> `);
+      const defaultSlot = el.shadowRoot?.querySelector('[part="label"]');
+      expect(defaultSlot).to.not.have.class('button__icon-only');
+    });
+
+    it('should not add the className "button__icon-only" if a text node is in default slot', async () => {
+      const el = await fixture<SynButton>(html` <syn-button>
+        <syn-icon name="wallpaper"></syn-icon>
+        Button Label
+      </syn-button> `);
+      const defaultSlot = el.shadowRoot?.querySelector('[part="label"]');
+      expect(defaultSlot).to.not.have.class('button__icon-only');
+    });
+  });
 });

--- a/packages/components/src/components/radio-button/radio-button.component.ts
+++ b/packages/components/src/components/radio-button/radio-button.component.ts
@@ -63,6 +63,9 @@ export default class SynRadioButton extends SynergyElement {
    */
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
 
+  /** Draws a pill-style radio button with rounded edges. */
+  @property({ type: Boolean, reflect: true }) pill = false;
+
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('role', 'presentation');
@@ -112,6 +115,7 @@ export default class SynRadioButton extends SynergyElement {
           aria-checked="${this.checked}"
           class=${classMap({
             button: true,
+            'button--default': true,
             'button--small': this.size === 'small',
             'button--medium': this.size === 'medium',
             'button--large': this.size === 'large',
@@ -119,6 +123,7 @@ export default class SynRadioButton extends SynergyElement {
             'button--disabled': this.disabled,
             'button--focused': this.hasFocus,
             'button--outline': true,
+            'button--pill': this.pill,
             'button--has-label': this.hasSlotController.test('[default]'),
             'button--has-prefix': this.hasSlotController.test('prefix'),
             'button--has-suffix': this.hasSlotController.test('suffix')

--- a/packages/docs/stories/components/button.stories.ts
+++ b/packages/docs/stories/components/button.stories.ts
@@ -142,6 +142,56 @@ export const SettingACustomWidth: Story = {
   <syn-button size="large" style="width: 100%;">Large</syn-button>`,
 };
 
+export const IconOnly: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: generateStoryDescription('button', 'icon-only'),
+      },
+    },
+  },
+  render: () => html`
+    <syn-button size="small" variant="filled">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+    <syn-button size="small">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+    <syn-button size="small" variant="text">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+
+    <br> 
+
+    <syn-button size="medium" variant="filled">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+    <syn-button size="medium">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+    <syn-button size="medium" variant="text">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+
+    <br> 
+
+    <syn-button size="large" variant="filled">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+    <syn-button size="large">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+    <syn-button size="large" variant="text">
+      <syn-icon name="settings"></syn-icon>
+    </syn-button>
+  <style>
+    syn-button {
+      margin: 10px 10px 0 0;
+    }
+  </style>
+  `,
+};
+
 export const PrefixAndSuffixIcons: Story = {
   parameters: {
     docs: {

--- a/packages/tokens/src/figma-tokens/_docs.json
+++ b/packages/tokens/src/figma-tokens/_docs.json
@@ -173,7 +173,7 @@
         "title": {
           "value": "Breadcrumb Item",
           "type": "text"
-        }  
+        }
       }
     },
     "breadcrumb": {
@@ -328,6 +328,16 @@
           "value": "The focus event gives the user feedback that the Button has been focused by the keyboard interaction and that the button component is ready for use.",
           "type": "text"
         }
+      },
+      "icon-only": {
+        "title": {
+          "value": "Icon-only",
+          "type": "text"
+        },
+        "description": {
+          "value": "Insert just a single icon to use the same button style.",
+          "type": "text"
+        }
       }
     },
     "button-group": {
@@ -349,7 +359,7 @@
         "title": {
           "value": "Card",
           "type": "text"
-        }  
+        }
       },
       "basic-card": {
         "description": {

--- a/packages/vue/src/components/SynVueRadioButton.vue
+++ b/packages/vue/src/components/SynVueRadioButton.vue
@@ -70,6 +70,11 @@ const props = defineProps<{
 this attribute can typically be omitted.
  */
   'size'?: SynRadioButton['size'];
+
+  /**
+* Draws a pill-style radio button with rounded edges.
+ */
+  'pill'?: SynRadioButton['pill'];
 }>();
 
 // Make sure prop binding only forwards the props that are actually there.


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!--
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This PR adds the possibility to use the button as icon-only button which is squared, if only an icon is used in the default slot.

### 🎫 Issues

<!--
* List and link relevant issues here.
-->
Closes #309 

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

When I vendored the button, I noticed, that until know we also always vendored the radio-button and the icon-button with the button.vendorism.js. Because we only checked for:
```js
if (path.endsWith('button.component.ts')) {
```
I fixed this, so they are no longer getting vendored with the button.vendorism. But because of that we got a change in the radio-button.components.ts.
I decided not to create a radio-button.vendorism.js because until know we do NOT officially ship the radio-button (it just came with the radio-group) and therefore other stuff is still not right in the radio-button. I would postpone this, until we officially add the radio-button as component.

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
- have a look at the new icon-only story: http://localhost:6006/?path=/story/components-syn-button--icon-only
- check that nothing else was broken with this changes

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
