### PR TITLE
fix: 🐛 Wrong font weight for text content in button

### DIFF
--- a/packages/components/src/components/button/button.custom.styles.ts
+++ b/packages/components/src/components/button/button.custom.styles.ts
@@ -1,6 +1,10 @@
 import { css } from 'lit';
 
 export default css`
+  .button {
+    font-weight: var(--syn-font-weight-bold);
+  }
+
   .button:focus-visible {
     outline: var(--syn-focus-ring-color) solid var(--syn-focus-ring-width);
     outline-offset: var(--syn-focus-ring-width);


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes the `font-weight` of `<syn-button>` (should be bold instead of semi-bold).

### 🎫 Issues

Closes #571 

## 👩‍💻 Reviewer Notes

This is a really small fix, but may lead to various layout shifts in different components (see Chromatic for results).

## 📑 Test Plan

- Have a look at the changed code
- Check Chromatic for side effects.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
