### PR TITLE
fix: 🤔 Styles package uses fixed peerDependency for tokens

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -110,6 +110,6 @@
     "stylelint": "^16.5.0"
   },
   "peerDependencies": {
-    "@synergy-design-system/tokens": "workspace:*"
+    "@synergy-design-system/tokens": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,7 +764,7 @@ importers:
   packages/styles:
     dependencies:
       '@synergy-design-system/tokens':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tokens
     devDependencies:
       '@semantic-release/changelog':


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that `@synergy-design-system/styles` is not installable out of the box because of a wrong version specifier, as seen in this output:

```bash
npm info @synergy-design-system/styles peerDependencies
{ '@synergy-design-system/tokens': '2.2.0' }
```

The version of the tokens package is actually fixed until we push the package again. It should read `^2.2.0` instead of `2.2.0`.

### 🎫 Issues

Closes #539 

## 👩‍💻 Reviewer Notes

Nothing that much to do here, just check the change in `package.json`.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
