### PR TITLE
fix: 🐛 syn-prio-nav: priority menu position is always calculated from the absolute left of the document

### DIFF
--- a/packages/components/src/components/prio-nav/prio-nav.component.ts
+++ b/packages/components/src/components/prio-nav/prio-nav.component.ts
@@ -122,12 +122,14 @@ export default class SynPrioNav extends SynergyElement {
    * @param items The items to cache the position for
    */
   private cacheItemPositions(items: SynNavItem[]) {
+    const { left } = this.horizontalNav.getBoundingClientRect();
     items.forEach(item => {
       // We have to measure while the items are in the primary slot,
       // else we will just get the placement in the priority menu
       item.removeAttribute('slot');
       const { right } = item.getBoundingClientRect();
-      item.dataset.right = right.toString();
+      // We also need to consider the location of the parent
+      item.dataset.right = (right - left).toString();
     });
 
     this.itemPositionsCached = true;

--- a/packages/components/src/components/prio-nav/prio-nav.test.ts
+++ b/packages/components/src/components/prio-nav/prio-nav.test.ts
@@ -72,17 +72,19 @@ describe('<syn-prio-nav>', () => {
      * Create a fixture for our horizontal nav
      * Note we are forcing a fixed width of the items
      * to make sure they are available in all test environments
+     * Without flex-shrink: 0, the items will shrink to fit the container,
+     * rendering most of the tests pointless
      * @param width The width to use
      * @returns A horizontal nav fixture
      */
-    const createFixture = async (width = 800) => fixture<SynPrioNav>(html`
-      <syn-prio-nav style="width: ${width}px;">
-        <syn-nav-item horizontal style="width: 100px">Item 1</syn-nav-item>
-        <syn-nav-item horizontal style="width: 100px">Item 2</syn-nav-item>
-        <syn-nav-item horizontal style="width: 100px">Item 3</syn-nav-item>
-        <syn-nav-item horizontal style="width: 100px">Item 4</syn-nav-item>
-        <syn-nav-item horizontal style="width: 100px" id="button-item" role="button">Item 5</syn-nav-item>
-        <syn-nav-item horizontal style="width: 100px">Item 6</syn-nav-item>
+    const createFixture = async (width = 800, marginLeft = 0) => fixture<SynPrioNav>(html`
+      <syn-prio-nav style="width: ${width}px; margin-left: ${marginLeft}px;">
+        <syn-nav-item horizontal style="width: 100px; flex-shrink: 0;">Item 1</syn-nav-item>
+        <syn-nav-item horizontal style="width: 100px; flex-shrink: 0;">Item 2</syn-nav-item>
+        <syn-nav-item horizontal style="width: 100px; flex-shrink: 0;">Item 3</syn-nav-item>
+        <syn-nav-item horizontal style="width: 100px; flex-shrink: 0;">Item 4</syn-nav-item>
+        <syn-nav-item horizontal style="width: 100px; flex-shrink: 0;" id="button-item" role="button">Item 5</syn-nav-item>
+        <syn-nav-item horizontal style="width: 100px; flex-shrink: 0;">Item 6</syn-nav-item>
       </syn-prio-nav>
     `);
 
@@ -119,7 +121,7 @@ describe('<syn-prio-nav>', () => {
     });
 
     it('should move the items to the "menu" slot and change their role to "menuitem" if there is not enough space', async () => {
-      const nav = await createFixture(100);
+      const nav = await createFixture(150);
       const [itemsInDefaultSlot, itemsInPrioritySlot] = getSlottedChildrenAsTuple(nav);
 
       expect(itemsInDefaultSlot).to.have.length(1);
@@ -177,6 +179,16 @@ describe('<syn-prio-nav>', () => {
       const buttonItemAfterResizeBack = getButtonItem(nav);
       expect(buttonItemAfterResizeBack, 'The button item should be back the default slot and exist').to.exist;
       expect(buttonItemAfterResizeBack, 'The button item should have its original role of "button"').to.have.attribute('role', 'button');
+    });
+
+    it("should work if there's a margin on the priority menu", async () => {
+      // Adding this margin should not affect the tests
+      const nav = await createFixture(800, 300);
+
+      const [itemsInDefaultSlot, itemsInPrioritySlot] = getSlottedChildrenAsTuple(nav);
+
+      expect(itemsInDefaultSlot).to.have.length(6);
+      expect(itemsInPrioritySlot).to.be.empty;
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This fixes an issue that is very clear if the syn-prio-nav is not on the left edge of the viewport, where it will start displaying the dropdown menu a lot earlier than is needed.

It also makes sure to not take into account the size of the dropdown button unless the dropdown button is actually shown.

Also slightly related, the cache should probably be purged if the size of the elements change, but I'll perhaps tackle that at another point.

### 🎫 Issues

Closes #639 

## 👩‍💻 Reviewer Notes

This seems like it'd be quite easy to create a test for. Can someone point me in the right direction where to add such a test?

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
