### PR TITLE
docs: 📚  some codepen assets are not loaded

### DIFF
--- a/packages/docs/stories/components/card.stories.ts
+++ b/packages/docs/stories/components/card.stories.ts
@@ -64,7 +64,7 @@ const meta: Meta = {
     {
       name: 'image',
       type: 'slot',
-      value: '<img slot="image" src="/card-example.jpg" alt="Multiple persons having lunch in SICK Academy" />',
+      value: '<img slot="image" src="https://synergy-design-system.github.io/card-example.jpg" alt="Multiple persons having lunch in SICK Academy" />',
     },
     {
       name: 'default',
@@ -205,7 +205,7 @@ export const Images: Story = {
   },
   render: () => html`
     <syn-card class="card-image">
-      <img slot="image" src="/card-example.jpg" alt="Multiple persons having lunch in SICK Academy" />
+      <img slot="image" src="https://synergy-design-system.github.io/card-example.jpg" alt="Multiple persons having lunch in SICK Academy" />
       This are some happy employees, but not just any employees. These are SICK employees.
     </syn-card>
 
@@ -227,7 +227,7 @@ export const SharpCard: Story = {
   },
   render: () => html`
     <syn-card class="sharp-card" sharp>
-      <img slot="image" src="/card-example.jpg" alt="Multiple persons having lunch in SICK Academy" />
+      <img slot="image" src="https://synergy-design-system.github.io/card-example.jpg" alt="Multiple persons having lunch in SICK Academy" />
       This are some happy employees, but not just any employees. These are SICK employees.
     </syn-card>
 

--- a/packages/docs/stories/components/icon-default-icons.stories.ts
+++ b/packages/docs/stories/components/icon-default-icons.stories.ts
@@ -3,6 +3,7 @@
 import '../../../components/src/components/icon/icon.js';
 import { type Meta, type StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import { registerIconLibrary } from '../../../components/src/utilities/icon-library.js';
 import { defaultIcons } from '../../../assets/src/default-icons.js';
 
 const meta: Meta = {
@@ -15,12 +16,22 @@ type Story = StoryObj;
 
 const createIconPage = (letter: string): Story => ({
   render: () => {
+    registerIconLibrary('bundled-default', {
+      mutator: svg => svg.setAttribute('fill', 'currentColor'),
+      resolver: (name) => {
+        if (name in defaultIcons) {
+          const defaultName = name as keyof typeof defaultIcons;
+          return `data:image/svg+xml,${encodeURIComponent(defaultIcons[defaultName])}`;
+        }
+        return '';
+      },
+    });
     const regex = new RegExp(`^${letter}`);
     const iconKeys = Object.keys(defaultIcons);
     const iconContainer = iconKeys.filter((key) => key.match(regex)).map((key) => (html`
       <div style="display: flex; flex-direction: column; align-items: center; cursor: pointer"  >
         <span style="font-size: var(--syn-font-size-x-small)">${key}</span>
-        <syn-icon style="font-size: var(--syn-font-size-2x-large)" name="${key}"></syn-icon>
+        <syn-icon style="font-size: var(--syn-font-size-2x-large)" name="${key}" library="bundled-default"></syn-icon>
       </div>
       `));
     return html`<div 

--- a/packages/docs/stories/templates/table.stories.tsx
+++ b/packages/docs/stories/templates/table.stories.tsx
@@ -87,7 +87,7 @@ const createBodyRowProduct = () => html`
       <div class="product-cell">
         <img
           class="product-image"
-          src="/card-example.jpg"
+          src="https://synergy-design-system.github.io/card-example.jpg"
           alt="Multiple persons having lunch in SICK Academy"
         />
         <div>


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR uses absolute paths to .jpg images used in stories and templates, so they are also available for codepen.

Additionally the loading of the default icons (https://synergy-design-system.github.io/?path=/docs/components-syn-icon-default-icons--docs) is improved via using the bundled icons as source for the syn-icon's. 
Previously not all icons where loaded initially , when going to the default icons page. And there were also a lot of error logs in the console because of too many fetch requests. See following image:

![image](https://github.com/user-attachments/assets/a16f43f2-1a5c-4f24-8092-936c0ab4950d)


### 🎫 Issues
Closes #580 

## 👩‍💻 Reviewer Notes

- let it run locally and have a look at this page: http://localhost:6006/?path=/docs/components-syn-icon-default-icons--docs
 all icons should have loaded directly (even the ones starting with `z`) and there should no longer be error logs in the console, which say: 
![image](https://github.com/user-attachments/assets/0fb8edb2-8982-40dc-8ca7-bcfaf7af728f)

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
