### PR TITLE
fix: 🤔 Typescript error on vue components with no properties

### DIFF
--- a/packages/vue/src/components/SynVueAccordion.vue
+++ b/packages/vue/src/components/SynVueAccordion.vue
@@ -56,10 +56,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueBadge.vue
+++ b/packages/vue/src/components/SynVueBadge.vue
@@ -45,10 +45,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueBreadcrumb.vue
+++ b/packages/vue/src/components/SynVueBreadcrumb.vue
@@ -50,10 +50,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueBreadcrumbItem.vue
+++ b/packages/vue/src/components/SynVueBreadcrumbItem.vue
@@ -68,10 +68,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueButtonGroup.vue
+++ b/packages/vue/src/components/SynVueButtonGroup.vue
@@ -47,10 +47,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueCard.vue
+++ b/packages/vue/src/components/SynVueCard.vue
@@ -59,10 +59,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueDivider.vue
+++ b/packages/vue/src/components/SynVueDivider.vue
@@ -45,10 +45,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueMenu.vue
+++ b/packages/vue/src/components/SynVueMenu.vue
@@ -27,21 +27,6 @@ defineExpose({
   nativeElement,
 });
 
-// Map attributes
-const props = defineProps<{
-
-}>();
-
-// Make sure prop binding only forwards the props that are actually there.
-// This is needed because :param="param" also adds an empty attribute
-// when using web-components, which breaks optional arguments like size in SynInput
-// @see https://github.com/vuejs/core/issues/5190#issuecomment-1003112498
-const visibleProps = computed(() => Object.fromEntries(
-  Object
-    .entries(props)
-    .filter(([, value]) => typeof value !== 'undefined'),
-));
-
 // Map events
 defineEmits<{
   /**
@@ -57,9 +42,8 @@ export type { SynSelectEvent } from '@synergy-design-system/components';
 
 <template>
   <syn-menu
-    v-bind="visibleProps"
-
     ref="nativeElement"
+
     @syn-select="$emit('syn-select', $event)"
   >
     <slot />

--- a/packages/vue/src/components/SynVueMenuItem.vue
+++ b/packages/vue/src/components/SynVueMenuItem.vue
@@ -83,10 +83,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueMenuLabel.vue
+++ b/packages/vue/src/components/SynVueMenuLabel.vue
@@ -33,31 +33,11 @@ defineExpose({
   nativeElement,
 });
 
-// Map attributes
-const props = defineProps<{
-
-}>();
-
-// Make sure prop binding only forwards the props that are actually there.
-// This is needed because :param="param" also adds an empty attribute
-// when using web-components, which breaks optional arguments like size in SynInput
-// @see https://github.com/vuejs/core/issues/5190#issuecomment-1003112498
-const visibleProps = computed(() => Object.fromEntries(
-  Object
-    .entries(props)
-    .filter(([, value]) => typeof value !== 'undefined'),
-));
-
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>
   <syn-menu-label
 
-    v-bind="visibleProps"
     ref="nativeElement"
   >
     <slot />

--- a/packages/vue/src/components/SynVueOptgroup.vue
+++ b/packages/vue/src/components/SynVueOptgroup.vue
@@ -63,10 +63,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueOption.vue
+++ b/packages/vue/src/components/SynVueOption.vue
@@ -63,10 +63,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVuePrioNav.vue
+++ b/packages/vue/src/components/SynVuePrioNav.vue
@@ -51,31 +51,11 @@ defineExpose({
   nativeElement,
 });
 
-// Map attributes
-const props = defineProps<{
-
-}>();
-
-// Make sure prop binding only forwards the props that are actually there.
-// This is needed because :param="param" also adds an empty attribute
-// when using web-components, which breaks optional arguments like size in SynInput
-// @see https://github.com/vuejs/core/issues/5190#issuecomment-1003112498
-const visibleProps = computed(() => Object.fromEntries(
-  Object
-    .entries(props)
-    .filter(([, value]) => typeof value !== 'undefined'),
-));
-
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>
   <syn-prio-nav
 
-    v-bind="visibleProps"
     ref="nativeElement"
   >
     <slot />

--- a/packages/vue/src/components/SynVueProgressBar.vue
+++ b/packages/vue/src/components/SynVueProgressBar.vue
@@ -63,10 +63,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueProgressRing.vue
+++ b/packages/vue/src/components/SynVueProgressRing.vue
@@ -58,10 +58,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>

--- a/packages/vue/src/components/SynVueSpinner.vue
+++ b/packages/vue/src/components/SynVueSpinner.vue
@@ -29,31 +29,11 @@ defineExpose({
   nativeElement,
 });
 
-// Map attributes
-const props = defineProps<{
-
-}>();
-
-// Make sure prop binding only forwards the props that are actually there.
-// This is needed because :param="param" also adds an empty attribute
-// when using web-components, which breaks optional arguments like size in SynInput
-// @see https://github.com/vuejs/core/issues/5190#issuecomment-1003112498
-const visibleProps = computed(() => Object.fromEntries(
-  Object
-    .entries(props)
-    .filter(([, value]) => typeof value !== 'undefined'),
-));
-
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>
   <syn-spinner
 
-    v-bind="visibleProps"
     ref="nativeElement"
   />
 </template>

--- a/packages/vue/src/components/SynVueTabPanel.vue
+++ b/packages/vue/src/components/SynVueTabPanel.vue
@@ -52,10 +52,6 @@ const visibleProps = computed(() => Object.fromEntries(
     .filter(([, value]) => typeof value !== 'undefined'),
 ));
 
-// Map events
-defineEmits<{
-
-}>();
 </script>
 
 <template>


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR solves an issue that may arise when using `@synergy-design-system/vue` in Typescript projects. Some of our components [do not have any props](https://github.com/synergy-design-system/synergy-design-system/blob/main/packages/vue/src/components/SynVueMenuLabel.vue#L37), but are still defining the empty object via vues `defineProps` helper. This leads to an TS-Error.

On a sidenote, as we are now aware of this problem, we will provide some sanity checks via our e2e toolchain by implementing #555 in another PR.

### 🎫 Issues

Closes #554.

<!--
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

Basically, just have a look at the provided changeset. Start the local environment on this branch and include `SynVueSpinner` to our demo. It should not show errors.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
