### PR TITLE
fix: 🐛 syn-alert's left border does not reach the edge anymore

### DIFF
--- a/packages/components/scripts/vendorism/custom/alert.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/alert.vendorism.js
@@ -19,6 +19,9 @@ const transformStyles = (path, originalContent) => {
       preserveEnd: true,
       removePrecedingWhitespace: false,
     }],
+    // Remove the overflow:hidden, which came with shoelace 2.17.0,
+    // as we do not use the countdown feature and it breaks the left border style
+    ['overflow: hidden;', ''],
   ], originalContent);
 
   return {

--- a/packages/components/src/components/alert/alert.styles.ts
+++ b/packages/components/src/components/alert/alert.styles.ts
@@ -31,7 +31,6 @@ export default css`
     line-height: 1.6;
     color: var(--syn-color-neutral-700);
     margin: inherit;
-    overflow: hidden;
   }
 
   .alert:not(.alert--has-icon) .alert__icon,
@@ -55,7 +54,6 @@ export default css`
     flex: 1 1 auto;
     display: block;
     padding: var(--syn-spacing-large);
-    overflow: hidden;
   }
 
   .alert__close-button {


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes the problem, that the left border of the syn-alert no longer reaches the edges since the update to shoelace 2.17.0
This is done via removing the `overflow:hidden` as we haven't added the new `countdown` feature and therefore don't need the `overflow: hidden`

### 🎫 Issues

Closes #675 

## 👩‍💻 Reviewer Notes

Check that the left border of the syn-alert reaches the edges again

## 📑 Test Plan

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
