### PR TITLE
fix: 🐛 Indentation of nested nav-items in side-nav is not shown correctly for firefox

### DIFF
--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -223,10 +223,25 @@ export default class SynNavItem extends SynergyElement {
    * Automatically add the correct level of indentation for sub items if none is provided
    */
   private handleSlotChange() {
+    const computedStyle = getComputedStyle(this);
+    const lengthStyle = computedStyle.length;
+
+    // This workaround is needed for firefox.
+    // When the nav-item is used inside a custom-element with a custom-element in it
+    // (e.g syn-side-nav with integrated syn-drawer), the getComputedStyle property is not yet there
+    // Moving it in the next render cycle works.
+    // Probably related to the firefox special behavior. See: https://caniuse.com/mdn-api_window_getcomputedstyle
+    if (lengthStyle === 0) {
+      setTimeout(() => {
+        this.handleSlotChange();
+      });
+      return;
+    }
+
     this.handleCurrentMarkedChild();
 
     // Use the current level of the component
-    const level = getComputedStyle(this).getPropertyValue('--indentation');
+    const level = computedStyle.getPropertyValue('--indentation');
 
     // We allow at most 3 levels
     const nextLevel = Math.min(parseInt(level, 10) + 1, 2);

--- a/packages/components/src/components/nav-item/nav-item.test.ts
+++ b/packages/components/src/components/nav-item/nav-item.test.ts
@@ -255,4 +255,43 @@ describe('<syn-nav-item>', () => {
     expect(el).property('current').to.be.false;
     expect(base).to.have.class('nav-item--current');
   });
+
+  describe('Nested syn-nav-items', () => {
+    it('should set the correct indentation level for nested nav-items', async () => {
+      const el = await fixture<SynNavItem>(html`
+        <syn-nav-item>
+          Parent
+          <syn-nav-item slot="children">Child</syn-nav-item>
+        </syn-nav-item>
+      `);
+
+      const child = el.querySelector('syn-nav-item')!;
+      expect(child.style.getPropertyValue('--indentation')).to.equal('1');
+    });
+
+    it('should set the indentation level to maximum 2 of nested children', async () => {
+      const el = await fixture<SynNavItem>(html`
+        <syn-nav-item>
+          Parent
+          <syn-nav-item slot="children" id="first">
+            First level
+            <syn-nav-item slot="children" id="second">
+              Second level
+              <syn-nav-item slot="children" id="third">
+                Third level
+              </syn-nav-item>
+            </syn-nav-item>
+          </syn-nav-item>
+        </syn-nav-item>
+      `);
+
+      const firstNested = el.querySelector('#first') as SynNavItem;
+      const secondNested = el.querySelector('#second') as SynNavItem;
+      const thirdNested = el.querySelector('#third') as SynNavItem;
+
+      expect(getComputedStyle(firstNested).getPropertyValue('--indentation')).to.equal('1');
+      expect(getComputedStyle(secondNested).getPropertyValue('--indentation')).to.equal('2');
+      expect(getComputedStyle(thirdNested).getPropertyValue('--indentation')).to.equal('2');
+    });
+  });
 });

--- a/packages/components/src/components/side-nav/side-nav.test.ts
+++ b/packages/components/src/components/side-nav/side-nav.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import '../../../dist/synergy.js';
 import {
+  aTimeout,
   expect,
   fixture,
   html,
@@ -8,6 +9,7 @@ import {
 } from '@open-wc/testing';
 import sinon from 'sinon';
 import type SynSideNav from './side-nav.js';
+import type SynNavItem from '../nav-item/nav-item.js';
 
 describe('<syn-side-nav>', () => {
   afterEach(() => {
@@ -33,7 +35,7 @@ describe('<syn-side-nav>', () => {
     it('should emit syn-show and syn-after-show when calling show()', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const showHandler = sinon.spy();
@@ -53,7 +55,7 @@ describe('<syn-side-nav>', () => {
     it('should emit syn-hide and syn-after-hide when calling hide()', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav  open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const hideHandler = sinon.spy();
@@ -75,7 +77,7 @@ describe('<syn-side-nav>', () => {
     it('should emit syn-show and syn-after-show when setting open = true', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const showHandler = sinon.spy();
@@ -95,7 +97,7 @@ describe('<syn-side-nav>', () => {
     it('should emit syn-hide and syn-after-hide when setting open = false', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const hideHandler = sinon.spy();
@@ -120,7 +122,7 @@ describe('<syn-side-nav>', () => {
 
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -141,7 +143,7 @@ describe('<syn-side-nav>', () => {
     it('should not be visible without the open attribute', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -154,7 +156,7 @@ describe('<syn-side-nav>', () => {
     it('should show an overlay on open state', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -171,7 +173,7 @@ describe('<syn-side-nav>', () => {
       const expectedSideNavOpenSize = '72px';
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -193,7 +195,7 @@ describe('<syn-side-nav>', () => {
 
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -212,7 +214,7 @@ describe('<syn-side-nav>', () => {
     it('should show no overlay on open state', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -228,7 +230,7 @@ describe('<syn-side-nav>', () => {
 
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail open>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -241,8 +243,8 @@ describe('<syn-side-nav>', () => {
     it('should not show nested open nav-item`s without the open attribute', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail>
-          <syn-nav-item class="root" vertical open>nav 1
-            <syn-nav-item vertical slot="children">nav 1</syn-nav-item> 
+          <syn-nav-item class="root" open>nav 1
+            <syn-nav-item slot="children">nav 1</syn-nav-item> 
           </syn-nav-item> 
         </syn-side-nav>
       `);
@@ -256,7 +258,7 @@ describe('<syn-side-nav>', () => {
     it('should remove the forcing of drawer visibility if rail mode changed to rail = false and open = false', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const drawer = sideNav.shadowRoot!.querySelector<HTMLElement>('[part~="drawer"]')!;
@@ -274,7 +276,7 @@ describe('<syn-side-nav>', () => {
     it('should open the side-nav if nav-item is focused and close it if it looses focus', async () => {
       const sideNav = await fixture<SynSideNav>(html`
         <syn-side-nav rail>
-          <syn-nav-item vertical>nav 1</syn-nav-item> 
+          <syn-nav-item>nav 1</syn-nav-item> 
         </syn-side-nav>
       `);
       const navItem = sideNav.querySelector('syn-nav-item')!;
@@ -289,5 +291,31 @@ describe('<syn-side-nav>', () => {
 
       expect(sideNav.open).to.be.false;
     });
+  });
+
+  it('should show an indentation for nested nav-items (#708)', async () => {
+    const sideNav = await fixture<SynSideNav>(html`
+      <syn-side-nav rail>
+        <syn-nav-item id="first">
+          first level
+          <syn-nav-item slot="children" id="second">
+            second level
+            <syn-nav-item slot="children" id="third">third level</syn-nav-item> 
+          </syn-nav-item> 
+        </syn-nav-item> 
+      </syn-side-nav>
+    `);
+
+    // For the firefox fix, we needed to move the `handleSlotChange` of the syn-nav-item into
+    // the next update cycle. Therefore we need to wait
+    await aTimeout(0);
+
+    const firstNested = sideNav.querySelector('#first') as SynNavItem;
+    const secondNested = sideNav.querySelector('#second') as SynNavItem;
+    const thirdNested = sideNav.querySelector('#third') as SynNavItem;
+
+    expect(getComputedStyle(firstNested).getPropertyValue('--indentation')).to.equal('0');
+    expect(getComputedStyle(secondNested).getPropertyValue('--indentation')).to.equal('1');
+    expect(getComputedStyle(thirdNested).getPropertyValue('--indentation')).to.equal('2');
   });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes the issue that in firefox the syn-side-nav with nested syn-nav-items does not show an indentation for them.

### 🎫 Issues
Closes #708 

## 👩‍💻 Reviewer Notes
This problem occurs only in firefox. 
Using `getComputedStyles` in firefox with a parent window with no presentation (e.g. display: none) results in an empty object. For more information about this see [the firefox notes on caniuse](https://caniuse.com/?search=getComputedStyle).

Nesting the syn-nav-items without an syn-side-nav works fine in firefox, but our syn-side-nav uses a syn-drawer in itself, which leads to this behavior. It has nothing to do with the side-nav or the drawer but just the fact of slotting the nav-item into a custom-element which uses a custom element in it. This seems to trigger the behavior in firefox only.
My guess would be that the inner custom element (in our case the syn-drawer) is not yet finished and has therefore no presentation, which leads to this.

The solution is moving everything in the handleSlotChange for firefox in the next render cycle.

## 📑 Test Plan

Check out the indentation syn-side-nav story in firefox, that it looks correct now: http://localhost:6006/?path=/story/components-syn-side-nav--indentation&globals=viewport:defaultViewPort

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
