### PR TITLE
docs: 📘 Click listeners bleed implementation details to the outside

### DIFF
--- a/packages/_private/react-demo/src/Layout.tsx
+++ b/packages/_private/react-demo/src/Layout.tsx
@@ -6,17 +6,14 @@ import {
 import {
   type FC,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
-import type { SynSideNav as SynSideNavType } from '@synergy-design-system/components';
 import { RouterLink } from './RouterLink';
 import { ThemeSwitch } from './ThemeSwitch';
 
 export const Layout: FC = () => {
   const location = useLocation();
-  const sideNavRef = useRef<SynSideNavType>(null);
   const [currentNavigationPath, setCurrentNavigationPath] = useState('/');
 
   useEffect(() => {
@@ -32,7 +29,7 @@ export const Layout: FC = () => {
         </div>
       </SynHeader>
       <div className="main">
-        <SynSideNav rail ref={sideNavRef}>
+        <SynSideNav rail>
           <RouterLink href="/" current={currentNavigationPath === '/'}>
             Home
             <SynIcon name="home" slot="prefix" />

--- a/packages/_private/vanilla-demo/src/main.ts
+++ b/packages/_private/vanilla-demo/src/main.ts
@@ -60,9 +60,10 @@ const initRouting = async () => {
       e.preventDefault();
       e.stopPropagation();
 
-      if ((e.target as HTMLElement).tagName.toLowerCase() === 'syn-nav-item') {
-        const target = e.target as SynNavItem;
-        history.push(history.createHref(target.href));
+      const clickedNavItem = (e.target as HTMLElement).closest('syn-nav-item') as SynNavItem;
+
+      if (clickedNavItem) {
+        history.push(history.createHref(clickedNavItem.href));
       }
     });
   });


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an Issue when clicking a `syn-nav-item` in our vanilla demo.

### 🎫 Issues

Fixes #528 

## 👩‍💻 Reviewer Notes

Just smaller fixes for our vanilla demo. Makes icons clickable.

## 📑 Test Plan

Spin up our local vanilla demo and check if you are able to click one of the icons in the `syn-side-nav`.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
