### PR TITLE
fix: 🤔 syn-side-nav and syn-details may throw an error when unmounted too quick

### DIFF
--- a/packages/components/scripts/vendorism/replace-section.js
+++ b/packages/components/scripts/vendorism/replace-section.js
@@ -89,7 +89,7 @@ export const addSectionBefore = (content, search, insert, options = {}) => {
   }
 
   if (tabsAfterInsertion > 0) {
-    output += new Array(tabsAfterInsertion).fill('\t').join('');
+    output += new Array(tabsAfterInsertion).fill('  ').join('');
   }
 
   return content.slice(0, index) + output + content.slice(index);

--- a/packages/components/scripts/vendorism/replace-section.js
+++ b/packages/components/scripts/vendorism/replace-section.js
@@ -44,7 +44,7 @@ export const addSectionAfter = (content, search, insert, options = {}) => {
   }
 
   if (tabsBeforeInsertion > 0) {
-    additions += new Array(tabsBeforeInsertion).fill('\t').join('');
+    additions += new Array(tabsBeforeInsertion).fill('  ').join('');
   }
 
   output = additions + output;

--- a/packages/components/src/components/details/details.component.ts
+++ b/packages/components/src/components/details/details.component.ts
@@ -76,10 +76,10 @@ export default class SynDetails extends SynergyElement {
   /** Disables the details so it can't be toggled. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
-  /** Draws the details as contained element. */
+	/** Draws the details as contained element. */
   @property({ type: Boolean, reflect: true }) contained = false;
 
-  /** The details's size. */
+	/** The details's size. */
   @property({ reflect: true }) size: 'medium' | 'large' = 'medium';
 
   firstUpdated() {
@@ -104,7 +104,7 @@ export default class SynDetails extends SynergyElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.detailsObserver.disconnect();
+    this.detailsObserver?.disconnect();
   }
 
   private handleSummaryClick(event: MouseEvent) {
@@ -207,11 +207,11 @@ export default class SynDetails extends SynergyElement {
         part="base"
         class=${classMap({
           details: true,
-          'details--size-medium': this.size === 'medium',
+					'details--size-medium': this.size === 'medium',
           'details--size-large': this.size === 'large',
           'details--open': this.open,
           'details--disabled': this.disabled,
-          'details--contained': this.contained,
+					'details--contained': this.contained,
         })}
       >
         <summary

--- a/packages/components/src/components/details/details.component.ts
+++ b/packages/components/src/components/details/details.component.ts
@@ -76,10 +76,10 @@ export default class SynDetails extends SynergyElement {
   /** Disables the details so it can't be toggled. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
-	/** Draws the details as contained element. */
+  /** Draws the details as contained element. */
   @property({ type: Boolean, reflect: true }) contained = false;
 
-	/** The details's size. */
+  /** The details's size. */
   @property({ reflect: true }) size: 'medium' | 'large' = 'medium';
 
   firstUpdated() {
@@ -207,11 +207,11 @@ export default class SynDetails extends SynergyElement {
         part="base"
         class=${classMap({
           details: true,
-					'details--size-medium': this.size === 'medium',
+          'details--size-medium': this.size === 'medium',
           'details--size-large': this.size === 'large',
           'details--open': this.open,
           'details--disabled': this.disabled,
-					'details--contained': this.contained,
+          'details--contained': this.contained,
         })}
       >
         <summary

--- a/packages/components/src/components/side-nav/side-nav.component.ts
+++ b/packages/components/src/components/side-nav/side-nav.component.ts
@@ -310,8 +310,10 @@ export default class SynSideNav extends SynergyElement {
     super.disconnectedCallback();
 
     //  Remove modal listeners
-    unlockBodyScrolling(this.drawer);
-    this.drawer.modal.deactivate();
+    if (this.drawer) {
+      unlockBodyScrolling(this.drawer);
+      this.drawer.modal.deactivate();
+    }
   }
 
   render() {

--- a/packages/components/src/components/tab-group/tab-group.component.ts
+++ b/packages/components/src/components/tab-group/tab-group.component.ts
@@ -81,7 +81,7 @@ export default class SynTabGroup extends SynergyElement {
   /** Disables the scroll arrows that appear when tabs overflow. */
   @property({ attribute: 'no-scroll-controls', type: Boolean }) noScrollControls = false;
 
-	/** Draws the tab group as a contained element. */
+  /** Draws the tab group as a contained element. */
   @property({ type: Boolean }) contained = false;
   
   /** Draws the tab group with edges instead of roundings. Takes only effect if used with the 'contained' property */


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR prevents two errors that may appear when removing the <syn-details /> or the <syn-side-nav/>  too fast from the DOM. This may especially happen in test frameworks (e.g. vitest), where the current behaviour leads to errors if using those both components.

### 🎫 Issues
Closes #556 

## 👩‍💻 Reviewer Notes

I also improved / rewrote the details.vendorism.js in this PR.

## 📑 Test Plan

Can be tested with this vue test repo: https://github.com/kirchsuSICKAG/vue-test
To make the errors appear change the vitests environment from 'happy-dom' to 'jsdom'

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
