### PR TITLE
fix: 🐛 Add default entry for default export for better tooling compatibility

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,7 +14,11 @@
   "exports": {
     ".": {
       "types": "./dist/synergy.d.ts",
-      "import": "./dist/synergy.js"
+      "import": "./dist/synergy.js",
+      "default": "./dist/synergy.js"
+    },
+    "./package.json": {
+      "default": "./package.json"
     },
     "./custom-elements.json": "./dist/custom-elements.json",
     "./synergy.js": "./dist/synergy.js",


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a `default` fallback entry to our `@synergy-design-system/components` `package.json` file that allows the better usage of tooling and a graceful fallback for bundlers that do not understand esm syntax.

It also adds the `package.json` field to the export list so it is easy to use, for example for dynamically requiring it and obtaining the information.

### 🎫 Issues

Closes #594

## 👩‍💻 Reviewer Notes

Just have a look at the changed `package.json`. Create a new local version of the components package and check if it works with vite + webpack.

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
