### PR TITLE
fix: 🤔 syn-tab-group may throw an error when unmounted too quick

### DIFF
--- a/packages/components/scripts/vendorism/custom/tab-group.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/tab-group.vendorism.js
@@ -59,6 +59,16 @@ const transformComponent = (path, originalContent) => {
       'this.indicator.style.translate = `0 ${offset.top}px`;',
       "this.indicator.style.translate = `0 calc(${offset.top}px + ${ (this.contained || this.sharp) ? 'var(--syn-spacing-small)' : '0px' })`;",
     ],
+
+    // Make sure we don't unobserve an undefined element
+    // @todo: Remove when shoelace ships this fix
+    [
+      'this.resizeObserver.unobserve(this.nav);', `
+      if (this.nav) {
+      this.resizeObserver.unobserve(this.nav);
+    }
+    `.trim(),
+    ],
   ], originalContent);
 
   content = removeSections([

--- a/packages/components/src/components/tab-group/tab-group.component.ts
+++ b/packages/components/src/components/tab-group/tab-group.component.ts
@@ -136,7 +136,9 @@ export default class SynTabGroup extends SynergyElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.mutationObserver.disconnect();
-    this.resizeObserver.unobserve(this.nav);
+    if (this.nav) {
+      this.resizeObserver.unobserve(this.nav);
+    }
   }
 
   private getAllTabs(options: { includeDisabled: boolean } = { includeDisabled: true }) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a catch during unmount of the `<syn-tab-group>` that leads to errors when using the components in test environments.

```bash
Uncaught TypeError: Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element'. thrown 
```

<!--
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

Closes #511 

<!--
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
