### PR TITLE
chore: 🔧 Fix github actions

### DIFF
--- a/.github/workflows/chromatic-main.yml
+++ b/.github/workflows/chromatic-main.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
       - uses: pnpm/action-setup@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
       - name: Install dependencies
         # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
         run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true pnpm i

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
         working-directory: ./synergy-design-system

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -142,6 +142,11 @@ jobs:
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
       - uses: pnpm/action-setup@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
       # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
       - name: Install dependencies
         run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true pnpm i

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
       - name: Install dependencies
         run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true pnpm i
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes our github actions.
Our `deploy-docs` actions needs an explicit pnpm version added, as the package.json key "packageManager" is not available there.

Also we updated the supported node version to be ">=20.0.0", which lead to warning in some actions as there node 18 was used


## 👩‍💻 Reviewer Notes
Have a look at the github actions and verify that there is no issue / warning anymore


## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
