### PR TITLE
fix: 🐛 syn-tab-group may throw an error when unmounted too quick

### DIFF
--- a/packages/components/scripts/vendorism/custom/tab-group.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/tab-group.vendorism.js
@@ -63,9 +63,9 @@ const transformComponent = (path, originalContent) => {
     // Make sure we don't unobserve an undefined element
     // @todo: Remove when shoelace ships this fix
     [
-      'this.resizeObserver.unobserve(this.nav);', `
+      'this.resizeObserver?.unobserve(this.nav);', `
       if (this.nav) {
-      this.resizeObserver.unobserve(this.nav);
+      this.resizeObserver?.unobserve(this.nav);
     }
     `.trim(),
     ],

--- a/packages/components/src/components/tab-group/tab-group.component.ts
+++ b/packages/components/src/components/tab-group/tab-group.component.ts
@@ -145,7 +145,9 @@ export default class SynTabGroup extends SynergyElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.mutationObserver?.disconnect();
-    this.resizeObserver?.unobserve(this.nav);
+    if (this.nav) {
+      this.resizeObserver?.unobserve(this.nav);
+    }
   }
 
   private getAllTabs() {

--- a/packages/components/src/components/tab-group/tab-group.custom.test.ts
+++ b/packages/components/src/components/tab-group/tab-group.custom.test.ts
@@ -4,6 +4,15 @@ import { expect, fixture, html } from '@open-wc/testing';
 import type SynTabGroup from './tab-group.js';
 
 describe('<syn-tab-group>', () => {
+  it('should not throw error when unmounted too fast', async () => {
+    const el = await fixture(html`
+      <div></div>
+    `);
+
+    el.innerHTML = '<syn-tab-group></syn-tab-group>';
+    el.innerHTML = '';
+  });
+
   describe('when sharp is provided', () => {
     it('should not add the className "tab-group--sharp" when sharp is set to "false"', async () => {
       const el = await fixture<SynTabGroup>(html`


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR prevents an error that may appear when removing the syn-tab-group too fast from the DOM. This may especially happen in test frameworks (e.g. vitest, karma), where the current behaviour leads to errors if using those component

### 🎫 Issues
Closes #652 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
