### PR TITLE
feat: ✨ DX: Angular should allow using boolean attributes without square brackets in templates

### DIFF
--- a/packages/_private/angular-demo/src/app.component.html
+++ b/packages/_private/angular-demo/src/app.component.html
@@ -13,16 +13,16 @@
 </syn-header>
 
 <div class="main">
-  <syn-side-nav [rail]="true">
+  <syn-side-nav rail>
     <syn-nav-item routerLink="/" routerLinkActive [routerLinkActiveOptions]="{exact: true}">
       Home
       <syn-icon name="home" slot="prefix"></syn-icon>
     </syn-nav-item>
-    <syn-nav-item [divider]="true" routerLink="/contact-form" routerLinkActive [routerLinkActiveOptions]="{exact: true}">
+    <syn-nav-item divider routerLink="/contact-form" routerLinkActive [routerLinkActiveOptions]="{exact: true}">
       Contact Form
       <syn-icon name="contact_mail" slot="prefix"></syn-icon>
     </syn-nav-item>
-    <syn-nav-item [divider]="true" routerLink="/contact-form-validate" routerLinkActive [routerLinkActiveOptions]="{exact: true}">
+    <syn-nav-item divider routerLink="/contact-form-validate" routerLinkActive [routerLinkActiveOptions]="{exact: true}">
       Contact Form (Validation)
       <syn-icon name="contact_emergency" slot="prefix"></syn-icon>
     </syn-nav-item>

--- a/packages/_private/angular-demo/src/demoform/demoform.component.html
+++ b/packages/_private/angular-demo/src/demoform/demoform.component.html
@@ -15,7 +15,7 @@
       id="radiogroup-gender"
       name="gender"
       label="Please tell us your gender"
-      [required]="true"
+      required
     >
       <syn-radio value="f">Female</syn-radio>
       <syn-radio value="m">Male</syn-radio>
@@ -27,7 +27,7 @@
       id="select-role"
       label="Current position"
       name="role"
-      [required]="true"
+      required
     >
       <syn-optgroup label="Developers">
         <syn-option value="backend">Backend Developer</syn-option>
@@ -47,7 +47,7 @@
       [maxlength]="20"
       name="name"
       placeholder="Please insert a value for the regular text input (between 5 and 20 Characters)"
-      [required]="true"
+      required
       type="text"
     />
 
@@ -57,7 +57,7 @@
       label="E-Mail"
       name="email"
       placeholder="Please insert your E-mail address"
-      [required]="true"
+      required
       type="email"
     />
 
@@ -67,7 +67,7 @@
       label="Phone"
       name="phone"
       placeholder="Please provide your phone number"
-      [required]="true"
+      required
       type="tel"
     />
 
@@ -84,7 +84,7 @@
       id="input-nationality"
       label="Nationality"
       name="nationality"
-      [required]="true"
+      required
       [getOption]="highlightOptionRenderer"
     >
       <syn-option *ngFor="let nationality of nationalities">{{nationality}}</syn-option>
@@ -105,7 +105,6 @@
       password-toggle
       pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}"
       placeholder="Please provide at least one uppercase and lowercase letter and a number"
-      [required]="true"
       type="password"
     />
 
@@ -127,11 +126,11 @@
   <!-- Topics -->
   <demo-fieldset legend="Topics">
     <syn-select
-      [clearable]="true"
+      clearable
       formControlName="topics"
       id="topics"
       label="I am interested in the following technologies"
-      [multiple]="true"
+      multiple
       name="topics"
     >
       <syn-optgroup label="Frontend">
@@ -247,12 +246,12 @@
     />
     <syn-file
       accept="image/*"
-      [droparea]="true"
+      droparea
       formControlName="files"
       help-text="Please upload images only"
       id="screenshot"
       label="Optional Screenshot(s)"
-      [multiple]="true"
+      multiple
       name="files"
     />
   </demo-fieldset>

--- a/packages/_private/angular-demo/src/demoformvalidate/demoformvalidate.component.html
+++ b/packages/_private/angular-demo/src/demoformvalidate/demoformvalidate.component.html
@@ -16,7 +16,7 @@
         id="radiogroup-gender"
         name="gender"
         label="Please tell us your gender"
-        [required]="true"
+        required
       >
         <syn-radio value="">invalid</syn-radio>
         <syn-radio value="f">Female</syn-radio>
@@ -31,7 +31,7 @@
         id="select-role"
         label="Current position"
         name="role"
-        [required]="true"
+        required
       >
         <syn-option value="">---</syn-option>
         <syn-optgroup label="Developers">
@@ -54,7 +54,7 @@
         [maxlength]="20"
         name="name"
         placeholder="Please insert a value for the regular text input (between 5 and 20 Characters)"
-        [required]="true"
+        required
         type="text"
       />
     </syn-validate>
@@ -70,7 +70,7 @@
         label="E-Mail"
         name="email"
         placeholder="Please insert your E-mail address"
-        [required]="true"
+        required
         type="email"
       />
     </syn-validate>
@@ -91,7 +91,7 @@
         id="input-nationality"
         label="Nationality"
         name="nationality"
-        [required]="true"
+        required
         [getOption]="highlightOptionRenderer"
       >
         <syn-option *ngFor="let nationality of nationalities">{{nationality}}</syn-option>
@@ -114,7 +114,7 @@
         password-toggle
         pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}"
         placeholder="Please provide at least one uppercase and lowercase letter and a number"
-        [required]="true"
+        required
         type="password"
       />
     </syn-validate>
@@ -177,7 +177,7 @@
         formControlName="newsletterStandard"
         id="checkbox-newsletter-default"
         name="newsletterStandard"
-        [required]="true"
+        required
       >
         Please subscribe me to the synergy newsletter
       </syn-checkbox>
@@ -187,7 +187,7 @@
         formControlName="newsletterBeta"
         id="checkbox-newsletter-beta"
         name="newsletterBeta"
-        [required]="true"
+        required
       >
         I am interested in the Synergy Beta Program
       </syn-switch>
@@ -206,19 +206,19 @@
         label="Comment"
         name="comment"
         placeholder="Please provide additional information that might be helpful for your inquiry"
-        [required]="true"
+        required
         [rows]="10"
       />
     </syn-validate>
     <syn-validate variant="inline" on="live">
       <syn-file
         accept="image/*"
-        [droparea]="true"
+        droparea
         formControlName="files"
         help-text="Please upload images only"
         id="screenshot"
         label="Optional Screenshot(s)"
-        [multiple]="true"
+        multiple
         name="files"
       />
     </syn-validate>

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -253,7 +253,7 @@ You will then be able to use the provided wrappers in the following way:
   name="test"
   [title]="myLabel"
   type="text"
-  [required]="true"
+  required
 >
   <span slot="label"> {{myLabel}} </span>
 </syn-input>

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -139,7 +139,7 @@ The following two code examples show, how different attributes look like for web
 <syn-input
   label="Nickname"
   helpText="What would you like people to call you?"
-  [required]="true"
+  required
 ></syn-input>
 ```
 

--- a/packages/angular/src/components/accordion.component.ts
+++ b/packages/angular/src/components/accordion.component.ts
@@ -44,10 +44,12 @@ export class SynAccordionComponent {
    * Indicates whether or not multiple `<syn-detail>` elements can be open at the same time.
    */
   @Input()
-  set closeOthers(v: SynAccordion['closeOthers']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.closeOthers = v));
+  set closeOthers(v: '' | SynAccordion['closeOthers']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.closeOthers = v === '' || v),
+    );
   }
-  get closeOthers() {
+  get closeOthers(): SynAccordion['closeOthers'] {
     return this.nativeElement.closeOthers;
   }
 
@@ -55,10 +57,12 @@ export class SynAccordionComponent {
    * Draws the accordion and the slotted `<syn-details>` as contained elements.
    */
   @Input()
-  set contained(v: SynAccordion['contained']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.contained = v));
+  set contained(v: '' | SynAccordion['contained']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.contained = v === '' || v),
+    );
   }
-  get contained() {
+  get contained(): SynAccordion['contained'] {
     return this.nativeElement.contained;
   }
 
@@ -69,7 +73,7 @@ export class SynAccordionComponent {
   set size(v: SynAccordion['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynAccordion['size'] {
     return this.nativeElement.size;
   }
 }

--- a/packages/angular/src/components/alert.component.ts
+++ b/packages/angular/src/components/alert.component.ts
@@ -81,10 +81,12 @@ export class SynAlertComponent {
 use the `show()` and `hide()` methods and this attribute will reflect the alert's open state.
  */
   @Input()
-  set open(v: SynAlert['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynAlert['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynAlert['open'] {
     return this.nativeElement.open;
   }
 
@@ -92,10 +94,12 @@ use the `show()` and `hide()` methods and this attribute will reflect the alert'
    * Enables a close button that allows the user to dismiss the alert.
    */
   @Input()
-  set closable(v: SynAlert['closable']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.closable = v));
+  set closable(v: '' | SynAlert['closable']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.closable = v === '' || v),
+    );
   }
-  get closable() {
+  get closable(): SynAlert['closable'] {
     return this.nativeElement.closable;
   }
 
@@ -106,7 +110,7 @@ use the `show()` and `hide()` methods and this attribute will reflect the alert'
   set variant(v: SynAlert['variant']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.variant = v));
   }
-  get variant() {
+  get variant(): SynAlert['variant'] {
     return this.nativeElement.variant;
   }
 
@@ -122,7 +126,7 @@ the alert will not close on its own.
   set duration(v: SynAlert['duration']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.duration = v));
   }
-  get duration() {
+  get duration(): SynAlert['duration'] {
     return this.nativeElement.duration;
   }
 

--- a/packages/angular/src/components/badge.component.ts
+++ b/packages/angular/src/components/badge.component.ts
@@ -46,7 +46,7 @@ export class SynBadgeComponent {
   set variant(v: SynBadge['variant']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.variant = v));
   }
-  get variant() {
+  get variant(): SynBadge['variant'] {
     return this.nativeElement.variant;
   }
 }

--- a/packages/angular/src/components/breadcrumb-item.component.ts
+++ b/packages/angular/src/components/breadcrumb-item.component.ts
@@ -57,7 +57,7 @@ internally.
   set href(v: SynBreadcrumbItem['href']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.href = v));
   }
-  get href() {
+  get href(): SynBreadcrumbItem['href'] {
     return this.nativeElement.href;
   }
 
@@ -69,7 +69,7 @@ internally.
   set target(v: SynBreadcrumbItem['target']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.target = v));
   }
-  get target() {
+  get target(): SynBreadcrumbItem['target'] {
     return this.nativeElement.target;
   }
 
@@ -81,7 +81,7 @@ internally.
   set rel(v: SynBreadcrumbItem['rel']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.rel = v));
   }
-  get rel() {
+  get rel(): SynBreadcrumbItem['rel'] {
     return this.nativeElement.rel;
   }
 }

--- a/packages/angular/src/components/breadcrumb.component.ts
+++ b/packages/angular/src/components/breadcrumb.component.ts
@@ -51,7 +51,7 @@ screen readers and other assistive devices to provide more context for users.
   set label(v: SynBreadcrumb['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynBreadcrumb['label'] {
     return this.nativeElement.label;
   }
 }

--- a/packages/angular/src/components/button-group.component.ts
+++ b/packages/angular/src/components/button-group.component.ts
@@ -48,7 +48,7 @@ devices when interacting with the control and is strongly recommended.
   set label(v: SynButtonGroup['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynButtonGroup['label'] {
     return this.nativeElement.label;
   }
 }

--- a/packages/angular/src/components/button.component.ts
+++ b/packages/angular/src/components/button.component.ts
@@ -68,7 +68,7 @@ export class SynButtonComponent {
   set title(v: SynButton['title']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.title = v));
   }
-  get title() {
+  get title(): SynButton['title'] {
     return this.nativeElement.title;
   }
 
@@ -79,7 +79,7 @@ export class SynButtonComponent {
   set variant(v: SynButton['variant']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.variant = v));
   }
-  get variant() {
+  get variant(): SynButton['variant'] {
     return this.nativeElement.variant;
   }
 
@@ -90,7 +90,7 @@ export class SynButtonComponent {
   set size(v: SynButton['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynButton['size'] {
     return this.nativeElement.size;
   }
 
@@ -99,10 +99,12 @@ export class SynButtonComponent {
    * Used to indicate that the button triggers a dropdown menu or similar behavior.
    */
   @Input()
-  set caret(v: SynButton['caret']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.caret = v));
+  set caret(v: '' | SynButton['caret']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.caret = v === '' || v),
+    );
   }
-  get caret() {
+  get caret(): SynButton['caret'] {
     return this.nativeElement.caret;
   }
 
@@ -110,10 +112,12 @@ export class SynButtonComponent {
    * Disables the button.
    */
   @Input()
-  set disabled(v: SynButton['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynButton['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynButton['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -121,10 +125,12 @@ export class SynButtonComponent {
    * Draws the button in a loading state.
    */
   @Input()
-  set loading(v: SynButton['loading']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.loading = v));
+  set loading(v: '' | SynButton['loading']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.loading = v === '' || v),
+    );
   }
-  get loading() {
+  get loading(): SynButton['loading'] {
     return this.nativeElement.loading;
   }
 
@@ -138,7 +144,7 @@ export class SynButtonComponent {
   set type(v: SynButton['type']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.type = v));
   }
-  get type() {
+  get type(): SynButton['type'] {
     return this.nativeElement.type;
   }
 
@@ -150,7 +156,7 @@ This attribute is ignored when `href` is present.
   set name(v: SynButton['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynButton['name'] {
     return this.nativeElement.name;
   }
 
@@ -163,7 +169,7 @@ button is the submitter.
   set value(v: SynButton['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynButton['value'] {
     return this.nativeElement.value;
   }
 
@@ -174,7 +180,7 @@ button is the submitter.
   set href(v: SynButton['href']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.href = v));
   }
-  get href() {
+  get href(): SynButton['href'] {
     return this.nativeElement.href;
   }
 
@@ -186,7 +192,7 @@ button is the submitter.
   set target(v: SynButton['target']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.target = v));
   }
-  get target() {
+  get target(): SynButton['target'] {
     return this.nativeElement.target;
   }
 
@@ -203,7 +209,7 @@ setting the attribute to an empty string or a value of your choice, respectively
   set rel(v: SynButton['rel']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.rel = v));
   }
-  get rel() {
+  get rel(): SynButton['rel'] {
     return this.nativeElement.rel;
   }
 
@@ -215,7 +221,7 @@ setting the attribute to an empty string or a value of your choice, respectively
   set download(v: SynButton['download']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.download = v));
   }
-  get download() {
+  get download(): SynButton['download'] {
     return this.nativeElement.download;
   }
 
@@ -229,7 +235,7 @@ value of this attribute must be an id of a form in the same document or shadow r
   set form(v: SynButton['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynButton['form'] {
     return this.nativeElement.form;
   }
 
@@ -240,7 +246,7 @@ value of this attribute must be an id of a form in the same document or shadow r
   set formAction(v: SynButton['formAction']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.formAction = v));
   }
-  get formAction() {
+  get formAction(): SynButton['formAction'] {
     return this.nativeElement.formAction;
   }
 
@@ -251,7 +257,7 @@ value of this attribute must be an id of a form in the same document or shadow r
   set formEnctype(v: SynButton['formEnctype']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.formEnctype = v));
   }
-  get formEnctype() {
+  get formEnctype(): SynButton['formEnctype'] {
     return this.nativeElement.formEnctype;
   }
 
@@ -262,7 +268,7 @@ value of this attribute must be an id of a form in the same document or shadow r
   set formMethod(v: SynButton['formMethod']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.formMethod = v));
   }
-  get formMethod() {
+  get formMethod(): SynButton['formMethod'] {
     return this.nativeElement.formMethod;
   }
 
@@ -270,12 +276,12 @@ value of this attribute must be an id of a form in the same document or shadow r
    * Used to override the form owner's `novalidate` attribute.
    */
   @Input()
-  set formNoValidate(v: SynButton['formNoValidate']) {
+  set formNoValidate(v: '' | SynButton['formNoValidate']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.formNoValidate = v),
+      () => (this.nativeElement.formNoValidate = v === '' || v),
     );
   }
-  get formNoValidate() {
+  get formNoValidate(): SynButton['formNoValidate'] {
     return this.nativeElement.formNoValidate;
   }
 
@@ -286,7 +292,7 @@ value of this attribute must be an id of a form in the same document or shadow r
   set formTarget(v: SynButton['formTarget']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.formTarget = v));
   }
-  get formTarget() {
+  get formTarget(): SynButton['formTarget'] {
     return this.nativeElement.formTarget;
   }
 

--- a/packages/angular/src/components/card.component.ts
+++ b/packages/angular/src/components/card.component.ts
@@ -57,10 +57,12 @@ export class SynCardComponent {
    * when nesting multiple syn-cards to create hierarchy.
    */
   @Input()
-  set sharp(v: SynCard['sharp']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.sharp = v));
+  set sharp(v: '' | SynCard['sharp']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.sharp = v === '' || v),
+    );
   }
-  get sharp() {
+  get sharp(): SynCard['sharp'] {
     return this.nativeElement.sharp;
   }
 }

--- a/packages/angular/src/components/checkbox.component.ts
+++ b/packages/angular/src/components/checkbox.component.ts
@@ -79,7 +79,7 @@ export class SynCheckboxComponent {
   set title(v: SynCheckbox['title']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.title = v));
   }
-  get title() {
+  get title(): SynCheckbox['title'] {
     return this.nativeElement.title;
   }
 
@@ -90,7 +90,7 @@ export class SynCheckboxComponent {
   set name(v: SynCheckbox['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynCheckbox['name'] {
     return this.nativeElement.name;
   }
 
@@ -101,7 +101,7 @@ export class SynCheckboxComponent {
   set value(v: SynCheckbox['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynCheckbox['value'] {
     return this.nativeElement.value;
   }
 
@@ -112,7 +112,7 @@ export class SynCheckboxComponent {
   set size(v: SynCheckbox['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynCheckbox['size'] {
     return this.nativeElement.size;
   }
 
@@ -120,10 +120,12 @@ export class SynCheckboxComponent {
    * Disables the checkbox.
    */
   @Input()
-  set disabled(v: SynCheckbox['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynCheckbox['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynCheckbox['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -131,10 +133,12 @@ export class SynCheckboxComponent {
    * Draws the checkbox in a checked state.
    */
   @Input()
-  set checked(v: SynCheckbox['checked']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.checked = v));
+  set checked(v: '' | SynCheckbox['checked']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.checked = v === '' || v),
+    );
   }
-  get checked() {
+  get checked(): SynCheckbox['checked'] {
     return this.nativeElement.checked;
   }
 
@@ -144,12 +148,12 @@ export class SynCheckboxComponent {
 all/none" behavior when associated checkboxes have a mix of checked and unchecked states.
  */
   @Input()
-  set indeterminate(v: SynCheckbox['indeterminate']) {
+  set indeterminate(v: '' | SynCheckbox['indeterminate']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.indeterminate = v),
+      () => (this.nativeElement.indeterminate = v === '' || v),
     );
   }
-  get indeterminate() {
+  get indeterminate(): SynCheckbox['indeterminate'] {
     return this.nativeElement.indeterminate;
   }
 
@@ -164,7 +168,7 @@ the same document or shadow root for this to work.
   set form(v: SynCheckbox['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynCheckbox['form'] {
     return this.nativeElement.form;
   }
 
@@ -172,10 +176,12 @@ the same document or shadow root for this to work.
    * Makes the checkbox a required field.
    */
   @Input()
-  set required(v: SynCheckbox['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynCheckbox['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynCheckbox['required'] {
     return this.nativeElement.required;
   }
 
@@ -187,7 +193,7 @@ the same document or shadow root for this to work.
   set helpText(v: SynCheckbox['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynCheckbox['helpText'] {
     return this.nativeElement.helpText;
   }
 

--- a/packages/angular/src/components/combobox.component.ts
+++ b/packages/angular/src/components/combobox.component.ts
@@ -136,7 +136,7 @@ export class SynComboboxComponent {
   set name(v: SynCombobox['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynCombobox['name'] {
     return this.nativeElement.name;
   }
 
@@ -147,7 +147,7 @@ export class SynComboboxComponent {
   set value(v: SynCombobox['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynCombobox['value'] {
     return this.nativeElement.value;
   }
 
@@ -158,7 +158,7 @@ export class SynComboboxComponent {
   set size(v: SynCombobox['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynCombobox['size'] {
     return this.nativeElement.size;
   }
 
@@ -169,7 +169,7 @@ export class SynComboboxComponent {
   set placeholder(v: SynCombobox['placeholder']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placeholder = v));
   }
-  get placeholder() {
+  get placeholder(): SynCombobox['placeholder'] {
     return this.nativeElement.placeholder;
   }
 
@@ -177,10 +177,12 @@ export class SynComboboxComponent {
    * Disables the combobox control.
    */
   @Input()
-  set disabled(v: SynCombobox['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynCombobox['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynCombobox['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -188,10 +190,12 @@ export class SynComboboxComponent {
    * Adds a clear button when the combobox is not empty.
    */
   @Input()
-  set clearable(v: SynCombobox['clearable']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.clearable = v));
+  set clearable(v: '' | SynCombobox['clearable']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.clearable = v === '' || v),
+    );
   }
-  get clearable() {
+  get clearable(): SynCombobox['clearable'] {
     return this.nativeElement.clearable;
   }
 
@@ -201,10 +205,12 @@ You can toggle this attribute to show and hide the listbox, or you can use the `
 and `hide()` methods and this attribute will reflect the combobox's open state.
  */
   @Input()
-  set open(v: SynCombobox['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynCombobox['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynCombobox['open'] {
     return this.nativeElement.open;
   }
 
@@ -214,10 +220,12 @@ when the component is placed inside a container with `overflow: auto|scroll`.
 Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios.
  */
   @Input()
-  set hoist(v: SynCombobox['hoist']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hoist = v));
+  set hoist(v: '' | SynCombobox['hoist']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hoist = v === '' || v),
+    );
   }
-  get hoist() {
+  get hoist(): SynCombobox['hoist'] {
     return this.nativeElement.hoist;
   }
 
@@ -229,7 +237,7 @@ Hoisting uses a fixed positioning strategy that works in many, but not all, scen
   set label(v: SynCombobox['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynCombobox['label'] {
     return this.nativeElement.label;
   }
 
@@ -241,7 +249,7 @@ Note that the actual placement may vary as needed to keep the listbox inside of 
   set placement(v: SynCombobox['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynCombobox['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -253,7 +261,7 @@ Note that the actual placement may vary as needed to keep the listbox inside of 
   set helpText(v: SynCombobox['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynCombobox['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -267,7 +275,7 @@ The form must be in the same document or shadow root for this to work.
   set form(v: SynCombobox['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynCombobox['form'] {
     return this.nativeElement.form;
   }
 
@@ -275,10 +283,12 @@ The form must be in the same document or shadow root for this to work.
    * The combobox's required attribute.
    */
   @Input()
-  set required(v: SynCombobox['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynCombobox['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynCombobox['required'] {
     return this.nativeElement.required;
   }
 
@@ -294,7 +304,7 @@ If the query string should be highlighted use the `highlightOptionRenderer` func
   set getOption(v: SynCombobox['getOption']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.getOption = v));
   }
-  get getOption() {
+  get getOption(): SynCombobox['getOption'] {
     return this.nativeElement.getOption;
   }
 
@@ -306,7 +316,7 @@ The default filter method is a case- and diacritic-insensitive string comparison
   set filter(v: SynCombobox['filter']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.filter = v));
   }
-  get filter() {
+  get filter(): SynCombobox['filter'] {
     return this.nativeElement.filter;
   }
 

--- a/packages/angular/src/components/details.component.ts
+++ b/packages/angular/src/components/details.component.ts
@@ -83,10 +83,12 @@ export class SynDetailsComponent {
 can use the `show()` and `hide()` methods and this attribute will reflect the details' open state.
  */
   @Input()
-  set open(v: SynDetails['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynDetails['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynDetails['open'] {
     return this.nativeElement.open;
   }
 
@@ -98,7 +100,7 @@ can use the `show()` and `hide()` methods and this attribute will reflect the de
   set summary(v: SynDetails['summary']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.summary = v));
   }
-  get summary() {
+  get summary(): SynDetails['summary'] {
     return this.nativeElement.summary;
   }
 
@@ -106,10 +108,12 @@ can use the `show()` and `hide()` methods and this attribute will reflect the de
    * Disables the details so it can't be toggled.
    */
   @Input()
-  set disabled(v: SynDetails['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynDetails['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynDetails['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -117,10 +121,12 @@ can use the `show()` and `hide()` methods and this attribute will reflect the de
    * Draws the details as contained element.
    */
   @Input()
-  set contained(v: SynDetails['contained']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.contained = v));
+  set contained(v: '' | SynDetails['contained']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.contained = v === '' || v),
+    );
   }
-  get contained() {
+  get contained(): SynDetails['contained'] {
     return this.nativeElement.contained;
   }
 
@@ -131,7 +137,7 @@ can use the `show()` and `hide()` methods and this attribute will reflect the de
   set size(v: SynDetails['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynDetails['size'] {
     return this.nativeElement.size;
   }
 

--- a/packages/angular/src/components/dialog.component.ts
+++ b/packages/angular/src/components/dialog.component.ts
@@ -120,10 +120,12 @@ export class SynDialogComponent {
 use the `show()` and `hide()` methods and this attribute will reflect the dialog's open state.
  */
   @Input()
-  set open(v: SynDialog['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynDialog['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynDialog['open'] {
     return this.nativeElement.open;
   }
 
@@ -137,7 +139,7 @@ use the `show()` and `hide()` methods and this attribute will reflect the dialog
   set label(v: SynDialog['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynDialog['label'] {
     return this.nativeElement.label;
   }
 
@@ -147,10 +149,12 @@ use the `show()` and `hide()` methods and this attribute will reflect the dialog
 accessible way for users to dismiss the dialog.
  */
   @Input()
-  set noHeader(v: SynDialog['noHeader']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.noHeader = v));
+  set noHeader(v: '' | SynDialog['noHeader']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.noHeader = v === '' || v),
+    );
   }
-  get noHeader() {
+  get noHeader(): SynDialog['noHeader'] {
     return this.nativeElement.noHeader;
   }
 

--- a/packages/angular/src/components/divider.component.ts
+++ b/packages/angular/src/components/divider.component.ts
@@ -43,10 +43,12 @@ export class SynDividerComponent {
    * Draws the divider in a vertical orientation.
    */
   @Input()
-  set vertical(v: SynDivider['vertical']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.vertical = v));
+  set vertical(v: '' | SynDivider['vertical']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.vertical = v === '' || v),
+    );
   }
-  get vertical() {
+  get vertical(): SynDivider['vertical'] {
     return this.nativeElement.vertical;
   }
 }

--- a/packages/angular/src/components/drawer.component.ts
+++ b/packages/angular/src/components/drawer.component.ts
@@ -127,10 +127,12 @@ export class SynDrawerComponent {
 use the `show()` and `hide()` methods and this attribute will reflect the drawer's open state.
  */
   @Input()
-  set open(v: SynDrawer['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynDrawer['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynDrawer['open'] {
     return this.nativeElement.open;
   }
 
@@ -144,7 +146,7 @@ use the `show()` and `hide()` methods and this attribute will reflect the drawer
   set label(v: SynDrawer['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynDrawer['label'] {
     return this.nativeElement.label;
   }
 
@@ -155,7 +157,7 @@ use the `show()` and `hide()` methods and this attribute will reflect the drawer
   set placement(v: SynDrawer['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynDrawer['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -165,10 +167,12 @@ use the `show()` and `hide()` methods and this attribute will reflect the drawer
 its parent element, set this attribute and add `position: relative` to the parent.
  */
   @Input()
-  set contained(v: SynDrawer['contained']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.contained = v));
+  set contained(v: '' | SynDrawer['contained']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.contained = v === '' || v),
+    );
   }
-  get contained() {
+  get contained(): SynDrawer['contained'] {
     return this.nativeElement.contained;
   }
 
@@ -178,10 +182,12 @@ its parent element, set this attribute and add `position: relative` to the paren
 accessible way for users to dismiss the drawer.
  */
   @Input()
-  set noHeader(v: SynDrawer['noHeader']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.noHeader = v));
+  set noHeader(v: '' | SynDrawer['noHeader']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.noHeader = v === '' || v),
+    );
   }
-  get noHeader() {
+  get noHeader(): SynDrawer['noHeader'] {
     return this.nativeElement.noHeader;
   }
 

--- a/packages/angular/src/components/dropdown.component.ts
+++ b/packages/angular/src/components/dropdown.component.ts
@@ -80,10 +80,12 @@ export class SynDropdownComponent {
 can use the `show()` and `hide()` methods and this attribute will reflect the dropdown's open state.
  */
   @Input()
-  set open(v: SynDropdown['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynDropdown['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynDropdown['open'] {
     return this.nativeElement.open;
   }
 
@@ -96,7 +98,7 @@ inside of the viewport.
   set placement(v: SynDropdown['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynDropdown['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -104,10 +106,12 @@ inside of the viewport.
    * Disables the dropdown so the panel will not open.
    */
   @Input()
-  set disabled(v: SynDropdown['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynDropdown['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynDropdown['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -118,12 +122,12 @@ inside of the viewport.
 dropdowns that allow for multiple interactions.
  */
   @Input()
-  set stayOpenOnSelect(v: SynDropdown['stayOpenOnSelect']) {
+  set stayOpenOnSelect(v: '' | SynDropdown['stayOpenOnSelect']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.stayOpenOnSelect = v),
+      () => (this.nativeElement.stayOpenOnSelect = v === '' || v),
     );
   }
-  get stayOpenOnSelect() {
+  get stayOpenOnSelect(): SynDropdown['stayOpenOnSelect'] {
     return this.nativeElement.stayOpenOnSelect;
   }
 
@@ -134,7 +138,7 @@ dropdowns that allow for multiple interactions.
   set distance(v: SynDropdown['distance']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.distance = v));
   }
-  get distance() {
+  get distance(): SynDropdown['distance'] {
     return this.nativeElement.distance;
   }
 
@@ -145,7 +149,7 @@ dropdowns that allow for multiple interactions.
   set skidding(v: SynDropdown['skidding']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.skidding = v));
   }
-  get skidding() {
+  get skidding(): SynDropdown['skidding'] {
     return this.nativeElement.skidding;
   }
 
@@ -155,10 +159,12 @@ dropdowns that allow for multiple interactions.
 * Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios.
  */
   @Input()
-  set hoist(v: SynDropdown['hoist']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hoist = v));
+  set hoist(v: '' | SynDropdown['hoist']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hoist = v === '' || v),
+    );
   }
-  get hoist() {
+  get hoist(): SynDropdown['hoist'] {
     return this.nativeElement.hoist;
   }
 
@@ -169,7 +175,7 @@ dropdowns that allow for multiple interactions.
   set sync(v: SynDropdown['sync']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.sync = v));
   }
-  get sync() {
+  get sync(): SynDropdown['sync'] {
     return this.nativeElement.sync;
   }
 
@@ -185,7 +191,7 @@ components that use a dropdown internally.
       () => (this.nativeElement.containingElement = v),
     );
   }
-  get containingElement() {
+  get containingElement(): SynDropdown['containingElement'] {
     return this.nativeElement.containingElement;
   }
 

--- a/packages/angular/src/components/file.component.ts
+++ b/packages/angular/src/components/file.component.ts
@@ -105,7 +105,7 @@ via its length property.
   set files(v: SynFile['files']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.files = v));
   }
-  get files() {
+  get files(): SynFile['files'] {
     return this.nativeElement.files;
   }
 
@@ -116,7 +116,7 @@ via its length property.
   set name(v: SynFile['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynFile['name'] {
     return this.nativeElement.name;
   }
 
@@ -131,7 +131,7 @@ Beware that the only valid value when setting a file control is an empty string!
   set value(v: SynFile['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynFile['value'] {
     return this.nativeElement.value;
   }
 
@@ -142,7 +142,7 @@ Beware that the only valid value when setting a file control is an empty string!
   set size(v: SynFile['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynFile['size'] {
     return this.nativeElement.size;
   }
 
@@ -154,7 +154,7 @@ Beware that the only valid value when setting a file control is an empty string!
   set label(v: SynFile['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynFile['label'] {
     return this.nativeElement.label;
   }
 
@@ -166,7 +166,7 @@ If you need to display HTML, use the `help-text` slot instead.
   set helpText(v: SynFile['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynFile['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -174,10 +174,12 @@ If you need to display HTML, use the `help-text` slot instead.
    * Disables the file control.
    */
   @Input()
-  set disabled(v: SynFile['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynFile['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynFile['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -185,10 +187,12 @@ If you need to display HTML, use the `help-text` slot instead.
    * Draw the file control as a drop area
    */
   @Input()
-  set droparea(v: SynFile['droparea']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.droparea = v));
+  set droparea(v: '' | SynFile['droparea']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.droparea = v === '' || v),
+    );
   }
-  get droparea() {
+  get droparea(): SynFile['droparea'] {
     return this.nativeElement.droparea;
   }
 
@@ -200,7 +204,7 @@ If you need to display HTML, use the `help-text` slot instead.
   set accept(v: SynFile['accept']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.accept = v));
   }
-  get accept() {
+  get accept(): SynFile['accept'] {
     return this.nativeElement.accept;
   }
 
@@ -214,7 +218,7 @@ Works only when not using a droparea!
   set capture(v: SynFile['capture']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.capture = v));
   }
-  get capture() {
+  get capture(): SynFile['capture'] {
     return this.nativeElement.capture;
   }
 
@@ -224,10 +228,12 @@ Has no effect if webkitdirectory is set.
 [see MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple)
  */
   @Input()
-  set multiple(v: SynFile['multiple']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.multiple = v));
+  set multiple(v: '' | SynFile['multiple']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.multiple = v === '' || v),
+    );
   }
-  get multiple() {
+  get multiple(): SynFile['multiple'] {
     return this.nativeElement.multiple;
   }
 
@@ -239,12 +245,12 @@ Note: This is a non-standard attribute but is supported in the major browsers.
 [see MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory)
  */
   @Input()
-  set webkitdirectory(v: SynFile['webkitdirectory']) {
+  set webkitdirectory(v: '' | SynFile['webkitdirectory']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.webkitdirectory = v),
+      () => (this.nativeElement.webkitdirectory = v === '' || v),
     );
   }
-  get webkitdirectory() {
+  get webkitdirectory(): SynFile['webkitdirectory'] {
     return this.nativeElement.webkitdirectory;
   }
 
@@ -259,7 +265,7 @@ or shadow root for this to work.
   set form(v: SynFile['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynFile['form'] {
     return this.nativeElement.form;
   }
 
@@ -267,10 +273,12 @@ or shadow root for this to work.
    * Makes the input a required field.
    */
   @Input()
-  set required(v: SynFile['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynFile['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynFile['required'] {
     return this.nativeElement.required;
   }
 
@@ -278,10 +286,12 @@ or shadow root for this to work.
    * Suppress the value from being displayed in the file control
    */
   @Input()
-  set hideValue(v: SynFile['hideValue']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hideValue = v));
+  set hideValue(v: '' | SynFile['hideValue']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hideValue = v === '' || v),
+    );
   }
-  get hideValue() {
+  get hideValue(): SynFile['hideValue'] {
     return this.nativeElement.hideValue;
   }
 

--- a/packages/angular/src/components/header.component.ts
+++ b/packages/angular/src/components/header.component.ts
@@ -87,7 +87,7 @@ export class SynHeaderComponent {
   set label(v: SynHeader['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynHeader['label'] {
     return this.nativeElement.label;
   }
 
@@ -103,7 +103,7 @@ The following values can be used:
   set burgerMenu(v: SynHeader['burgerMenu']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.burgerMenu = v));
   }
-  get burgerMenu() {
+  get burgerMenu(): SynHeader['burgerMenu'] {
     return this.nativeElement.burgerMenu;
   }
 

--- a/packages/angular/src/components/icon-button.component.ts
+++ b/packages/angular/src/components/icon-button.component.ts
@@ -57,7 +57,7 @@ export class SynIconButtonComponent {
   set name(v: SynIconButton['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynIconButton['name'] {
     return this.nativeElement.name;
   }
 
@@ -68,7 +68,7 @@ export class SynIconButtonComponent {
   set library(v: SynIconButton['library']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.library = v));
   }
-  get library() {
+  get library(): SynIconButton['library'] {
     return this.nativeElement.library;
   }
 
@@ -81,7 +81,7 @@ can result in XSS attacks.
   set src(v: SynIconButton['src']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.src = v));
   }
-  get src() {
+  get src(): SynIconButton['src'] {
     return this.nativeElement.src;
   }
 
@@ -92,7 +92,7 @@ can result in XSS attacks.
   set href(v: SynIconButton['href']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.href = v));
   }
-  get href() {
+  get href(): SynIconButton['href'] {
     return this.nativeElement.href;
   }
 
@@ -104,7 +104,7 @@ can result in XSS attacks.
   set target(v: SynIconButton['target']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.target = v));
   }
-  get target() {
+  get target(): SynIconButton['target'] {
     return this.nativeElement.target;
   }
 
@@ -116,7 +116,7 @@ can result in XSS attacks.
   set download(v: SynIconButton['download']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.download = v));
   }
-  get download() {
+  get download(): SynIconButton['download'] {
     return this.nativeElement.download;
   }
 
@@ -129,7 +129,7 @@ that describes what the icon button does.
   set label(v: SynIconButton['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynIconButton['label'] {
     return this.nativeElement.label;
   }
 
@@ -140,7 +140,7 @@ that describes what the icon button does.
   set size(v: SynIconButton['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynIconButton['size'] {
     return this.nativeElement.size;
   }
 
@@ -152,7 +152,7 @@ The default "currentColor" makes it possible to easily style the icon button fro
   set color(v: SynIconButton['color']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.color = v));
   }
-  get color() {
+  get color(): SynIconButton['color'] {
     return this.nativeElement.color;
   }
 
@@ -160,10 +160,12 @@ The default "currentColor" makes it possible to easily style the icon button fro
    * Disables the button.
    */
   @Input()
-  set disabled(v: SynIconButton['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynIconButton['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynIconButton['disabled'] {
     return this.nativeElement.disabled;
   }
 

--- a/packages/angular/src/components/icon.component.ts
+++ b/packages/angular/src/components/icon.component.ts
@@ -56,7 +56,7 @@ export class SynIconComponent {
   set name(v: SynIcon['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynIcon['name'] {
     return this.nativeElement.name;
   }
 
@@ -69,7 +69,7 @@ can result in XSS attacks.
   set src(v: SynIcon['src']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.src = v));
   }
-  get src() {
+  get src(): SynIcon['src'] {
     return this.nativeElement.src;
   }
 
@@ -82,7 +82,7 @@ ignored by assistive devices.
   set label(v: SynIcon['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynIcon['label'] {
     return this.nativeElement.label;
   }
 
@@ -93,7 +93,7 @@ ignored by assistive devices.
   set library(v: SynIcon['library']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.library = v));
   }
-  get library() {
+  get library(): SynIcon['library'] {
     return this.nativeElement.library;
   }
 

--- a/packages/angular/src/components/input.component.ts
+++ b/packages/angular/src/components/input.component.ts
@@ -98,7 +98,7 @@ export class SynInputComponent {
   set title(v: SynInput['title']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.title = v));
   }
-  get title() {
+  get title(): SynInput['title'] {
     return this.nativeElement.title;
   }
 
@@ -112,7 +112,7 @@ to `text`.
   set type(v: SynInput['type']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.type = v));
   }
-  get type() {
+  get type(): SynInput['type'] {
     return this.nativeElement.type;
   }
 
@@ -123,7 +123,7 @@ to `text`.
   set name(v: SynInput['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynInput['name'] {
     return this.nativeElement.name;
   }
 
@@ -134,7 +134,7 @@ to `text`.
   set value(v: SynInput['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynInput['value'] {
     return this.nativeElement.value;
   }
 
@@ -145,7 +145,7 @@ to `text`.
   set size(v: SynInput['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynInput['size'] {
     return this.nativeElement.size;
   }
 
@@ -157,7 +157,7 @@ to `text`.
   set label(v: SynInput['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynInput['label'] {
     return this.nativeElement.label;
   }
 
@@ -169,7 +169,7 @@ to `text`.
   set helpText(v: SynInput['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynInput['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -177,10 +177,12 @@ to `text`.
    * Adds a clear button when the input is not empty.
    */
   @Input()
-  set clearable(v: SynInput['clearable']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.clearable = v));
+  set clearable(v: '' | SynInput['clearable']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.clearable = v === '' || v),
+    );
   }
-  get clearable() {
+  get clearable(): SynInput['clearable'] {
     return this.nativeElement.clearable;
   }
 
@@ -188,10 +190,12 @@ to `text`.
    * Disables the input.
    */
   @Input()
-  set disabled(v: SynInput['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynInput['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynInput['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -202,7 +206,7 @@ to `text`.
   set placeholder(v: SynInput['placeholder']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placeholder = v));
   }
-  get placeholder() {
+  get placeholder(): SynInput['placeholder'] {
     return this.nativeElement.placeholder;
   }
 
@@ -210,10 +214,12 @@ to `text`.
    * Makes the input readonly.
    */
   @Input()
-  set readonly(v: SynInput['readonly']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.readonly = v));
+  set readonly(v: '' | SynInput['readonly']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.readonly = v === '' || v),
+    );
   }
-  get readonly() {
+  get readonly(): SynInput['readonly'] {
     return this.nativeElement.readonly;
   }
 
@@ -222,12 +228,12 @@ to `text`.
    * Only applies to password types.
    */
   @Input()
-  set passwordToggle(v: SynInput['passwordToggle']) {
+  set passwordToggle(v: '' | SynInput['passwordToggle']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.passwordToggle = v),
+      () => (this.nativeElement.passwordToggle = v === '' || v),
     );
   }
-  get passwordToggle() {
+  get passwordToggle(): SynInput['passwordToggle'] {
     return this.nativeElement.passwordToggle;
   }
 
@@ -236,12 +242,12 @@ to `text`.
    * Only applies to password input types.
    */
   @Input()
-  set passwordVisible(v: SynInput['passwordVisible']) {
+  set passwordVisible(v: '' | SynInput['passwordVisible']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.passwordVisible = v),
+      () => (this.nativeElement.passwordVisible = v === '' || v),
     );
   }
-  get passwordVisible() {
+  get passwordVisible(): SynInput['passwordVisible'] {
     return this.nativeElement.passwordVisible;
   }
 
@@ -249,12 +255,12 @@ to `text`.
    * Hides the increment/decrement spin buttons for number inputs.
    */
   @Input()
-  set noSpinButtons(v: SynInput['noSpinButtons']) {
+  set noSpinButtons(v: '' | SynInput['noSpinButtons']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.noSpinButtons = v),
+      () => (this.nativeElement.noSpinButtons = v === '' || v),
     );
   }
-  get noSpinButtons() {
+  get noSpinButtons(): SynInput['noSpinButtons'] {
     return this.nativeElement.noSpinButtons;
   }
 
@@ -269,7 +275,7 @@ the same document or shadow root for this to work.
   set form(v: SynInput['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynInput['form'] {
     return this.nativeElement.form;
   }
 
@@ -277,10 +283,12 @@ the same document or shadow root for this to work.
    * Makes the input a required field.
    */
   @Input()
-  set required(v: SynInput['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynInput['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynInput['required'] {
     return this.nativeElement.required;
   }
 
@@ -291,7 +299,7 @@ the same document or shadow root for this to work.
   set pattern(v: SynInput['pattern']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.pattern = v));
   }
-  get pattern() {
+  get pattern(): SynInput['pattern'] {
     return this.nativeElement.pattern;
   }
 
@@ -302,7 +310,7 @@ the same document or shadow root for this to work.
   set minlength(v: SynInput['minlength']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.minlength = v));
   }
-  get minlength() {
+  get minlength(): SynInput['minlength'] {
     return this.nativeElement.minlength;
   }
 
@@ -313,7 +321,7 @@ the same document or shadow root for this to work.
   set maxlength(v: SynInput['maxlength']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.maxlength = v));
   }
-  get maxlength() {
+  get maxlength(): SynInput['maxlength'] {
     return this.nativeElement.maxlength;
   }
 
@@ -325,7 +333,7 @@ the same document or shadow root for this to work.
   set min(v: SynInput['min']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.min = v));
   }
-  get min() {
+  get min(): SynInput['min'] {
     return this.nativeElement.min;
   }
 
@@ -337,7 +345,7 @@ the same document or shadow root for this to work.
   set max(v: SynInput['max']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.max = v));
   }
-  get max() {
+  get max(): SynInput['max'] {
     return this.nativeElement.max;
   }
 
@@ -350,7 +358,7 @@ implied, allowing any numeric value.
   set step(v: SynInput['step']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.step = v));
   }
-  get step() {
+  get step(): SynInput['step'] {
     return this.nativeElement.step;
   }
 
@@ -363,7 +371,7 @@ implied, allowing any numeric value.
       () => (this.nativeElement.autocapitalize = v),
     );
   }
-  get autocapitalize() {
+  get autocapitalize(): SynInput['autocapitalize'] {
     return this.nativeElement.autocapitalize;
   }
 
@@ -374,7 +382,7 @@ implied, allowing any numeric value.
   set autocorrect(v: SynInput['autocorrect']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.autocorrect = v));
   }
-  get autocorrect() {
+  get autocorrect(): SynInput['autocorrect'] {
     return this.nativeElement.autocorrect;
   }
 
@@ -387,7 +395,7 @@ implied, allowing any numeric value.
   set autocomplete(v: SynInput['autocomplete']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.autocomplete = v));
   }
-  get autocomplete() {
+  get autocomplete(): SynInput['autocomplete'] {
     return this.nativeElement.autocomplete;
   }
 
@@ -395,10 +403,12 @@ implied, allowing any numeric value.
    * Indicates that the input should receive focus on page load.
    */
   @Input()
-  set autofocus(v: SynInput['autofocus']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.autofocus = v));
+  set autofocus(v: '' | SynInput['autofocus']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.autofocus = v === '' || v),
+    );
   }
-  get autofocus() {
+  get autofocus(): SynInput['autofocus'] {
     return this.nativeElement.autofocus;
   }
 
@@ -409,7 +419,7 @@ implied, allowing any numeric value.
   set enterkeyhint(v: SynInput['enterkeyhint']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.enterkeyhint = v));
   }
-  get enterkeyhint() {
+  get enterkeyhint(): SynInput['enterkeyhint'] {
     return this.nativeElement.enterkeyhint;
   }
 
@@ -417,10 +427,12 @@ implied, allowing any numeric value.
    * Enables spell checking on the input.
    */
   @Input()
-  set spellcheck(v: SynInput['spellcheck']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.spellcheck = v));
+  set spellcheck(v: '' | SynInput['spellcheck']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.spellcheck = v === '' || v),
+    );
   }
-  get spellcheck() {
+  get spellcheck(): SynInput['spellcheck'] {
     return this.nativeElement.spellcheck;
   }
 
@@ -432,7 +444,7 @@ keyboard on supportive devices.
   set inputmode(v: SynInput['inputmode']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.inputmode = v));
   }
-  get inputmode() {
+  get inputmode(): SynInput['inputmode'] {
     return this.nativeElement.inputmode;
   }
 

--- a/packages/angular/src/components/menu-item.component.ts
+++ b/packages/angular/src/components/menu-item.component.ts
@@ -63,7 +63,7 @@ export class SynMenuItemComponent {
   set type(v: SynMenuItem['type']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.type = v));
   }
-  get type() {
+  get type(): SynMenuItem['type'] {
     return this.nativeElement.type;
   }
 
@@ -71,10 +71,12 @@ export class SynMenuItemComponent {
    * Draws the item in a checked state.
    */
   @Input()
-  set checked(v: SynMenuItem['checked']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.checked = v));
+  set checked(v: '' | SynMenuItem['checked']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.checked = v === '' || v),
+    );
   }
-  get checked() {
+  get checked(): SynMenuItem['checked'] {
     return this.nativeElement.checked;
   }
 
@@ -86,7 +88,7 @@ export class SynMenuItemComponent {
   set value(v: SynMenuItem['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynMenuItem['value'] {
     return this.nativeElement.value;
   }
 
@@ -94,10 +96,12 @@ export class SynMenuItemComponent {
    * Draws the menu item in a loading state.
    */
   @Input()
-  set loading(v: SynMenuItem['loading']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.loading = v));
+  set loading(v: '' | SynMenuItem['loading']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.loading = v === '' || v),
+    );
   }
-  get loading() {
+  get loading(): SynMenuItem['loading'] {
     return this.nativeElement.loading;
   }
 
@@ -105,10 +109,12 @@ export class SynMenuItemComponent {
    * Draws the menu item in a disabled state, preventing selection.
    */
   @Input()
-  set disabled(v: SynMenuItem['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynMenuItem['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynMenuItem['disabled'] {
     return this.nativeElement.disabled;
   }
 }

--- a/packages/angular/src/components/nav-item.component.ts
+++ b/packages/angular/src/components/nav-item.component.ts
@@ -100,15 +100,17 @@ accordion behavior.
   set href(v: SynNavItem['href']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.href = v));
   }
-  get href() {
+  get href(): SynNavItem['href'] {
     return this.nativeElement.href;
   }
 
   @Input()
-  set current(v: SynNavItem['current']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.current = v));
+  set current(v: '' | SynNavItem['current']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.current = v === '' || v),
+    );
   }
-  get current() {
+  get current(): SynNavItem['current'] {
     return this.nativeElement.current;
   }
 
@@ -116,10 +118,12 @@ accordion behavior.
    * Disables the navigation item.
    */
   @Input()
-  set disabled(v: SynNavItem['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynNavItem['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynNavItem['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -127,10 +131,12 @@ accordion behavior.
    * The navigation item's orientation.
    */
   @Input()
-  set horizontal(v: SynNavItem['horizontal']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.horizontal = v));
+  set horizontal(v: '' | SynNavItem['horizontal']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.horizontal = v === '' || v),
+    );
   }
-  get horizontal() {
+  get horizontal(): SynNavItem['horizontal'] {
     return this.nativeElement.horizontal;
   }
 
@@ -139,10 +145,12 @@ accordion behavior.
 Only used if `horizontal` is false.
  */
   @Input()
-  set chevron(v: SynNavItem['chevron']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.chevron = v));
+  set chevron(v: '' | SynNavItem['chevron']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.chevron = v === '' || v),
+    );
   }
-  get chevron() {
+  get chevron(): SynNavItem['chevron'] {
     return this.nativeElement.chevron;
   }
 
@@ -151,10 +159,12 @@ Only used if `horizontal` is false.
 Only used if `horizontal` is false and `children` is defined.
  */
   @Input()
-  set open(v: SynNavItem['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynNavItem['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynNavItem['open'] {
     return this.nativeElement.open;
   }
 
@@ -163,10 +173,12 @@ Only used if `horizontal` is false and `children` is defined.
 Only available when horizontal is false.
  */
   @Input()
-  set divider(v: SynNavItem['divider']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.divider = v));
+  set divider(v: '' | SynNavItem['divider']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.divider = v === '' || v),
+    );
   }
-  get divider() {
+  get divider(): SynNavItem['divider'] {
     return this.nativeElement.divider;
   }
 

--- a/packages/angular/src/components/optgroup.component.ts
+++ b/packages/angular/src/components/optgroup.component.ts
@@ -55,10 +55,12 @@ export class SynOptgroupComponent {
    * Disables all options in the optgroup.
    */
   @Input()
-  set disabled(v: SynOptgroup['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynOptgroup['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynOptgroup['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -70,7 +72,7 @@ export class SynOptgroupComponent {
   set label(v: SynOptgroup['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynOptgroup['label'] {
     return this.nativeElement.label;
   }
 }

--- a/packages/angular/src/components/option.component.ts
+++ b/packages/angular/src/components/option.component.ts
@@ -59,7 +59,7 @@ multiple values.
   set value(v: SynOption['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynOption['value'] {
     return this.nativeElement.value;
   }
 
@@ -67,10 +67,12 @@ multiple values.
    * Draws the option in a disabled state, preventing selection.
    */
   @Input()
-  set disabled(v: SynOption['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynOption['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynOption['disabled'] {
     return this.nativeElement.disabled;
   }
 }

--- a/packages/angular/src/components/popup.component.ts
+++ b/packages/angular/src/components/popup.component.ts
@@ -75,7 +75,7 @@ element `id`, a DOM element reference, or a `VirtualElement`.
   set anchor(v: SynPopup['anchor']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.anchor = v));
   }
-  get anchor() {
+  get anchor(): SynPopup['anchor'] {
     return this.nativeElement.anchor;
   }
 
@@ -85,10 +85,12 @@ element `id`, a DOM element reference, or a `VirtualElement`.
 down and the popup will be hidden.
  */
   @Input()
-  set active(v: SynPopup['active']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.active = v));
+  set active(v: '' | SynPopup['active']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.active = v === '' || v),
+    );
   }
-  get active() {
+  get active(): SynPopup['active'] {
     return this.nativeElement.active;
   }
 
@@ -101,7 +103,7 @@ panel inside of the viewport.
   set placement(v: SynPopup['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynPopup['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -114,7 +116,7 @@ clipped, using a `fixed` position strategy can often workaround it.
   set strategy(v: SynPopup['strategy']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.strategy = v));
   }
-  get strategy() {
+  get strategy(): SynPopup['strategy'] {
     return this.nativeElement.strategy;
   }
 
@@ -125,7 +127,7 @@ clipped, using a `fixed` position strategy can often workaround it.
   set distance(v: SynPopup['distance']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.distance = v));
   }
-  get distance() {
+  get distance(): SynPopup['distance'] {
     return this.nativeElement.distance;
   }
 
@@ -136,7 +138,7 @@ clipped, using a `fixed` position strategy can often workaround it.
   set skidding(v: SynPopup['skidding']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.skidding = v));
   }
-  get skidding() {
+  get skidding(): SynPopup['skidding'] {
     return this.nativeElement.skidding;
   }
 
@@ -148,10 +150,12 @@ clipped, using a `fixed` position strategy can often workaround it.
 `::part(arrow)` in your stylesheet.
  */
   @Input()
-  set arrow(v: SynPopup['arrow']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.arrow = v));
+  set arrow(v: '' | SynPopup['arrow']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.arrow = v === '' || v),
+    );
   }
-  get arrow() {
+  get arrow(): SynPopup['arrow'] {
     return this.nativeElement.arrow;
   }
 
@@ -168,7 +172,7 @@ align the arrow to the start, end, or center of the popover instead.
       () => (this.nativeElement.arrowPlacement = v),
     );
   }
-  get arrowPlacement() {
+  get arrowPlacement(): SynPopup['arrowPlacement'] {
     return this.nativeElement.arrowPlacement;
   }
 
@@ -181,7 +185,7 @@ this will prevent it from overflowing the corners.
   set arrowPadding(v: SynPopup['arrowPadding']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.arrowPadding = v));
   }
-  get arrowPadding() {
+  get arrowPadding(): SynPopup['arrowPadding'] {
     return this.nativeElement.arrowPadding;
   }
 
@@ -191,10 +195,12 @@ this will prevent it from overflowing the corners.
 `flipFallbackPlacements` to further configure how the fallback placement is determined.
  */
   @Input()
-  set flip(v: SynPopup['flip']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.flip = v));
+  set flip(v: '' | SynPopup['flip']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.flip = v === '' || v),
+    );
   }
-  get flip() {
+  get flip(): SynPopup['flip'] {
     return this.nativeElement.flip;
   }
 
@@ -212,7 +218,7 @@ fallback strategy will be used instead.
       () => (this.nativeElement.flipFallbackPlacements = v),
     );
   }
-  get flipFallbackPlacements() {
+  get flipFallbackPlacements(): SynPopup['flipFallbackPlacements'] {
     return this.nativeElement.flipFallbackPlacements;
   }
 
@@ -227,7 +233,7 @@ preferred.
       () => (this.nativeElement.flipFallbackStrategy = v),
     );
   }
-  get flipFallbackStrategy() {
+  get flipFallbackStrategy(): SynPopup['flipFallbackStrategy'] {
     return this.nativeElement.flipFallbackStrategy;
   }
 
@@ -242,7 +248,7 @@ change the boundary by passing a reference to one or more elements to this prope
   set flipBoundary(v: SynPopup['flipBoundary']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.flipBoundary = v));
   }
-  get flipBoundary() {
+  get flipBoundary(): SynPopup['flipBoundary'] {
     return this.nativeElement.flipBoundary;
   }
 
@@ -253,7 +259,7 @@ change the boundary by passing a reference to one or more elements to this prope
   set flipPadding(v: SynPopup['flipPadding']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.flipPadding = v));
   }
-  get flipPadding() {
+  get flipPadding(): SynPopup['flipPadding'] {
     return this.nativeElement.flipPadding;
   }
 
@@ -261,10 +267,12 @@ change the boundary by passing a reference to one or more elements to this prope
    * Moves the popup along the axis to keep it in view when clipped.
    */
   @Input()
-  set shift(v: SynPopup['shift']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.shift = v));
+  set shift(v: '' | SynPopup['shift']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.shift = v === '' || v),
+    );
   }
-  get shift() {
+  get shift(): SynPopup['shift'] {
     return this.nativeElement.shift;
   }
 
@@ -281,7 +289,7 @@ change the boundary by passing a reference to one or more elements to this prope
       () => (this.nativeElement.shiftBoundary = v),
     );
   }
-  get shiftBoundary() {
+  get shiftBoundary(): SynPopup['shiftBoundary'] {
     return this.nativeElement.shiftBoundary;
   }
 
@@ -292,7 +300,7 @@ change the boundary by passing a reference to one or more elements to this prope
   set shiftPadding(v: SynPopup['shiftPadding']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.shiftPadding = v));
   }
-  get shiftPadding() {
+  get shiftPadding(): SynPopup['shiftPadding'] {
     return this.nativeElement.shiftPadding;
   }
 
@@ -303,7 +311,7 @@ change the boundary by passing a reference to one or more elements to this prope
   set autoSize(v: SynPopup['autoSize']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.autoSize = v));
   }
-  get autoSize() {
+  get autoSize(): SynPopup['autoSize'] {
     return this.nativeElement.autoSize;
   }
 
@@ -314,7 +322,7 @@ change the boundary by passing a reference to one or more elements to this prope
   set sync(v: SynPopup['sync']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.sync = v));
   }
-  get sync() {
+  get sync(): SynPopup['sync'] {
     return this.nativeElement.sync;
   }
 
@@ -331,7 +339,7 @@ change the boundary by passing a reference to one or more elements to this prope
       () => (this.nativeElement.autoSizeBoundary = v),
     );
   }
-  get autoSizeBoundary() {
+  get autoSizeBoundary(): SynPopup['autoSizeBoundary'] {
     return this.nativeElement.autoSizeBoundary;
   }
 
@@ -344,7 +352,7 @@ change the boundary by passing a reference to one or more elements to this prope
       () => (this.nativeElement.autoSizePadding = v),
     );
   }
-  get autoSizePadding() {
+  get autoSizePadding(): SynPopup['autoSizePadding'] {
     return this.nativeElement.autoSizePadding;
   }
 
@@ -357,10 +365,12 @@ because the pointer never technically leaves the element.
 active.
  */
   @Input()
-  set hoverBridge(v: SynPopup['hoverBridge']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hoverBridge = v));
+  set hoverBridge(v: '' | SynPopup['hoverBridge']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hoverBridge = v === '' || v),
+    );
   }
-  get hoverBridge() {
+  get hoverBridge(): SynPopup['hoverBridge'] {
     return this.nativeElement.hoverBridge;
   }
 

--- a/packages/angular/src/components/progress-bar.component.ts
+++ b/packages/angular/src/components/progress-bar.component.ts
@@ -54,7 +54,7 @@ export class SynProgressBarComponent {
   set value(v: SynProgressBar['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynProgressBar['value'] {
     return this.nativeElement.value;
   }
 
@@ -62,12 +62,12 @@ export class SynProgressBarComponent {
    * When true, percentage is ignored, the label is hidden, and the progress bar is drawn in an indeterminate state.
    */
   @Input()
-  set indeterminate(v: SynProgressBar['indeterminate']) {
+  set indeterminate(v: '' | SynProgressBar['indeterminate']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.indeterminate = v),
+      () => (this.nativeElement.indeterminate = v === '' || v),
     );
   }
-  get indeterminate() {
+  get indeterminate(): SynProgressBar['indeterminate'] {
     return this.nativeElement.indeterminate;
   }
 
@@ -78,7 +78,7 @@ export class SynProgressBarComponent {
   set label(v: SynProgressBar['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynProgressBar['label'] {
     return this.nativeElement.label;
   }
 }

--- a/packages/angular/src/components/progress-ring.component.ts
+++ b/packages/angular/src/components/progress-ring.component.ts
@@ -54,7 +54,7 @@ export class SynProgressRingComponent {
   set value(v: SynProgressRing['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynProgressRing['value'] {
     return this.nativeElement.value;
   }
 
@@ -65,7 +65,7 @@ export class SynProgressRingComponent {
   set label(v: SynProgressRing['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynProgressRing['label'] {
     return this.nativeElement.label;
   }
 }

--- a/packages/angular/src/components/radio-button.component.ts
+++ b/packages/angular/src/components/radio-button.component.ts
@@ -64,7 +64,7 @@ export class SynRadioButtonComponent {
   set value(v: SynRadioButton['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynRadioButton['value'] {
     return this.nativeElement.value;
   }
 
@@ -72,10 +72,12 @@ export class SynRadioButtonComponent {
    * Disables the radio button.
    */
   @Input()
-  set disabled(v: SynRadioButton['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynRadioButton['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynRadioButton['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -88,7 +90,7 @@ this attribute can typically be omitted.
   set size(v: SynRadioButton['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynRadioButton['size'] {
     return this.nativeElement.size;
   }
 
@@ -96,10 +98,12 @@ this attribute can typically be omitted.
    * Draws a pill-style radio button with rounded edges.
    */
   @Input()
-  set pill(v: SynRadioButton['pill']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.pill = v));
+  set pill(v: '' | SynRadioButton['pill']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.pill = v === '' || v),
+    );
   }
-  get pill() {
+  get pill(): SynRadioButton['pill'] {
     return this.nativeElement.pill;
   }
 

--- a/packages/angular/src/components/radio-group.component.ts
+++ b/packages/angular/src/components/radio-group.component.ts
@@ -75,7 +75,7 @@ instead.
   set label(v: SynRadioGroup['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynRadioGroup['label'] {
     return this.nativeElement.label;
   }
 
@@ -87,7 +87,7 @@ instead.
   set helpText(v: SynRadioGroup['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynRadioGroup['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -98,7 +98,7 @@ instead.
   set name(v: SynRadioGroup['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynRadioGroup['name'] {
     return this.nativeElement.name;
   }
 
@@ -109,7 +109,7 @@ instead.
   set value(v: SynRadioGroup['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynRadioGroup['value'] {
     return this.nativeElement.value;
   }
 
@@ -121,7 +121,7 @@ instead.
   set size(v: SynRadioGroup['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynRadioGroup['size'] {
     return this.nativeElement.size;
   }
 
@@ -136,7 +136,7 @@ the same document or shadow root for this to work.
   set form(v: SynRadioGroup['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynRadioGroup['form'] {
     return this.nativeElement.form;
   }
 
@@ -144,10 +144,12 @@ the same document or shadow root for this to work.
    * Ensures a child radio is checked before allowing the containing form to submit.
    */
   @Input()
-  set required(v: SynRadioGroup['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynRadioGroup['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynRadioGroup['required'] {
     return this.nativeElement.required;
   }
 

--- a/packages/angular/src/components/radio.component.ts
+++ b/packages/angular/src/components/radio.component.ts
@@ -63,7 +63,7 @@ export class SynRadioComponent {
   set value(v: SynRadio['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynRadio['value'] {
     return this.nativeElement.value;
   }
 
@@ -76,7 +76,7 @@ attribute can typically be omitted.
   set size(v: SynRadio['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynRadio['size'] {
     return this.nativeElement.size;
   }
 
@@ -84,10 +84,12 @@ attribute can typically be omitted.
    * Disables the radio.
    */
   @Input()
-  set disabled(v: SynRadio['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynRadio['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynRadio['disabled'] {
     return this.nativeElement.disabled;
   }
 

--- a/packages/angular/src/components/range-tick.component.ts
+++ b/packages/angular/src/components/range-tick.component.ts
@@ -47,10 +47,12 @@ export class SynRangeTickComponent {
    * Whether the tick should be shown as a subdivision.
    */
   @Input()
-  set subdivision(v: SynRangeTick['subdivision']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.subdivision = v));
+  set subdivision(v: '' | SynRangeTick['subdivision']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.subdivision = v === '' || v),
+    );
   }
-  get subdivision() {
+  get subdivision(): SynRangeTick['subdivision'] {
     return this.nativeElement.subdivision;
   }
 }

--- a/packages/angular/src/components/range.component.ts
+++ b/packages/angular/src/components/range.component.ts
@@ -106,7 +106,7 @@ export class SynRangeComponent {
   set name(v: SynRange['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynRange['name'] {
     return this.nativeElement.name;
   }
 
@@ -118,7 +118,7 @@ export class SynRangeComponent {
   set label(v: SynRange['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynRange['label'] {
     return this.nativeElement.label;
   }
 
@@ -130,7 +130,7 @@ export class SynRangeComponent {
   set helpText(v: SynRange['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynRange['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -138,10 +138,12 @@ export class SynRangeComponent {
    * Disables the range.
    */
   @Input()
-  set disabled(v: SynRange['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynRange['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynRange['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -152,7 +154,7 @@ export class SynRangeComponent {
   set min(v: SynRange['min']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.min = v));
   }
-  get min() {
+  get min(): SynRange['min'] {
     return this.nativeElement.min;
   }
 
@@ -163,7 +165,7 @@ export class SynRangeComponent {
   set max(v: SynRange['max']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.max = v));
   }
-  get max() {
+  get max(): SynRange['max'] {
     return this.nativeElement.max;
   }
 
@@ -174,7 +176,7 @@ export class SynRangeComponent {
   set step(v: SynRange['step']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.step = v));
   }
-  get step() {
+  get step(): SynRange['step'] {
     return this.nativeElement.step;
   }
 
@@ -185,7 +187,7 @@ export class SynRangeComponent {
   set size(v: SynRange['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynRange['size'] {
     return this.nativeElement.size;
   }
 
@@ -199,7 +201,7 @@ export class SynRangeComponent {
       () => (this.nativeElement.tooltipPlacement = v),
     );
   }
-  get tooltipPlacement() {
+  get tooltipPlacement(): SynRange['tooltipPlacement'] {
     return this.nativeElement.tooltipPlacement;
   }
 
@@ -210,7 +212,7 @@ export class SynRangeComponent {
   set value(v: SynRange['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynRange['value'] {
     return this.nativeElement.value;
   }
 
@@ -224,7 +226,7 @@ The form must be in the same document or shadow root for this to work.
   set form(v: SynRange['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynRange['form'] {
     return this.nativeElement.form;
   }
 
@@ -239,7 +241,7 @@ The function should return a string to display in the tooltip.
       () => (this.nativeElement.tooltipFormatter = v),
     );
   }
-  get tooltipFormatter() {
+  get tooltipFormatter(): SynRange['tooltipFormatter'] {
     return this.nativeElement.tooltipFormatter;
   }
 

--- a/packages/angular/src/components/select.component.ts
+++ b/packages/angular/src/components/select.component.ts
@@ -129,7 +129,7 @@ export class SynSelectComponent {
   set name(v: SynSelect['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynSelect['name'] {
     return this.nativeElement.name;
   }
 
@@ -144,7 +144,7 @@ be an array.
   set value(v: SynSelect['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynSelect['value'] {
     return this.nativeElement.value;
   }
 
@@ -155,7 +155,7 @@ be an array.
   set size(v: SynSelect['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynSelect['size'] {
     return this.nativeElement.size;
   }
 
@@ -166,7 +166,7 @@ be an array.
   set placeholder(v: SynSelect['placeholder']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placeholder = v));
   }
-  get placeholder() {
+  get placeholder(): SynSelect['placeholder'] {
     return this.nativeElement.placeholder;
   }
 
@@ -174,10 +174,12 @@ be an array.
    * Allows more than one option to be selected.
    */
   @Input()
-  set multiple(v: SynSelect['multiple']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.multiple = v));
+  set multiple(v: '' | SynSelect['multiple']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.multiple = v === '' || v),
+    );
   }
-  get multiple() {
+  get multiple(): SynSelect['multiple'] {
     return this.nativeElement.multiple;
   }
 
@@ -193,7 +195,7 @@ indicate the number of additional items that are selected.
       () => (this.nativeElement.maxOptionsVisible = v),
     );
   }
-  get maxOptionsVisible() {
+  get maxOptionsVisible(): SynSelect['maxOptionsVisible'] {
     return this.nativeElement.maxOptionsVisible;
   }
 
@@ -201,10 +203,12 @@ indicate the number of additional items that are selected.
    * Disables the select control.
    */
   @Input()
-  set disabled(v: SynSelect['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynSelect['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynSelect['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -212,10 +216,12 @@ indicate the number of additional items that are selected.
    * Adds a clear button when the select is not empty.
    */
   @Input()
-  set clearable(v: SynSelect['clearable']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.clearable = v));
+  set clearable(v: '' | SynSelect['clearable']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.clearable = v === '' || v),
+    );
   }
-  get clearable() {
+  get clearable(): SynSelect['clearable'] {
     return this.nativeElement.clearable;
   }
 
@@ -225,10 +231,12 @@ indicate the number of additional items that are selected.
 use the `show()` and `hide()` methods and this attribute will reflect the select's open state.
  */
   @Input()
-  set open(v: SynSelect['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynSelect['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynSelect['open'] {
     return this.nativeElement.open;
   }
 
@@ -238,10 +246,12 @@ use the `show()` and `hide()` methods and this attribute will reflect the select
 * Hoisting uses a fixed positioning strategy that works in many, but not all, scenarios.
  */
   @Input()
-  set hoist(v: SynSelect['hoist']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hoist = v));
+  set hoist(v: '' | SynSelect['hoist']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hoist = v === '' || v),
+    );
   }
-  get hoist() {
+  get hoist(): SynSelect['hoist'] {
     return this.nativeElement.hoist;
   }
 
@@ -253,7 +263,7 @@ use the `show()` and `hide()` methods and this attribute will reflect the select
   set label(v: SynSelect['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynSelect['label'] {
     return this.nativeElement.label;
   }
 
@@ -266,7 +276,7 @@ inside of the viewport.
   set placement(v: SynSelect['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynSelect['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -278,7 +288,7 @@ inside of the viewport.
   set helpText(v: SynSelect['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynSelect['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -293,7 +303,7 @@ the same document or shadow root for this to work.
   set form(v: SynSelect['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynSelect['form'] {
     return this.nativeElement.form;
   }
 
@@ -301,10 +311,12 @@ the same document or shadow root for this to work.
    * The select's required attribute.
    */
   @Input()
-  set required(v: SynSelect['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynSelect['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynSelect['required'] {
     return this.nativeElement.required;
   }
 
@@ -319,7 +331,7 @@ the specified value.
   set getTag(v: SynSelect['getTag']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.getTag = v));
   }
-  get getTag() {
+  get getTag(): SynSelect['getTag'] {
     return this.nativeElement.getTag;
   }
 

--- a/packages/angular/src/components/side-nav.component.ts
+++ b/packages/angular/src/components/side-nav.component.ts
@@ -111,10 +111,12 @@ or without an overlay for non-touch devices.
 Without `open`, the side-nav will only show the prefix of nav-item's.
  */
   @Input()
-  set open(v: SynSideNav['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynSideNav['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynSideNav['open'] {
     return this.nativeElement.open;
   }
 
@@ -127,10 +129,12 @@ Note: The Rail is only an option if all Navigation Items on the first level have
 If this is not the case you should use a burger navigation.
  */
   @Input()
-  set rail(v: SynSideNav['rail']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.rail = v));
+  set rail(v: '' | SynSideNav['rail']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.rail = v === '' || v),
+    );
   }
-  get rail() {
+  get rail(): SynSideNav['rail'] {
     return this.nativeElement.rail;
   }
 
@@ -139,12 +143,12 @@ If this is not the case you should use a burger navigation.
 To disable the focus trapping, set this attribute.
  */
   @Input()
-  set noFocusTrapping(v: SynSideNav['noFocusTrapping']) {
+  set noFocusTrapping(v: '' | SynSideNav['noFocusTrapping']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.noFocusTrapping = v),
+      () => (this.nativeElement.noFocusTrapping = v === '' || v),
     );
   }
-  get noFocusTrapping() {
+  get noFocusTrapping(): SynSideNav['noFocusTrapping'] {
     return this.nativeElement.noFocusTrapping;
   }
 

--- a/packages/angular/src/components/switch.component.ts
+++ b/packages/angular/src/components/switch.component.ts
@@ -78,7 +78,7 @@ export class SynSwitchComponent {
   set title(v: SynSwitch['title']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.title = v));
   }
-  get title() {
+  get title(): SynSwitch['title'] {
     return this.nativeElement.title;
   }
 
@@ -89,7 +89,7 @@ export class SynSwitchComponent {
   set name(v: SynSwitch['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynSwitch['name'] {
     return this.nativeElement.name;
   }
 
@@ -100,7 +100,7 @@ export class SynSwitchComponent {
   set value(v: SynSwitch['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynSwitch['value'] {
     return this.nativeElement.value;
   }
 
@@ -111,7 +111,7 @@ export class SynSwitchComponent {
   set size(v: SynSwitch['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynSwitch['size'] {
     return this.nativeElement.size;
   }
 
@@ -119,10 +119,12 @@ export class SynSwitchComponent {
    * Disables the switch.
    */
   @Input()
-  set disabled(v: SynSwitch['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynSwitch['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynSwitch['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -130,10 +132,12 @@ export class SynSwitchComponent {
    * Draws the switch in a checked state.
    */
   @Input()
-  set checked(v: SynSwitch['checked']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.checked = v));
+  set checked(v: '' | SynSwitch['checked']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.checked = v === '' || v),
+    );
   }
-  get checked() {
+  get checked(): SynSwitch['checked'] {
     return this.nativeElement.checked;
   }
 
@@ -148,7 +152,7 @@ the same document or shadow root for this to work.
   set form(v: SynSwitch['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynSwitch['form'] {
     return this.nativeElement.form;
   }
 
@@ -156,10 +160,12 @@ the same document or shadow root for this to work.
    * Makes the switch a required field.
    */
   @Input()
-  set required(v: SynSwitch['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynSwitch['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynSwitch['required'] {
     return this.nativeElement.required;
   }
 
@@ -171,7 +177,7 @@ the same document or shadow root for this to work.
   set helpText(v: SynSwitch['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynSwitch['helpText'] {
     return this.nativeElement.helpText;
   }
 

--- a/packages/angular/src/components/tab-group.component.ts
+++ b/packages/angular/src/components/tab-group.component.ts
@@ -78,7 +78,7 @@ export class SynTabGroupComponent {
   set placement(v: SynTabGroup['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynTabGroup['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -91,7 +91,7 @@ manual, the tab will receive focus but will not show until the user presses spac
   set activation(v: SynTabGroup['activation']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.activation = v));
   }
-  get activation() {
+  get activation(): SynTabGroup['activation'] {
     return this.nativeElement.activation;
   }
 
@@ -99,12 +99,12 @@ manual, the tab will receive focus but will not show until the user presses spac
    * Disables the scroll arrows that appear when tabs overflow.
    */
   @Input()
-  set noScrollControls(v: SynTabGroup['noScrollControls']) {
+  set noScrollControls(v: '' | SynTabGroup['noScrollControls']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.noScrollControls = v),
+      () => (this.nativeElement.noScrollControls = v === '' || v),
     );
   }
-  get noScrollControls() {
+  get noScrollControls(): SynTabGroup['noScrollControls'] {
     return this.nativeElement.noScrollControls;
   }
 
@@ -112,10 +112,12 @@ manual, the tab will receive focus but will not show until the user presses spac
    * Draws the tab group as a contained element.
    */
   @Input()
-  set contained(v: SynTabGroup['contained']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.contained = v));
+  set contained(v: '' | SynTabGroup['contained']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.contained = v === '' || v),
+    );
   }
-  get contained() {
+  get contained(): SynTabGroup['contained'] {
     return this.nativeElement.contained;
   }
 
@@ -124,10 +126,12 @@ manual, the tab will receive focus but will not show until the user presses spac
    * Takes only effect if used with the 'contained' property
    */
   @Input()
-  set sharp(v: SynTabGroup['sharp']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.sharp = v));
+  set sharp(v: '' | SynTabGroup['sharp']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.sharp = v === '' || v),
+    );
   }
-  get sharp() {
+  get sharp(): SynTabGroup['sharp'] {
     return this.nativeElement.sharp;
   }
 
@@ -135,12 +139,12 @@ manual, the tab will receive focus but will not show until the user presses spac
    * Prevent scroll buttons from being hidden when inactive.
    */
   @Input()
-  set fixedScrollControls(v: SynTabGroup['fixedScrollControls']) {
+  set fixedScrollControls(v: '' | SynTabGroup['fixedScrollControls']) {
     this._ngZone.runOutsideAngular(
-      () => (this.nativeElement.fixedScrollControls = v),
+      () => (this.nativeElement.fixedScrollControls = v === '' || v),
     );
   }
-  get fixedScrollControls() {
+  get fixedScrollControls(): SynTabGroup['fixedScrollControls'] {
     return this.nativeElement.fixedScrollControls;
   }
 

--- a/packages/angular/src/components/tab-panel.component.ts
+++ b/packages/angular/src/components/tab-panel.component.ts
@@ -48,7 +48,7 @@ export class SynTabPanelComponent {
   set name(v: SynTabPanel['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynTabPanel['name'] {
     return this.nativeElement.name;
   }
 
@@ -56,10 +56,12 @@ export class SynTabPanelComponent {
    * When true, the tab panel will be shown.
    */
   @Input()
-  set active(v: SynTabPanel['active']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.active = v));
+  set active(v: '' | SynTabPanel['active']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.active = v === '' || v),
+    );
   }
-  get active() {
+  get active(): SynTabPanel['active'] {
     return this.nativeElement.active;
   }
 }

--- a/packages/angular/src/components/tab.component.ts
+++ b/packages/angular/src/components/tab.component.ts
@@ -56,7 +56,7 @@ export class SynTabComponent {
   set panel(v: SynTab['panel']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.panel = v));
   }
-  get panel() {
+  get panel(): SynTab['panel'] {
     return this.nativeElement.panel;
   }
 
@@ -64,10 +64,12 @@ export class SynTabComponent {
    * Draws the tab in an active state.
    */
   @Input()
-  set active(v: SynTab['active']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.active = v));
+  set active(v: '' | SynTab['active']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.active = v === '' || v),
+    );
   }
-  get active() {
+  get active(): SynTab['active'] {
     return this.nativeElement.active;
   }
 
@@ -75,10 +77,12 @@ export class SynTabComponent {
    * Makes the tab closable and shows a close button.
    */
   @Input()
-  set closable(v: SynTab['closable']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.closable = v));
+  set closable(v: '' | SynTab['closable']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.closable = v === '' || v),
+    );
   }
-  get closable() {
+  get closable(): SynTab['closable'] {
     return this.nativeElement.closable;
   }
 
@@ -86,10 +90,12 @@ export class SynTabComponent {
    * Disables the tab and prevents selection.
    */
   @Input()
-  set disabled(v: SynTab['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynTab['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynTab['disabled'] {
     return this.nativeElement.disabled;
   }
 

--- a/packages/angular/src/components/tag.component.ts
+++ b/packages/angular/src/components/tag.component.ts
@@ -56,7 +56,7 @@ export class SynTagComponent {
   set size(v: SynTag['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynTag['size'] {
     return this.nativeElement.size;
   }
 
@@ -64,10 +64,12 @@ export class SynTagComponent {
    * Makes the tag removable and shows a remove button.
    */
   @Input()
-  set removable(v: SynTag['removable']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.removable = v));
+  set removable(v: '' | SynTag['removable']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.removable = v === '' || v),
+    );
   }
-  get removable() {
+  get removable(): SynTag['removable'] {
     return this.nativeElement.removable;
   }
 

--- a/packages/angular/src/components/textarea.component.ts
+++ b/packages/angular/src/components/textarea.component.ts
@@ -75,7 +75,7 @@ export class SynTextareaComponent {
   set title(v: SynTextarea['title']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.title = v));
   }
-  get title() {
+  get title(): SynTextarea['title'] {
     return this.nativeElement.title;
   }
 
@@ -86,7 +86,7 @@ export class SynTextareaComponent {
   set name(v: SynTextarea['name']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.name = v));
   }
-  get name() {
+  get name(): SynTextarea['name'] {
     return this.nativeElement.name;
   }
 
@@ -97,7 +97,7 @@ export class SynTextareaComponent {
   set value(v: SynTextarea['value']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.value = v));
   }
-  get value() {
+  get value(): SynTextarea['value'] {
     return this.nativeElement.value;
   }
 
@@ -108,7 +108,7 @@ export class SynTextareaComponent {
   set size(v: SynTextarea['size']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.size = v));
   }
-  get size() {
+  get size(): SynTextarea['size'] {
     return this.nativeElement.size;
   }
 
@@ -120,7 +120,7 @@ export class SynTextareaComponent {
   set label(v: SynTextarea['label']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.label = v));
   }
-  get label() {
+  get label(): SynTextarea['label'] {
     return this.nativeElement.label;
   }
 
@@ -132,7 +132,7 @@ export class SynTextareaComponent {
   set helpText(v: SynTextarea['helpText']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.helpText = v));
   }
-  get helpText() {
+  get helpText(): SynTextarea['helpText'] {
     return this.nativeElement.helpText;
   }
 
@@ -143,7 +143,7 @@ export class SynTextareaComponent {
   set placeholder(v: SynTextarea['placeholder']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placeholder = v));
   }
-  get placeholder() {
+  get placeholder(): SynTextarea['placeholder'] {
     return this.nativeElement.placeholder;
   }
 
@@ -154,7 +154,7 @@ export class SynTextareaComponent {
   set rows(v: SynTextarea['rows']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.rows = v));
   }
-  get rows() {
+  get rows(): SynTextarea['rows'] {
     return this.nativeElement.rows;
   }
 
@@ -165,7 +165,7 @@ export class SynTextareaComponent {
   set resize(v: SynTextarea['resize']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.resize = v));
   }
-  get resize() {
+  get resize(): SynTextarea['resize'] {
     return this.nativeElement.resize;
   }
 
@@ -173,10 +173,12 @@ export class SynTextareaComponent {
    * Disables the textarea.
    */
   @Input()
-  set disabled(v: SynTextarea['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynTextarea['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynTextarea['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -184,10 +186,12 @@ export class SynTextareaComponent {
    * Makes the textarea readonly.
    */
   @Input()
-  set readonly(v: SynTextarea['readonly']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.readonly = v));
+  set readonly(v: '' | SynTextarea['readonly']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.readonly = v === '' || v),
+    );
   }
-  get readonly() {
+  get readonly(): SynTextarea['readonly'] {
     return this.nativeElement.readonly;
   }
 
@@ -202,7 +206,7 @@ the same document or shadow root for this to work.
   set form(v: SynTextarea['form']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.form = v));
   }
-  get form() {
+  get form(): SynTextarea['form'] {
     return this.nativeElement.form;
   }
 
@@ -210,10 +214,12 @@ the same document or shadow root for this to work.
    * Makes the textarea a required field.
    */
   @Input()
-  set required(v: SynTextarea['required']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.required = v));
+  set required(v: '' | SynTextarea['required']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.required = v === '' || v),
+    );
   }
-  get required() {
+  get required(): SynTextarea['required'] {
     return this.nativeElement.required;
   }
 
@@ -224,7 +230,7 @@ the same document or shadow root for this to work.
   set minlength(v: SynTextarea['minlength']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.minlength = v));
   }
-  get minlength() {
+  get minlength(): SynTextarea['minlength'] {
     return this.nativeElement.minlength;
   }
 
@@ -235,7 +241,7 @@ the same document or shadow root for this to work.
   set maxlength(v: SynTextarea['maxlength']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.maxlength = v));
   }
-  get maxlength() {
+  get maxlength(): SynTextarea['maxlength'] {
     return this.nativeElement.maxlength;
   }
 
@@ -248,7 +254,7 @@ the same document or shadow root for this to work.
       () => (this.nativeElement.autocapitalize = v),
     );
   }
-  get autocapitalize() {
+  get autocapitalize(): SynTextarea['autocapitalize'] {
     return this.nativeElement.autocapitalize;
   }
 
@@ -259,7 +265,7 @@ the same document or shadow root for this to work.
   set autocorrect(v: SynTextarea['autocorrect']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.autocorrect = v));
   }
-  get autocorrect() {
+  get autocorrect(): SynTextarea['autocorrect'] {
     return this.nativeElement.autocorrect;
   }
 
@@ -272,7 +278,7 @@ the same document or shadow root for this to work.
   set autocomplete(v: SynTextarea['autocomplete']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.autocomplete = v));
   }
-  get autocomplete() {
+  get autocomplete(): SynTextarea['autocomplete'] {
     return this.nativeElement.autocomplete;
   }
 
@@ -280,10 +286,12 @@ the same document or shadow root for this to work.
    * Indicates that the input should receive focus on page load.
    */
   @Input()
-  set autofocus(v: SynTextarea['autofocus']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.autofocus = v));
+  set autofocus(v: '' | SynTextarea['autofocus']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.autofocus = v === '' || v),
+    );
   }
-  get autofocus() {
+  get autofocus(): SynTextarea['autofocus'] {
     return this.nativeElement.autofocus;
   }
 
@@ -294,7 +302,7 @@ the same document or shadow root for this to work.
   set enterkeyhint(v: SynTextarea['enterkeyhint']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.enterkeyhint = v));
   }
-  get enterkeyhint() {
+  get enterkeyhint(): SynTextarea['enterkeyhint'] {
     return this.nativeElement.enterkeyhint;
   }
 
@@ -302,10 +310,12 @@ the same document or shadow root for this to work.
    * Enables spell checking on the textarea.
    */
   @Input()
-  set spellcheck(v: SynTextarea['spellcheck']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.spellcheck = v));
+  set spellcheck(v: '' | SynTextarea['spellcheck']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.spellcheck = v === '' || v),
+    );
   }
-  get spellcheck() {
+  get spellcheck(): SynTextarea['spellcheck'] {
     return this.nativeElement.spellcheck;
   }
 
@@ -317,7 +327,7 @@ keyboard on supportive devices.
   set inputmode(v: SynTextarea['inputmode']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.inputmode = v));
   }
-  get inputmode() {
+  get inputmode(): SynTextarea['inputmode'] {
     return this.nativeElement.inputmode;
   }
 

--- a/packages/angular/src/components/tooltip.component.ts
+++ b/packages/angular/src/components/tooltip.component.ts
@@ -86,7 +86,7 @@ export class SynTooltipComponent {
   set content(v: SynTooltip['content']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.content = v));
   }
-  get content() {
+  get content(): SynTooltip['content'] {
     return this.nativeElement.content;
   }
 
@@ -99,7 +99,7 @@ inside of the viewport.
   set placement(v: SynTooltip['placement']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.placement = v));
   }
-  get placement() {
+  get placement(): SynTooltip['placement'] {
     return this.nativeElement.placement;
   }
 
@@ -107,10 +107,12 @@ inside of the viewport.
    * Disables the tooltip so it won't show when triggered.
    */
   @Input()
-  set disabled(v: SynTooltip['disabled']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.disabled = v));
+  set disabled(v: '' | SynTooltip['disabled']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.disabled = v === '' || v),
+    );
   }
-  get disabled() {
+  get disabled(): SynTooltip['disabled'] {
     return this.nativeElement.disabled;
   }
 
@@ -121,7 +123,7 @@ inside of the viewport.
   set distance(v: SynTooltip['distance']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.distance = v));
   }
-  get distance() {
+  get distance(): SynTooltip['distance'] {
     return this.nativeElement.distance;
   }
 
@@ -130,10 +132,12 @@ inside of the viewport.
    * You can use this in lieu of the show/hide methods.
    */
   @Input()
-  set open(v: SynTooltip['open']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.open = v));
+  set open(v: '' | SynTooltip['open']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.open = v === '' || v),
+    );
   }
-  get open() {
+  get open(): SynTooltip['open'] {
     return this.nativeElement.open;
   }
 
@@ -144,7 +148,7 @@ inside of the viewport.
   set skidding(v: SynTooltip['skidding']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.skidding = v));
   }
-  get skidding() {
+  get skidding(): SynTooltip['skidding'] {
     return this.nativeElement.skidding;
   }
 
@@ -160,7 +164,7 @@ programmatically.
   set trigger(v: SynTooltip['trigger']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.trigger = v));
   }
-  get trigger() {
+  get trigger(): SynTooltip['trigger'] {
     return this.nativeElement.trigger;
   }
 
@@ -171,10 +175,12 @@ programmatically.
 scenarios.
  */
   @Input()
-  set hoist(v: SynTooltip['hoist']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hoist = v));
+  set hoist(v: '' | SynTooltip['hoist']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hoist = v === '' || v),
+    );
   }
-  get hoist() {
+  get hoist(): SynTooltip['hoist'] {
     return this.nativeElement.hoist;
   }
 

--- a/packages/angular/src/components/validate.component.ts
+++ b/packages/angular/src/components/validate.component.ts
@@ -57,7 +57,7 @@ The following variants are supported:
   set variant(v: SynValidate['variant']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.variant = v));
   }
-  get variant() {
+  get variant(): SynValidate['variant'] {
     return this.nativeElement.variant;
   }
 
@@ -65,10 +65,12 @@ The following variants are supported:
    * Do not show the error icon when using the inline variant validation
    */
   @Input()
-  set hideIcon(v: SynValidate['hideIcon']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.hideIcon = v));
+  set hideIcon(v: '' | SynValidate['hideIcon']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.hideIcon = v === '' || v),
+    );
   }
-  get hideIcon() {
+  get hideIcon(): SynValidate['hideIcon'] {
     return this.nativeElement.hideIcon;
   }
 
@@ -85,7 +87,7 @@ and [the use of form invalid events](https://developer.mozilla.org/en-US/docs/We
   set on(v: SynValidate['on']) {
     this._ngZone.runOutsideAngular(() => (this.nativeElement.on = v));
   }
-  get on() {
+  get on(): SynValidate['on'] {
     return this.nativeElement.on;
   }
 
@@ -100,7 +102,7 @@ Set to an empty string to reset the validation message.
       () => (this.nativeElement.customValidationMessage = v),
     );
   }
-  get customValidationMessage() {
+  get customValidationMessage(): SynValidate['customValidationMessage'] {
     return this.nativeElement.customValidationMessage;
   }
 
@@ -114,10 +116,12 @@ the last eager field as it is using a tooltip.
 In this case it is better to just provide one eager field.
  */
   @Input()
-  set eager(v: SynValidate['eager']) {
-    this._ngZone.runOutsideAngular(() => (this.nativeElement.eager = v));
+  set eager(v: '' | SynValidate['eager']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.eager = v === '' || v),
+    );
   }
-  get eager() {
+  get eager(): SynValidate['eager'] {
     return this.nativeElement.eager;
   }
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR provides a small change for our angular wrappers, adding the possibility to use short hand notation for `boolean` attributes without angulars... angular syntax :).

### Before:

```html
<syn-input name="something" [required]="true" />
<syn-checkbox name="checkbox" [required]="true" [checked]="true" />
```

### After:

```html
<syn-input name="something" required />
<syn-checkbox name="checkbox" required checked />
```

Both syntaxes are valid from now on, making it possible to use the shorter syntax in the future without breaking current projects relying on the angular-bracket notation.

### 🎫 Issues

Closes #689

## 👩‍💻 Reviewer Notes

Just have a look at the created code for the angular components. Also, play around with the angular demo project to see how this can be mixed and matched to taste.

## 📑 Test Plan

- Check out the repository
- Install and build all
- Move to the angular demo and start it up. This version already uses the short hand syntax where possible
- Change one of the required fields in a demo to the old syntax. Note that there is no difference between both versions.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
