### PR TITLE
fix: 🐛 Various issues with syn-prio-nav

### DIFF
--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -5,6 +5,7 @@ import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import SynDivider from '../divider/divider.component.js';
 import { HasSlotController } from '../../internal/slot.js';
+import { watch } from '../../internal/watch.js';
 import SynergyElement from '../../internal/synergy-element.js';
 import componentStyles from '../../styles/component.styles.js';
 import styles from './nav-item.styles.js';
@@ -263,10 +264,23 @@ export default class SynNavItem extends SynergyElement {
     });
   }
 
+  // Make sure the resize observer is disconnected when the horizontal property is set to true
+  // In this case we, never want it to use prefix only mode
+  @watch('horizontal', { waitUntilFirstUpdate: true })
+  handleHorizontalChange() {
+    if (this.horizontal) {
+      this.resizeObserver.disconnect();
+    } else {
+      this.resizeObserver.observe(this);
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.resizeObserver = new ResizeObserver((entries) => this.handleWidth(entries));
-    this.resizeObserver.observe(this);
+    if (!this.horizontal) {
+      this.resizeObserver.observe(this);
+    }
   }
 
   firstUpdated(_changedProperties: PropertyValues) {

--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -1,5 +1,5 @@
 import { classMap } from 'lit/directives/class-map.js';
-import type { CSSResultGroup } from 'lit';
+import type { CSSResultGroup, PropertyValues } from 'lit';
 import { html, literal } from 'lit/static-html.js';
 import { property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -8,7 +8,6 @@ import { HasSlotController } from '../../internal/slot.js';
 import SynergyElement from '../../internal/synergy-element.js';
 import componentStyles from '../../styles/component.styles.js';
 import styles from './nav-item.styles.js';
-import { watch } from '../../internal/watch.js';
 
 /**
  * @summary Flexible button / link component that can be used to quickly build navigations.
@@ -65,6 +64,8 @@ export default class SynNavItem extends SynergyElement {
   private readonly hasSlotController = new HasSlotController(this, '[default]', 'children', 'prefix', 'suffix');
 
   private resizeObserver: ResizeObserver;
+
+  private mutationObserver: MutationObserver;
 
   /**
    * The current focus state
@@ -177,12 +178,9 @@ export default class SynNavItem extends SynergyElement {
     const sideNav = this.closest('syn-side-nav');
 
     if (!this.open || !!sideNav?.rail) {
-      const navItemChildren = this.getAllNestedNavItems(this.childrenSlot);
-
-      const currentMarkedItem = navItemChildren
-        .findIndex((item) => !!item.shadowRoot?.querySelector('.nav-item--current'));
-
-      this.currentMarkedChild = currentMarkedItem !== -1;
+      this.currentMarkedChild = this
+        .getAllNestedNavItems(this.childrenSlot)
+        .some(item => item.current);
     }
   }
 
@@ -265,20 +263,31 @@ export default class SynNavItem extends SynergyElement {
     });
   }
 
-  @watch('open')
-  handleOpenChange() {
-    this.handleCurrentMarkedChild();
-  }
-
   connectedCallback() {
     super.connectedCallback();
     this.resizeObserver = new ResizeObserver((entries) => this.handleWidth(entries));
     this.resizeObserver.observe(this);
   }
 
+  firstUpdated(_changedProperties: PropertyValues) {
+    super.firstUpdated(_changedProperties);
+    this.mutationObserver = new MutationObserver(() => {
+      if (this.childrenSlot) {
+        this.handleCurrentMarkedChild();
+      }
+    });
+
+    this.mutationObserver.observe(this, {
+      attributeFilter: ['current', 'open'],
+      childList: true,
+      subtree: true,
+    });
+  }
+
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.resizeObserver.disconnect();
+    this.resizeObserver?.disconnect();
+    this.mutationObserver?.disconnect();
   }
 
   /**

--- a/packages/components/src/components/nav-item/nav-item.styles.ts
+++ b/packages/components/src/components/nav-item/nav-item.styles.ts
@@ -36,13 +36,14 @@ export default css`
    * Core nav item wrapper
    */
   .nav-item {
+    align-items: center;
     background: transparent;
     border: none;
     box-shadow: inset 0 -1px 0 0 transparent;
     box-sizing: border-box;
     color: var(--syn-color-neutral-950);
     cursor: pointer;
-    display: inline-block;
+    display: inline-flex;
     font: var(--syn-font-sans);
     font-size: var(--syn-font-size-small);
     min-height: var(--syn-spacing-2x-large);

--- a/packages/components/src/components/nav-item/nav-item.styles.ts
+++ b/packages/components/src/components/nav-item/nav-item.styles.ts
@@ -192,9 +192,9 @@ export default css`
    * Show prefix only
    */
   /* stylelint-disable no-descending-specificity */
-  :host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__content-container,
-  :host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__suffix,
-  :host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__chevron {
+  .nav-item--show-prefix-only .nav-item__content-container,
+  .nav-item--show-prefix-only .nav-item__suffix,
+  .nav-item--show-prefix-only .nav-item__chevron {
     height: var(--syn-spacing-large);
   }
   /* stylelint-enable no-descending-specificity */
@@ -203,13 +203,13 @@ export default css`
    * Adjust the paddings for the label, depending if there is a pre- and/or suffix available.
    * But only if the there is a main content or additionally a prefix / suffix
    */
-  :host(:not([horizontal])) .nav-item--has-prefix.nav-item--has-content .nav-item__content-container,
-  :host(:not([horizontal])) .nav-item--has-prefix.nav-item--has-suffix .nav-item__content-container {
+  .nav-item--has-prefix.nav-item--has-content .nav-item__content-container,
+  .nav-item--has-prefix.nav-item--has-suffix .nav-item__content-container {
     margin-inline-start: var(--syn-spacing-x-small);
   }
 
-  :host(:not([horizontal])) .nav-item--has-suffix.nav-item--has-content .nav-item__content-container,
-  :host(:not([horizontal])) .nav-item--has-suffix.nav-item--has-prefix .nav-item__content-container {
+  .nav-item--has-suffix.nav-item--has-content .nav-item__content-container,
+  .nav-item--has-suffix.nav-item--has-prefix .nav-item__content-container {
     margin-inline-end: var(--syn-spacing-x-small);
   }
 

--- a/packages/components/src/components/nav-item/nav-item.styles.ts
+++ b/packages/components/src/components/nav-item/nav-item.styles.ts
@@ -192,9 +192,9 @@ export default css`
    * Show prefix only
    */
   /* stylelint-disable no-descending-specificity */
-  .nav-item--show-prefix-only .nav-item__content-container,
-  .nav-item--show-prefix-only .nav-item__suffix,
-  .nav-item--show-prefix-only .nav-item__chevron {
+  :host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__content-container,
+  :host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__suffix,
+  :host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__chevron {
     height: var(--syn-spacing-large);
   }
   /* stylelint-enable no-descending-specificity */
@@ -203,13 +203,13 @@ export default css`
    * Adjust the paddings for the label, depending if there is a pre- and/or suffix available.
    * But only if the there is a main content or additionally a prefix / suffix
    */
-  .nav-item--has-prefix.nav-item--has-content .nav-item__content-container,
-  .nav-item--has-prefix.nav-item--has-suffix .nav-item__content-container {
+  :host(:not([horizontal])) .nav-item--has-prefix.nav-item--has-content .nav-item__content-container,
+  :host(:not([horizontal])) .nav-item--has-prefix.nav-item--has-suffix .nav-item__content-container {
     margin-inline-start: var(--syn-spacing-x-small);
   }
 
-  .nav-item--has-suffix.nav-item--has-content .nav-item__content-container,
-  .nav-item--has-suffix.nav-item--has-prefix .nav-item__content-container {
+  :host(:not([horizontal])) .nav-item--has-suffix.nav-item--has-content .nav-item__content-container,
+  :host(:not([horizontal])) .nav-item--has-suffix.nav-item--has-prefix .nav-item__content-container {
     margin-inline-end: var(--syn-spacing-x-small);
   }
 

--- a/packages/components/src/components/nav-item/nav-item.test.ts
+++ b/packages/components/src/components/nav-item/nav-item.test.ts
@@ -241,7 +241,6 @@ describe('<syn-nav-item>', () => {
     expect(base).to.not.have.class('nav-item--show-prefix-only');
   });
 
-
   it('should display current indicator on root nav-item if it has a current marked child and is not open', async () => {
     const el = await fixture<SynNavItem>(html`
       <syn-nav-item>

--- a/packages/components/src/components/nav-item/nav-item.test.ts
+++ b/packages/components/src/components/nav-item/nav-item.test.ts
@@ -184,7 +184,7 @@ describe('<syn-nav-item>', () => {
     });
   });
 
-  it('should show prefix only if there is not enough space', async () => {
+  it('should show prefix only if there is not enough space and horizontal is not set', async () => {
     const el = await fixture<SynNavItem>(html`
       <syn-nav-item>
         Label
@@ -201,6 +201,46 @@ describe('<syn-nav-item>', () => {
 
     expect(base).to.have.class('nav-item--show-prefix-only');
   });
+
+  it('should show prefix only if there is not enough space and horizontal is toggled from false to true', async () => {
+    const el = await fixture<SynNavItem>(html`
+      <syn-nav-item horizontal>
+        Label
+        <span slot="prefix">
+          prefix
+        </span>
+      </syn-nav-item>
+    `);
+
+    el.style.width = '80px';
+    const base = el.shadowRoot!.querySelector('.nav-item') as HTMLElement;
+
+    expect(base).to.not.have.class('nav-item--show-prefix-only');
+
+    el.horizontal = false;
+    await el.updateComplete;
+
+    // We need to wait because of the resize observer
+    await waitUntil(() => base.classList.contains('nav-item--show-prefix-only'));
+
+    expect(base).to.have.class('nav-item--show-prefix-only');
+  });
+
+  it('should not show prefix only if horizontal is set', async () => {
+    const el = await fixture<SynNavItem>(html`
+      <syn-nav-item horizontal>
+        Label
+        <span slot="prefix">
+          prefix
+        </span>
+      </syn-nav-item>`);
+
+    el.style.width = '80px';
+    const base = el.shadowRoot!.querySelector('.nav-item') as HTMLElement;
+
+    expect(base).to.not.have.class('nav-item--show-prefix-only');
+  });
+
 
   it('should display current indicator on root nav-item if it has a current marked child and is not open', async () => {
     const el = await fixture<SynNavItem>(html`

--- a/packages/components/src/components/prio-nav/prio-nav.component.ts
+++ b/packages/components/src/components/prio-nav/prio-nav.component.ts
@@ -14,6 +14,8 @@ import { LocalizeController } from '../../utilities/localize.js';
 import {
   filterOnlyNavItems,
   getAssignedElementsForSlot,
+  hideNavigationItem,
+  showNavigationItem,
 } from './utils.js';
 
 /**
@@ -154,44 +156,38 @@ export default class SynPrioNav extends SynergyElement {
     // Cache the first item
     let firstHiddenItemRightPos: number | undefined;
 
-    let visibleItems = 0;
+    const itemVisibilities = navItems.map(item => {
+      const isHidden = !!(firstHiddenItemRightPos || parseFloat(item.dataset.right!) >= finalWidth);
 
-    // Save the position of all the elements in a cache
-    navItems.forEach(item => {
-      // Make sure to use the cache obtained in createGhostItems
-      const isHidden = firstHiddenItemRightPos || parseFloat(item.dataset.right!) >= finalWidth;
+      // Get the position of the first item
+      // Will get used to position the priority menu
+      if (isHidden && !firstHiddenItemRightPos) {
+        firstHiddenItemRightPos = parseFloat(item.dataset.right!);
+      }
 
-      if (isHidden) {
-        item.removeAttribute('horizontal');
-        item.setAttribute('slot', 'menu');
+      return {
+        isHidden,
+        item,
+      };
+    });
 
-        // Makes sure the item is focusable in a syn-dropdown
-        item.setAttribute('role', 'menuitem');
+    const visibleItems = itemVisibilities.filter(({ isHidden }) => !isHidden).length;
+    const hasOnlyOneItem = visibleItems === 1;
 
-        // Get the position of the first item
-        // Will get used to position the priority menu
-        if (!firstHiddenItemRightPos) {
-          firstHiddenItemRightPos = parseFloat(item.dataset.right!);
-        }
+    // Finally, hide or show the items based on the visibility
+    // As requested in #410, we hide all items if there is only one item
+    itemVisibilities.forEach(({ item, isHidden }) => {
+      if (isHidden || hasOnlyOneItem) {
+        hideNavigationItem(item);
       } else {
-        visibleItems += 1;
-        item.setAttribute('horizontal', 'true');
-        item.removeAttribute('slot');
-        item.removeAttribute('tabindex');
-
-        // Reset the role to the original value
-        if (item.dataset.originalRole) {
-          item.setAttribute('role', item.dataset.originalRole);
-        } else {
-          item.removeAttribute('role');
-        }
+        showNavigationItem(item);
       }
     });
 
     // Tell the render call that we have items in the priority menu
     // and toggle the visibility of the priority menu label
     this.hasItemsInDropdown = visibleItems !== navItems.length;
-    this.amountOfVisibleItems = visibleItems;
+    this.amountOfVisibleItems = hasOnlyOneItem ? 0 : visibleItems;
   }
 
   private renderPriorityMenu() {

--- a/packages/components/src/components/prio-nav/utils.ts
+++ b/packages/components/src/components/prio-nav/utils.ts
@@ -26,3 +26,32 @@ export const isNavItem = (item: HTMLElement): item is SynNavItem => (
  * @returns New array of all found syn-nav-items
  */
 export const filterOnlyNavItems = (items: HTMLElement[]) => items.filter(isNavItem);
+
+/**
+ * Show a navigation item
+ * @param item The item to show
+ */
+export const showNavigationItem = (item: SynNavItem) => {
+  item.setAttribute('horizontal', 'true');
+  item.removeAttribute('slot');
+  item.removeAttribute('tabindex');
+
+  // Reset the role to the original value
+  if (item.dataset.originalRole) {
+    item.setAttribute('role', item.dataset.originalRole);
+  } else {
+    item.removeAttribute('role');
+  }
+};
+
+/**
+ * Hide a navigation item
+ * @param item The item to hide
+ */
+export const hideNavigationItem = (item: SynNavItem) => {
+  item.removeAttribute('horizontal');
+  item.setAttribute('slot', 'menu');
+
+  // Makes sure the item is focusable in a syn-dropdown
+  item.setAttribute('role', 'menuitem');
+};

--- a/packages/docs/stories/components/nav-item.stories.ts
+++ b/packages/docs/stories/components/nav-item.stories.ts
@@ -173,7 +173,7 @@ export const ChildrenClosedOrOpenVerticalOnly: Story = {
       <syn-nav-item open >
         Children open
         <nav slot="children">
-          <syn-nav-item>Item 1</syn-nav-item>
+          <syn-nav-item href="javascript:void(0)">Item 1</syn-nav-item>
           <syn-nav-item>Item 2</syn-nav-item>
         </nav>
       </syn-nav-item>

--- a/packages/docs/stories/components/prio-nav.stories.ts
+++ b/packages/docs/stories/components/prio-nav.stories.ts
@@ -26,7 +26,7 @@ const meta: Meta = {
       value: `
         <syn-nav-item current horizontal>Domains</syn-nav-item>
         <syn-nav-item horizontal>Projects</syn-nav-item>
-        <syn-nav-item horizontal>Trainings</syn-nav-item>
+        <syn-nav-item horizontal href="javascript:void(0)">Trainings</syn-nav-item>
       `,
     },
   ], defaultArgs),

--- a/packages/docs/stories/components/prio-nav.stories.ts
+++ b/packages/docs/stories/components/prio-nav.stories.ts
@@ -75,12 +75,12 @@ export const PriorityMenu = {
     <div style="display: flex; flex-direction: column; gap: var(--syn-spacing-2x-large)">
       <syn-prio-nav style="width: 250px;">
         <syn-nav-item current horizontal>Domains</syn-nav-item>
-        <syn-nav-item horizontal>Projects</syn-nav-item>
+        <syn-nav-item horizontal href="javascript:void(0)">Projects</syn-nav-item>
         <syn-nav-item horizontal>Trainings</syn-nav-item>
       </syn-prio-nav>
-      <syn-prio-nav style="width: 100px;">
+      <syn-prio-nav style="width: 170px;">
         <syn-nav-item current horizontal>Domains</syn-nav-item>
-        <syn-nav-item horizontal>Projects</syn-nav-item>
+        <syn-nav-item horizontal href="javascript:void(0)">Projects</syn-nav-item>
         <syn-nav-item horizontal>Trainings</syn-nav-item>
       </syn-prio-nav>
     </div>
@@ -99,14 +99,14 @@ export const PriorityMenu = {
 //     },
 //   },
 //   render: () => html`
-//     <syn-prio-nav id="demo-ding">
+//     <syn-prio-nav id="demo-ding" style="width: 120px">
 //       <syn-nav-item current horizontal>Domains</syn-nav-item>
 //       <syn-nav-item horizontal>Projects</syn-nav-item>
 //       <syn-nav-item horizontal>Trainings</syn-nav-item>
 //       <syn-nav-item horizontal>Item 1</syn-nav-item>
 //       <syn-nav-item horizontal>Item 2</syn-nav-item>
 //       <syn-nav-item horizontal>Item 3</syn-nav-item>
-//       <syn-menu-item href="#" role="menuitem">Hello</syn-menu-item>
+//       <syn-menu-item href="#" role="menuitem" horizontal>Hello</syn-menu-item>
 //       <syn-nav-item horizontal>Item 4</syn-nav-item>
 //     </syn-prio-nav>
 //     <syn-button>Add an Item</syn-button>

--- a/packages/docs/stories/components/prio-nav.stories.ts
+++ b/packages/docs/stories/components/prio-nav.stories.ts
@@ -99,7 +99,7 @@ export const PriorityMenu = {
 //     },
 //   },
 //   render: () => html`
-//     <syn-prio-nav id="demo-ding" style="width: 120px">
+//     <syn-prio-nav id="demo-ding">
 //       <syn-nav-item current horizontal>Domains</syn-nav-item>
 //       <syn-nav-item horizontal>Projects</syn-nav-item>
 //       <syn-nav-item horizontal>Trainings</syn-nav-item>

--- a/packages/tokens/src/figma-tokens/_docs.json
+++ b/packages/tokens/src/figma-tokens/_docs.json
@@ -1115,7 +1115,7 @@
       },
       "priority-menu": {
         "description": {
-          "value": "If there is not enough space, elements will move into a dropdown.",
+          "value": "If there is not enough space, elements will move into a dropdown. If there is only space for  one item, it will display the priority menu only.",
           "type": "text"
         },
         "title": {


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR acts as an umbrella for various tickets related to the `<syn-prio-nav>` and `<syn-nav-item>` components.

### 🎫 Issues

Closes #644 
Closes #582
Closes #631
Closes #410
Closes #409
Closes #630 
Closes #639

## 👩‍💻 Reviewer Notes

This PR is used to add multiple fixes to our navigation items. It is easier to review those tickets in one scope, so we created an umbrella ticket housing all changes.

## 📑 Test Plan

The following list of steps describes all issues and their related tests:

### Issue #631

Before: https://codepen.io/schilchSICKAG/pen/LYwGraY?editors=1110
After: http://localhost:6006/?path=/docs/components-syn-prio-nav--docs

tl;dr: When using a href attribute, the alignment must now always fit in horizontal mode. The default story of `<syn-prio-nav>` was adjusted to include a `<syn-nav-item>` with a href attribute to check this also in visual integration.

---

### Issue #410

When displaying a `<syn-prio-nav>` where only one item would be visible, this item is now also hidden. Play around with the priority-menu story for this to test.

Open question: I have currently the marker internally in the method:

```typescript
private handlePriorityMenu() {
  // code
  const visibleItems = itemVisibilities.filter(({ isHidden }) => !isHidden).length;
  const hasOnlyOneItem = visibleItems === 1;
  // even more code :(
}
```

It would be possible to let users control this behavior if we would use an attribute for this (e.g. something like `<syn-prio-nav items-before-menu-visible="2"></syn-prio-nav>`. Anyone seeing any value in this?

---

### Issue #409

~~The fix was archived by making sure to apply the styling only if the `<syn-nav-item>` is not in horizontal mode (e.g. `.nav-item--show-prefix-only .nav-item__content-container` became `:host(:not([horizontal])) .nav-item--show-prefix-only .nav-item__content-container`.~~

**Note**: We could also have adjusted the code to make sure the `handleWidth` is only called when the `horizontal` attribute is set. From a code perspective, this would have various advantages, like calling the listener only when NOT in horizontal mode. If wanted, we could do this easily, too by adding a `@watch` decorator to the `horizontal` and pausing / starting the `ResizeObserver` if it is true. Let´s discuss this. The current solution is working fine either way.

> We have opted to use the code centric above. The resizeObserver is now paused when the `horizontal` prop is detected (or in case of mounting the component, not even started when it is set).

---

### Issue #582 

Before: https://synergy-design-system.github.io/?path=/docs/components-syn-side-nav--docs#indentation
After: http://localhost:6006/?path=/docs/components-syn-side-nav--docs#indentation

This issue was hard to fix because we do not have information about the structure of a navigation. The only thing we really know are the children of a given `<syn-nav-item>`. I have now opted to remove the original `@watch` decorator for the open property as there is no way to trigger this correctly when the user clicks another item. However, what CAN be done is listening for changes to the `open` and `current` props, together with a `MutationObserver`. With this, it will happily apply the changes. There are some minor performance problems on this (e.g. the change list will also include all sub-parts), but I think this is a minor problem and did not lead to bigger performance issues.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
