### PR TITLE
fix: 🐛 Align prefixes, suffixes and build-in icons to design

### DIFF
--- a/packages/components/src/components/badge/badge.custom.styles.ts
+++ b/packages/components/src/components/badge/badge.custom.styles.ts
@@ -4,7 +4,7 @@ export default css`
   .badge {
     border: none;
     border-radius: var(--syn-border-radius-pill);
-    font: var(--syn-body-x-small-bold);
+    font: var(--syn-body-medium-bold);
     height: var(--syn-spacing-large);
     line-height: var(--syn-spacing-large);
     min-width: var(--syn-spacing-large);

--- a/packages/components/src/components/button/button.custom.styles.ts
+++ b/packages/components/src/components/button/button.custom.styles.ts
@@ -183,4 +183,19 @@ export default css`
   .button.button--large.button--has-suffix .button__suffix {
     font-size: var(--syn-font-size-2x-large);
   }
+
+  /*
+   * Caret modifier
+   */
+  .button--caret.button--small .button__caret{
+    font-size: var(--syn-font-size-medium);
+  }
+
+  .button--caret.button--medium .button__caret{
+    font-size: var(--syn-font-size-x-large);
+  }
+
+  .button--caret.button--large .button__caret{
+    font-size: var(--syn-font-size-2x-large);
+  }
 `;

--- a/packages/components/src/components/header/header.styles.ts
+++ b/packages/components/src/components/header/header.styles.ts
@@ -86,6 +86,7 @@ export default css`
   }
 
   .header__meta-navigation ::slotted(*) {
+    color: var(--syn-color-neutral-950);
     display: contents;
     font-size: var(--syn-font-size-x-large);
   }

--- a/packages/components/src/components/input/input.custom.styles.ts
+++ b/packages/components/src/components/input/input.custom.styles.ts
@@ -49,6 +49,12 @@ export default css`
     width: auto;
   }
 
+  /* Prefix / Suffix color */
+  .input__prefix ::slotted(*),
+  .input__suffix ::slotted(*) {
+    color: var(--syn-input-icon-color);
+  }
+
 
   /* PADDINGS */
   .input--small .input__control {

--- a/packages/components/src/components/menu-item/menu-item.custom.styles.ts
+++ b/packages/components/src/components/menu-item/menu-item.custom.styles.ts
@@ -23,6 +23,7 @@ export default css`
    */
   .menu-item .menu-item__prefix::slotted(syn-icon),
   .menu-item .menu-item__suffix::slotted(syn-icon) {
+    color: var(--syn-color-neutral-800);
     font-size: var(--syn-font-size-x-large);
   }
 

--- a/packages/components/src/components/optgroup/optgroup.styles.ts
+++ b/packages/components/src/components/optgroup/optgroup.styles.ts
@@ -49,7 +49,7 @@ export default css`
 
   .optgroup__prefix,
   .optgroup__suffix {
-    color: var(--syn-color-neutral-950);
+    color: var(--syn-color-neutral-800);
     font-size: var(--syn-spacing-large);
   }
 `;

--- a/packages/components/src/components/option/option.custom.styles.ts
+++ b/packages/components/src/components/option/option.custom.styles.ts
@@ -41,6 +41,7 @@ export default css`
   /* Set correct icon size when someone uses syn-icon in the slots */
   .option__prefix::slotted(syn-icon),
   .option__suffix::slotted(syn-icon) {
+    color: var(--syn-color-neutral-800);
     font-size: var(--syn-spacing-large);
   }
 `;

--- a/packages/components/src/components/select/select.custom.styles.ts
+++ b/packages/components/src/components/select/select.custom.styles.ts
@@ -35,8 +35,19 @@ export default css`
   /* Expand icon */
   .select__expand-icon {
     color: var(--syn-color-neutral-950);
-    font-size: var(--syn-spacing-large);
     margin-inline-start: var(--syn-spacing-small);
+  }
+
+  .select--small .select__expand-icon {
+    font-size: var(--syn-spacing-medium);
+  }
+
+  .select--medium .select__expand-icon {
+    font-size: var(--syn-spacing-large);
+  }
+
+  .select--large .select__expand-icon {
+    font-size: var(--syn-spacing-x-large);
   }
 
   /* Change select border on hover */
@@ -56,6 +67,12 @@ export default css`
     margin-inline-start: var(--syn-spacing-x-small);
   }
 
+  .select--small .select__suffix::slotted(syn-icon),
+  .select--small .select__prefix::slotted(syn-icon) {
+    font-size: var(--syn-font-size-medium);
+  }
+
+  /* Medium */
   .select--medium .select__prefix::slotted(*) {
     margin-inline-end: var(--syn-input-spacing-small);
   }
@@ -64,6 +81,12 @@ export default css`
     margin-inline-start: var(--syn-input-spacing-small);
   }
 
+  .select--medium .select__suffix::slotted(syn-icon),
+  .select--medium .select__prefix::slotted(syn-icon) {
+    font-size: var(--syn-font-size-x-large);
+  }
+
+  /* Large */
   .select--large .select__prefix::slotted(*) {
     margin-inline-end: var(--syn-input-spacing-medium);
   }
@@ -71,6 +94,12 @@ export default css`
   .select--large .select__suffix::slotted(*) {
     margin-inline-start: var(--syn-input-spacing-medium);
   }
+
+  .select--large .select__suffix::slotted(syn-icon),
+  .select--large .select__prefix::slotted(syn-icon) {
+    font-size: var(--syn-font-size-2x-large);
+  }
+
 
   .select__prefix,
   .select__suffix {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR aligns all prefixes, suffixes and built-in icons to the design.

### 🎫 Issues

Closes #573

## 👩‍💻 Reviewer Notes

Currently the prefix and suffix icons of our `syn-select` does have another color than the prefix and suffix icons of our `syn-input` in design. I guess they should have the same color, so we need to adapt this in design also
- syn-input icon color: input/icon/color (#5E676B)
- syn-select icon color: neutral/950 (#31373A)

## 📑 Test Plan
Have a look at the changes of chromatic, if they are now correct

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
