### PR TITLE
fix: 🐛 Various issues with syn-combobox

### DIFF
--- a/packages/components/scripts/vendorism/custom/option.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/option.vendorism.js
@@ -1,4 +1,4 @@
-import { addSectionBefore } from '../replace-section.js';
+import { addSectionsBefore, replaceSections } from '../replace-section.js';
 
 const FILES_TO_TRANSFORM = [
   'option.component.ts',
@@ -13,16 +13,57 @@ const FILES_TO_TRANSFORM = [
  * @returns
  */
 const transformComponent = (path, originalContent) => {
-  const content = addSectionBefore(
-    originalContent,
-    "customElements.whenDefined('syn-select').then(() => {",
-    `customElements.whenDefined('syn-combobox').then(() => {
-      const controller = this.closest('syn-combobox');
+  let content = replaceSections([
+    // Fix performance issues for many options:
+    // only trigger handleDefaultSlotChange for controller, if it is not the initial render
+    // TODO: can be removed if shoelace fixed this issue on their side
+    [
+      `
+    // When the label changes, tell the controller to update
+    customElements.whenDefined('syn-select').then(() => {
+      const controller = this.closest('syn-select');
       if (controller) {
         controller.handleDefaultSlotChange();
       }
     });`,
-    { tabsAfterInsertion: 2 },
+      `
+      if(this.isInitialized) {
+      // When the label changes, tell the controller to update
+      customElements.whenDefined('syn-select').then(() => {
+        const controller = this.closest('syn-select');
+        if (controller) {
+          controller.handleDefaultSlotChange();
+        }
+      });
+    } else {
+      this.isInitialized = true;
+    }`,
+    ],
+  ], originalContent);
+
+  content = addSectionsBefore(
+    [
+      // Fix performance issues for many options:
+      // only trigger handleDefaultSlotChange for controller, if it is not the initial render
+      // TODO: can be removed if shoelace fixed this issue on their side
+      [
+        "@query('.option__label') defaultSlot: HTMLSlotElement;",
+        'private isInitialized = false;',
+        { newlinesAfterInsertion: 2, tabsAfterInsertion: 1 },
+      ],
+      // Add "handleDefaultSlotChange" trigger for syn-combobox
+      [
+        "customElements.whenDefined('syn-select').then(() => {",
+    `customElements.whenDefined('syn-combobox').then(() => {
+        const controller = this.closest('syn-combobox');
+        if (controller) {
+          controller.handleDefaultSlotChange();
+        }
+      });`,
+    { tabsAfterInsertion: 3 },
+      ],
+    ],
+    content,
   );
 
   return {

--- a/packages/components/scripts/vendorism/custom/webTestRunner.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/webTestRunner.vendorism.js
@@ -1,3 +1,5 @@
+import { addSectionsAfter, replaceSections } from '../replace-section.js';
+
 /**
  * Adjust the web-test-runner config
  */
@@ -9,31 +11,42 @@ export const vendorWebTestRunnerConfig = (path, content) => {
     };
   }
 
-  // Adjust the path to the theme to make sure we always fetch
-  // the latest version from the package
-  let nextContent = content.replaceAll(
-    '<link rel="stylesheet" href="dist/themes/light.css">',
-    `<link rel="stylesheet" href="node_modules/@synergy-design-system/tokens/dist/themes/light.css">
-        <link rel="stylesheet" href="dist/styles/index.css">`,
-  );
+  let nextContent = addSectionsAfter([
+    // Add the synergy test plugins to the imports
+    [
+      "runner-playwright';",
+      "import synTestPlugins from './scripts/tests/index.js';",
+    ],
+    // Add the synergy test plugins to the plugins
+    [
+      'plugins: [',
+      '...synTestPlugins.plugins,',
+      { tabsBeforeInsertion: 2 },
+    ],
+    // Add the synergy theme to the test runner html
+    [
+      '<link rel="stylesheet" href="dist/themes/light.css">',
+      '<link rel="stylesheet" href="node_modules/@synergy-design-system/tokens/dist/themes/light.css">',
+      { tabsBeforeInsertion: 4 },
+    ],
+    // add mocha config to fail if somewhere is `.only` used in a test
+    [
+      'timeout: 3000,',
+      'forbidOnly: true,',
+      { tabsBeforeInsertion: 3 },
+    ],
+  ], content);
 
-  // Add the synergy test plugins to the mix
-  nextContent = nextContent.replaceAll(
-    "runner-playwright';",
-    `runner-playwright';
-import synTestPlugins from './scripts/tests/index.js';`,
-  );
-
-  nextContent = nextContent.replaceAll(
-    'esbuildPlugin({',
-    `...synTestPlugins.plugins,
-    esbuildPlugin({`,
-  );
-
-  // Enable testing with firefox.
-  // TODO: As soon as shoelace enabled it on their side, this can be removed
-  // TODO: We add concurrency: 1 to prevent the issue at https://github.com/modernweb-dev/web/issues/2374
-  nextContent = nextContent.replace(
+  nextContent = replaceSections([
+    // Adjust the path to the theme to make sure we always fetch the latest version from the package
+    [
+      '<link rel="stylesheet" href="dist/themes/light.css">',
+      '<link rel="stylesheet" href="dist/styles/index.css">',
+    ],
+    // Enable testing with firefox.
+    // TODO: As soon as shoelace enabled it on their side, this can be removed
+    // TODO: We add concurrency: 1 to prevent the issue at https://github.com/modernweb-dev/web/issues/2374
+    [
       `// Firefox started failing randomly so we're temporarily disabling it here. This could be a rogue test, not really
     // sure what's happening.
     // playwrightLauncher({ product: 'firefox' }),`,
@@ -42,7 +55,11 @@ import synTestPlugins from './scripts/tests/index.js';`,
     // @see https://github.com/modernweb-dev/web/issues/2374
     playwrightLauncher({ product: 'firefox', concurrency: 1 }),
 `,
-  );
+    ],
+  ], nextContent);
+
+  // add mocha config to fail if somewhere is `.only` used in a test
+  // );
   return {
     content: nextContent,
     path,

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -1,7 +1,6 @@
 import type { CSSResultGroup } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { html } from 'lit';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { property, query, state } from 'lit/decorators.js';
 import { animateTo, stopAnimations } from '../../internal/animate.js';
 import { defaultValue } from '../../internal/default-value.js';
@@ -18,11 +17,12 @@ import SynergyElement from '../../internal/synergy-element.js';
 import SynIcon from '../icon/icon.component.js';
 import SynPopup from '../popup/popup.component.js';
 import type { SynergyFormControl } from '../../internal/synergy-element.js';
-import type SynOption from '../option/option.component.js';
+import SynOption from '../option/option.component.js';
 import type SynOptGroup from '../optgroup/optgroup.js';
 import styles from './combobox.styles.js';
 import customStyles from './combobox.custom.styles.js';
 import {
+  createOptionFromDifferentTypes,
   filterOnlyOptgroups, getAllOptions, getAssignedElementsForSlot, normalizeString,
 } from './utils.js';
 import { scrollIntoView } from '../../internal/scroll.js';
@@ -105,6 +105,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   /** The last value of a syn-option, that was selected by click or via keyboard navigation */
   private lastOptionValue = '';
 
+  private isOptionRendererTriggered = false;
+
   @query('.combobox') popup: SynPopup;
 
   @query('.combobox__inputs') combobox: HTMLSlotElement;
@@ -115,8 +117,6 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   @query('.combobox__listbox') listbox: HTMLSlotElement;
 
-  @query('.listbox__options') filteredWrapper: HTMLSlotElement;
-
   @query('slot:not([name])') private defaultSlot: HTMLSlotElement;
 
   @state() private hasFocus = false;
@@ -125,7 +125,9 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   @state() selectedOption: SynOption | undefined;
 
-  @state() filteredOptions: Array<SynOption | SynOptGroup> = [];
+  @state() numberFilteredOptions = 0;
+
+  @state() cachedOptions: SynOption [] = [];
 
   /** The name of the combobox, submitted as a name/value pair with form data. */
   @property() name = '';
@@ -206,7 +208,11 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
    */
   // eslint-disable-next-line class-methods-use-this
   @property() filter: (option: SynOption, queryString: string) => boolean = (option, queryStr) => {
-    const normalizedOption = normalizeString(option.getTextLabel());
+    let content = option?.textContent || '';
+    if (option instanceof SynOption) {
+      content = option.getTextLabel();
+    }
+    const normalizedOption = normalizeString(content);
     const normalizedQuery = normalizeString(queryStr);
     return normalizedOption.includes(normalizedQuery);
   };
@@ -232,29 +238,6 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     // initially set the displayLabel if the value was set via property initially
     this.displayLabel = this.value;
     this.formControlController.updateValidity();
-  }
-
-  protected get options() {
-    const renderOption = (option: SynOption) => {
-      const queryString = this.displayInput.value;
-      const optionHtml = this.getOption(option, queryString);
-      return html`${typeof optionHtml === 'string' ? unsafeHTML(optionHtml) : optionHtml}`;
-    };
-
-    return this.filteredOptions.map((item: SynOption | SynOptGroup) => {
-      if (item.tagName.toLowerCase() === 'syn-optgroup') {
-        Array.from(item.children).forEach((option: HTMLElement) => {
-          if (option.tagName.toLowerCase() === 'syn-option') {
-            // @todo: What was the intention of this?
-            // renderOption does nothing with the group itself
-            renderOption(option as SynOption);
-          }
-        });
-
-        return item;
-      }
-      return renderOption(item as SynOption);
-    });
   }
 
   private addOpenListeners() {
@@ -421,13 +404,14 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     this.displayInput.focus();
   }
 
-  private handleComboboxMouseDown() {
+  private handleComboboxMouseDown(event: MouseEvent) {
     // Ignore disabled controls
     if (this.disabled) {
       return;
     }
 
     const toggleListboxOpen = () => (this.open ? this.hide() : this.show());
+    event.preventDefault();
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     toggleListboxOpen().then(() => {
@@ -527,7 +511,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   }
 
   private getAllFilteredOptions() {
-    return [...this.filteredWrapper.querySelectorAll<SynOption>('syn-option')];
+    return this.getSlottedOptions().filter(option => !option.hidden);
   }
 
   private getCurrentOption() {
@@ -587,8 +571,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     this.formControlController.emitInvalidEvent(event);
   }
 
-  @watch('filter', { waitUntilFirstUpdate: true })
-  handleFilterChange() {
+  @watch(['filter', 'getOption'], { waitUntilFirstUpdate: true })
+  handlePropertiesChange() {
     this.createComboboxOptionsFromQuery(this.value);
   }
 
@@ -616,7 +600,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   @watch('open', { waitUntilFirstUpdate: true })
   async handleOpenChange() {
     if (this.open && !this.disabled) {
-      if (this.filteredOptions.length === 0) {
+      if (this.numberFilteredOptions === 0) {
         // Don't open the listbox if there are no options
         this.open = false;
         this.emit('syn-error');
@@ -712,44 +696,57 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     this.displayInput.blur();
   }
 
+  /* eslint-disable no-param-reassign, @typescript-eslint/no-floating-promises */
   private createComboboxOptionsFromQuery(queryString: string) {
-    const optgroups: SynOptGroup[] = [];
+    this.numberFilteredOptions = 0;
+    this.isOptionRendererTriggered = true;
 
-    this.filteredOptions = this.getSlottedOptions()
-      .filter(option => this.filter(option, queryString) || queryString === '')
-      .map(option => {
-        const clonedOption = option.cloneNode(true) as SynOption;
+    // Update the syn-option's based on the query string and getOption
+    this.getSlottedOptions()
+      .forEach(option => {
+        // Use the original cached option, to do changes on it
+        const cachedOption = this.cachedOptions.find(o => o.id === option.id) || option;
+        const optionResult = this.getOption(cachedOption, queryString);
+        let updatedOption = createOptionFromDifferentTypes(optionResult);
 
-        // Check if the option has a syn-optgroup as parent
-        const hasOptgroup = option.parentElement?.tagName.toLowerCase() === 'syn-optgroup';
-        if (!hasOptgroup) {
-          return clonedOption;
+        // The type of the getOption function is incorrect, therefore use the original option
+        if (!updatedOption) {
+          updatedOption = cachedOption;
         }
 
-        const optgroup = option.parentElement as SynOptGroup;
-        const filteredOptgroup = optgroups.find((el) => el.id === optgroup.id);
+        const hideOption = !(this.filter(updatedOption, queryString) || queryString === '');
+        updatedOption.hidden = hideOption;
+        option.replaceWith(updatedOption);
 
-        // Check if the optgroup was already added to the filteredOptions.
-        // It should only be added once!
-        if (filteredOptgroup) {
-          filteredOptgroup?.appendChild(clonedOption);
-          return undefined;
+        if (!hideOption) {
+          this.numberFilteredOptions += 1;
         }
+      });
 
-        const clonedOptgroup = optgroup.cloneNode() as SynOptGroup;
-        clonedOptgroup.appendChild(clonedOption);
-        optgroups.push(clonedOptgroup);
-        return clonedOptgroup;
-      })
-      // we need to remove the undefined values here
-      .filter(Boolean) as Array<SynOption | SynOptGroup>;
+    // Update the syn-optgroup's if available
+    const visibleOptgroups = this.getSlottedOptGroups().filter(optgroup => {
+      const options = getAllOptions(Array.from(optgroup.children) as HTMLElement[]).flat();
+      const isVisible = options.some(option => !option.hidden);
+      optgroup.hidden = !isVisible;
+      return isVisible;
+    });
+
+    // Hide the divider of the first visible optgroup, as it can unfortunately not be hidden via css
+    visibleOptgroups[0]?.style.setProperty('--display-divider', 'none');
+
+    // This is needed so the component does not endlessly rerender,
+    // because the slot change event is endlessly retriggered otherwise.
+    setTimeout(() => {
+      this.isOptionRendererTriggered = false;
+    }, 0);
   }
+  /* eslint-enable no-param-reassign, @typescript-eslint/no-floating-promises */
 
   private async handleInput() {
     const inputValue = this.displayInput.value;
     this.value = inputValue;
     await this.updateComplete;
-    this.open = this.filteredWrapper.children.length > 0;
+    this.open = this.numberFilteredOptions > 0;
     this.setSelectedOption(undefined);
 
     this.formControlController.updateValidity();
@@ -778,32 +775,38 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     return filterOnlyOptgroups(getAssignedElementsForSlot(this.defaultSlot));
   }
 
-  /* eslint-disable no-param-reassign, @typescript-eslint/no-floating-promises */
+  /* eslint-disable no-param-reassign, @typescript-eslint/no-floating-promises, complexity */
   /* @internal - used by options to update labels */
   public handleDefaultSlotChange() {
-    // Rerun this handler when <syn-option> is registered
-    if (!customElements.get('syn-option')) {
-      customElements.whenDefined('syn-option').then(() => this.handleDefaultSlotChange());
-      return;
-    }
+    if (!this.isOptionRendererTriggered) {
+      // Rerun this handler when <syn-option> is registered
+      if (!customElements.get('syn-option')) {
+        customElements.whenDefined('syn-option').then(() => this.handleDefaultSlotChange());
+        return;
+      }
 
-    const slottedOptions = this.getSlottedOptions();
-    const slottedOptgroups = this.getSlottedOptGroups();
-    slottedOptions.forEach((option, index) => {
-      option.id = option.id || `syn-combobox-option-${index}`;
-    });
+      const slottedOptions = this.getSlottedOptions();
+      const slottedOptgroups = this.getSlottedOptGroups();
 
-    slottedOptgroups.forEach((optgroup, index) => {
-      optgroup.id = optgroup.id || `syn-combobox-optgroup-${index}`;
-    });
+      slottedOptions.forEach((option, index) => {
+        option.id = option.id || `syn-combobox-option-${index}`;
+      });
 
-    this.createComboboxOptionsFromQuery(this.value);
+      slottedOptgroups.forEach((optgroup, index) => {
+        optgroup.id = optgroup.id || `syn-combobox-optgroup-${index}`;
+      });
 
-    if (this.hasFocus && this.value.length > 0 && !this.open) {
-      this.show();
+      // Cache the slotted options
+      this.cachedOptions = [...slottedOptions];
+
+      this.createComboboxOptionsFromQuery(this.value);
+
+      if (this.hasFocus && this.value.length > 0 && !this.open) {
+        this.show();
+      }
     }
   }
-  /* eslint-enable no-param-reassign, @typescript-eslint/no-floating-promises */
+  /* eslint-enable no-param-reassign, @typescript-eslint/no-floating-promises, complexity */
 
   /* eslint-disable @typescript-eslint/unbound-method */
   // eslint-disable-next-line complexity
@@ -945,9 +948,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
               @mouseup=${this.handleOptionClick}
             >
               <div class="listbox__options" part="filtered-listbox">
-                ${this.options}
+                <slot @slotchange=${this.handleDefaultSlotChange}></slot>      
               </div>
-              <slot @slotchange=${this.handleDefaultSlotChange}></slot>      
             </div>
           </syn-popup>
         </div>

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -701,6 +701,12 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     this.numberFilteredOptions = 0;
     this.isOptionRendererTriggered = true;
 
+    // This is needed for angular. For some reason the handleDefaultSlotChange is not triggered
+    // initially and therefore the cachedOptions are not set.
+    if (this.cachedOptions.length === 0) {
+      this.cacheSlottedOptionsAndOptgroups();
+    }
+
     // Update the syn-option's based on the query string and getOption
     this.getSlottedOptions()
       .forEach(option => {
@@ -775,7 +781,25 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     return filterOnlyOptgroups(getAssignedElementsForSlot(this.defaultSlot));
   }
 
-  /* eslint-disable no-param-reassign, @typescript-eslint/no-floating-promises, complexity */
+  /* eslint-disable no-param-reassign */
+  private cacheSlottedOptionsAndOptgroups() {
+    const slottedOptions = this.getSlottedOptions();
+    const slottedOptgroups = this.getSlottedOptGroups();
+
+    slottedOptions.forEach((option, index) => {
+      option.id = option.id || `syn-combobox-option-${index}`;
+    });
+
+    slottedOptgroups.forEach((optgroup, index) => {
+      optgroup.id = optgroup.id || `syn-combobox-optgroup-${index}`;
+    });
+
+    // Cache the slotted options
+    this.cachedOptions = [...slottedOptions];
+  }
+  /* eslint-enable no-param-reassign */
+
+  /* eslint-disable @typescript-eslint/no-floating-promises, complexity */
   /* @internal - used by options to update labels */
   public handleDefaultSlotChange() {
     if (!this.isOptionRendererTriggered) {
@@ -785,19 +809,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
         return;
       }
 
-      const slottedOptions = this.getSlottedOptions();
-      const slottedOptgroups = this.getSlottedOptGroups();
-
-      slottedOptions.forEach((option, index) => {
-        option.id = option.id || `syn-combobox-option-${index}`;
-      });
-
-      slottedOptgroups.forEach((optgroup, index) => {
-        optgroup.id = optgroup.id || `syn-combobox-optgroup-${index}`;
-      });
-
-      // Cache the slotted options
-      this.cachedOptions = [...slottedOptions];
+      this.cacheSlottedOptionsAndOptgroups();
 
       this.createComboboxOptionsFromQuery(this.value);
 
@@ -806,7 +818,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
       }
     }
   }
-  /* eslint-enable no-param-reassign, @typescript-eslint/no-floating-promises, complexity */
+  /* eslint-enable @typescript-eslint/no-floating-promises, complexity */
 
   /* eslint-disable @typescript-eslint/unbound-method */
   // eslint-disable-next-line complexity

--- a/packages/components/src/components/combobox/combobox.custom.styles.ts
+++ b/packages/components/src/components/combobox/combobox.custom.styles.ts
@@ -1,34 +1,12 @@
 import { css } from 'lit';
 
 export default css`
-  /** 
-   * Hide the default slot, because the filtered options are rendered in the listbox__options
-   */
-  .combobox__listbox slot:not([name]) {
-    display: none;
-  }
-
-  /**
-   * The filtered options
-   */
-  .listbox__options syn-option mark {
-    background-color: transparent;
-    color: var(--syn-color-neutral-950);
-    font: var(--syn-body-medium-bold);
-  }
-
-  .listbox__options syn-option[aria-selected='true'] mark {
-    color: var(--syn-color-neutral-0);
-  }
-
   .combobox:not(.combobox--disabled) .combobox__display-input {
     cursor: text;
   }
 
-  /**
-   * Make sure to hide the syn-divider for the first syn-optgroup
-   */
-  .listbox__options syn-optgroup:first-of-type::part(divider) {
+  .listbox__options ::slotted(syn-option[hidden]), 
+  .listbox__options ::slotted(syn-optgroup[hidden]) {
     display: none;
   }
 `;

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -161,8 +161,7 @@ describe('<syn-combobox>', () => {
 
       await el.show();
 
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const secondOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[1];
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
       const changeHandler = sinon.spy();
       const inputHandler = sinon.spy();
 
@@ -264,8 +263,7 @@ describe('<syn-combobox>', () => {
 
       await clickOnElement(el);
       await aTimeout(500);
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const secondOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[1];
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
 
       await clickOnElement(secondOption);
       await el.updateComplete;
@@ -290,8 +288,7 @@ describe('<syn-combobox>', () => {
       await el.updateComplete;
       await aTimeout(500);
 
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const firstOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[0];
+      const firstOption = el.querySelectorAll<SynOption>('syn-option')[0];
 
       expect(displayInput.getAttribute('aria-expanded')).to.equal('true');
       expect(firstOption.getAttribute('aria-selected')).to.equal('true');
@@ -313,8 +310,8 @@ describe('<syn-combobox>', () => {
       await el.updateComplete;
       await aTimeout(500);
 
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const lastOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[filteredListbox.children.length - 1];
+      const filteredOptions = el.querySelectorAll<SynOption>('syn-option');
+      const lastOption = filteredOptions[filteredOptions.length - 1];
 
       expect(displayInput.getAttribute('aria-expanded')).to.equal('true');
       expect(lastOption.getAttribute('aria-selected')).to.equal('true');
@@ -335,11 +332,12 @@ describe('<syn-combobox>', () => {
       await sendKeys({ press: 'e' });
       await el.updateComplete;
 
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const filteredOptions = filteredListbox.querySelectorAll<SynOption>('syn-option');
+      const allOptions = el.querySelectorAll<SynOption>('syn-option');
 
       expect(displayInput.getAttribute('aria-expanded')).to.equal('true');
-      expect(filteredOptions.length).to.equal(2);
+      expect(allOptions[0]).not.to.be.displayed;
+      expect(allOptions[1]).to.be.displayed;
+      expect(allOptions[2]).to.be.displayed;
     });
 
     it('should not open the listbox when a letter key is pressed with syn-combobox is on focus with no appropriate options', async () => {
@@ -356,29 +354,14 @@ describe('<syn-combobox>', () => {
       await sendKeys({ press: 'f' });
       await el.updateComplete;
 
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const filteredOptions = filteredListbox.querySelectorAll<SynOption>('syn-option');
+      const filteredListbox = el.shadowRoot!.querySelector('.combobox__listbox')!;
+      const allOptions = el.querySelectorAll<SynOption>('syn-option');
 
       expect(displayInput.getAttribute('aria-expanded')).to.equal('false');
-      expect(filteredOptions.length).to.equal(0);
-    });
-
-    it('should not open the listbox when ctrl + R is pressed with syn-combobox is on focus', async () => {
-      const el = await fixture<SynCombobox>(html`
-        <syn-combobox>
-          <syn-option value="option-1">Option 1</syn-option>
-          <syn-option value="option-2">Option 2</syn-option>
-          <syn-option value="option-3">Option 3</syn-option>
-        </syn-combobox>
-      `);
-      const displayInput = el.shadowRoot!.querySelector<HTMLInputElement>('.combobox__display-input')!;
-
-      el.focus();
-      await sendKeys({ down: 'Control' });
-      await sendKeys({ press: 'r' });
-      await sendKeys({ up: 'Control' });
-      await el.updateComplete;
-      expect(displayInput.getAttribute('aria-expanded')).to.equal('false');
+      expect(filteredListbox.getAttribute('aria-expanded')).to.equal('false');
+      expect(allOptions[0]).not.to.be.displayed;
+      expect(allOptions[1]).not.to.be.displayed;
+      expect(allOptions[2]).not.to.be.displayed;
     });
 
     it('should not open the listbox when ctrl + R is pressed with syn-combobox is on focus', async () => {
@@ -634,8 +617,7 @@ describe('<syn-combobox>', () => {
 
       await el.show();
 
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const secondOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[1];
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
 
       await clickOnElement(secondOption);
       await el.updateComplete;
@@ -664,8 +646,7 @@ describe('<syn-combobox>', () => {
       expect(el.hasAttribute('data-user-valid')).to.be.false;
 
       await el.show();
-      const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-      const secondOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[1];
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
 
       await clickOnElement(secondOption);
       el.value = '';
@@ -1004,53 +985,70 @@ describe('<syn-combobox>', () => {
     expect(errorHandler).to.have.been.calledOnce;
   });
 
-  it.only('should update the filtered list when an option changes', async () => {
+  it('should update the filtered list when an option changes', async () => {
     const el = await fixture<SynCombobox>(html`
-      <syn-combobox>
+      <syn-combobox value="opt">
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>
       </syn-combobox>
     `);
-    const secondSlottedOption = el.querySelectorAll('syn-option')[1];
+    const firstOption = el.querySelectorAll('syn-option')[0];
+    const secondOption = el.querySelectorAll('syn-option')[1];
+    const thirdOption = el.querySelectorAll('syn-option')[2];
 
     await el.show();
-    const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-    const secondOption = filteredListbox.querySelectorAll('syn-option')[1];
 
-    expect(secondOption.getTextLabel()).to.equal('Option 2');
+    expect(firstOption).to.be.displayed;
+    expect(secondOption).to.be.displayed;
+    expect(thirdOption).to.be.displayed;
 
-    secondSlottedOption.textContent = 'updated';
+    secondOption.textContent = 'updated';
     await el.updateComplete;
     await aTimeout(0);
-    const secondUpdatedOption = filteredListbox.querySelectorAll('syn-option')[1];
 
-    expect(secondUpdatedOption.getTextLabel()).to.equal('updated');
+    expect(firstOption).to.be.displayed;
+    expect(secondOption).not.to.be.displayed;
+    expect(thirdOption).to.be.displayed;
   });
 
-  it('should update the filtered list when an option is added dynamically', async () => {
+  it('should update the filtered list when options are added dynamically', async () => {
     const el = await fixture<SynCombobox>(html`
-      <syn-combobox>
+      <syn-combobox value="opt">
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>
       </syn-combobox>
     `);
-    const newOption = document.createElement('syn-option');
-    newOption.value = 'option-4';
-    newOption.textContent = 'Option 4';
+
+    const visibleOptions = el.querySelectorAll('syn-option:not([hidden])');
 
     await el.show();
-    const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
 
-    expect(filteredListbox.children.length).to.equal(3);
+    expect(visibleOptions.length).to.equal(3);
 
-    el.appendChild(newOption);
-    const slotWrapper = el.shadowRoot!.querySelector('.combobox__listbox')!;
-    await oneEvent(slotWrapper, 'slotchange');
+    const visibleOption = document.createElement('syn-option');
+    visibleOption.value = 'option-4';
+    visibleOption.textContent = 'Option 4';
+
+    const notVisibleOption = document.createElement('syn-option');
+    notVisibleOption.value = 'not-visible';
+    notVisibleOption.textContent = 'Not visible';
+
+    el.appendChild(visibleOption);
+    el.appendChild(notVisibleOption);
+
     await el.updateComplete;
 
-    expect(filteredListbox.children.length).to.equal(4);
+    const newVisibleOptions = el.querySelectorAll('syn-option:not([hidden])');
+    expect(newVisibleOptions.length).to.equal(4);
+
+    const allOptions = el.querySelectorAll('syn-option');
+    expect(allOptions[0]).to.be.displayed;
+    expect(allOptions[1]).to.be.displayed;
+    expect(allOptions[2]).to.be.displayed;
+    expect(allOptions[3]).to.be.displayed;
+    expect(allOptions[4]).not.to.be.displayed;
   });
 
   it('should use the custom filter if the filter property is used', async () => {
@@ -1068,41 +1066,12 @@ describe('<syn-combobox>', () => {
     await el.show();
     await el.updateComplete;
 
-    const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-    const options = filteredListbox.querySelectorAll('syn-option');
+    const options = el.querySelectorAll('syn-option');
 
     expect(filterHandler).to.have.been.calledThrice;
-    expect(options.length).to.equal(2);
-  });
-
-  it('should use the custom getOption renderer if the getOption property is used', async () => {
-    const el = await fixture<SynCombobox>(html`
-      <syn-combobox>
-        <syn-option value="option-1">Option 1</syn-option>
-        <syn-option value="option-2">Option 2</syn-option>
-        <syn-option value="option-3">Option 3</syn-option>
-      </syn-combobox>
-    `);
-
-    const getOptionHandler = sinon.spy((option: SynOption) => {
-      const updatedText = option.getTextLabel().concat(' - custom');
-      // eslint-disable-next-line no-param-reassign
-      option.textContent = updatedText;
-      return option;
-    });
-
-    el.getOption = getOptionHandler;
-
-    await el.show();
-    await el.updateComplete;
-
-    const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-    const options = filteredListbox.querySelectorAll('syn-option');
-
-    options.forEach((option, index) => {
-      expect(option.getTextLabel()).to.equal(`Option ${index + 1} - custom`);
-    });
-    expect(getOptionHandler).to.have.been.calledThrice;
+    expect(options[0]).to.be.displayed;
+    expect(options[1]).not.to.be.displayed;
+    expect(options[2]).to.be.displayed;
   });
 
   it('should work with options that do not have a value', async () => {
@@ -1115,13 +1084,114 @@ describe('<syn-combobox>', () => {
     `);
     await el.show();
 
-    const filteredListbox = el.shadowRoot!.querySelector('.listbox__options')!;
-    const secondOption = filteredListbox.querySelectorAll<SynOption>('syn-option')[1];
+    const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
 
     await clickOnElement(secondOption);
     await el.updateComplete;
 
     expect(el.value).to.equal('Option 2');
+  });
+
+  describe('when using getOption', () => {
+    it('should use the HTMLElement getOption renderer if the getOption property is used', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      const getOptionHandler = sinon.spy((option: SynOption) => {
+        // eslint-disable-next-line no-param-reassign
+        option.textContent = `HtmlElement - ${option.getTextLabel()}`;
+        return option;
+      });
+
+      el.getOption = getOptionHandler;
+
+      await el.show();
+      await el.updateComplete;
+
+      const options = el.querySelectorAll('syn-option');
+
+      options.forEach((option, index) => {
+        expect(option.getTextLabel()).to.equal(`HtmlElement - Option ${index + 1}`);
+      });
+      expect(getOptionHandler).to.have.been.calledThrice;
+    });
+
+    it('should use the string getOption renderer if the getOption property is used', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      const getOptionHandler = sinon.spy((option: SynOption) => `<syn-option>String - ${option.getTextLabel()}</syn-option>`);
+
+      el.getOption = getOptionHandler;
+
+      await el.show();
+      await el.updateComplete;
+
+      const options = el.querySelectorAll('syn-option');
+
+      options.forEach((option, index) => {
+        expect(option.getTextLabel()).to.equal(`String - Option ${index + 1}`);
+      });
+      expect(getOptionHandler).to.have.been.calledThrice;
+    });
+
+    it('should use the TemplateResult getOption renderer if the getOption property is used', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      const getOptionHandler = sinon.spy((option: SynOption) => html`<syn-option>Template - ${option.getTextLabel()}</syn-option>`);
+
+      el.getOption = getOptionHandler;
+
+      await el.show();
+      await el.updateComplete;
+
+      const options = el.querySelectorAll('syn-option');
+
+      options.forEach((option, index) => {
+        expect(option.getTextLabel()).to.equal(`Template - Option ${index + 1}`);
+      });
+      expect(getOptionHandler).to.have.been.calledThrice;
+    });
+
+    it('should use the original option if incorrect getOption renderer is used', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      const getOptionHandler = sinon.spy((option: SynOption) => `<div>Invalid - ${option.getTextLabel()}</div>`);
+
+      el.getOption = getOptionHandler;
+
+      await el.show();
+      await el.updateComplete;
+
+      const options = el.querySelectorAll('syn-option');
+
+      options.forEach((option, index) => {
+        expect(option.getTextLabel()).to.equal(`Option ${index + 1}`);
+      });
+      expect(getOptionHandler).to.have.been.calledThrice;
+    });
   });
 
   runFormControlBaseTests('syn-combobox');

--- a/packages/components/src/components/combobox/option-renderer.ts
+++ b/packages/components/src/components/combobox/option-renderer.ts
@@ -1,4 +1,4 @@
-import type { TemplateResult } from 'lit';
+import { type TemplateResult } from 'lit';
 import type SynOption from '../option/option.component.js';
 
 /**
@@ -24,6 +24,28 @@ export const defaultOptionRenderer: OptionRenderer = (option: SynOption) => opti
 export const highlightOptionRenderer: OptionRenderer = (option: SynOption, query: string) => {
   if (!query) {
     return option;
+  }
+
+  const combobox = option.closest('syn-combobox');
+  // check if there is already a style for highlighting appended if not append one
+  // This is unfortunately needed as it is not possible to do something like this in css:
+  // .listbox__options ::slotted(syn-option mark)
+  if (combobox && !combobox?.querySelector('#syn-highlight-style')) {
+    const style = document.createElement('style');
+    style.id = 'syn-highlight-style';
+
+    style.textContent = `
+      syn-option mark {
+        background-color: transparent;
+        color: var(--syn-color-neutral-950);
+        font: var(--syn-body-medium-bold);
+      }
+      syn-option[aria-selected='true'] mark {
+        color: var(--syn-color-neutral-0);
+      }
+    `;
+
+    combobox.appendChild(style);
   }
 
   const clonedOption = option.cloneNode(true) as SynOption;

--- a/packages/components/src/components/combobox/option-renderer.ts
+++ b/packages/components/src/components/combobox/option-renderer.ts
@@ -26,28 +26,6 @@ export const highlightOptionRenderer: OptionRenderer = (option: SynOption, query
     return option;
   }
 
-  const combobox = option.closest('syn-combobox');
-  // check if there is already a style for highlighting appended if not append one
-  // This is unfortunately needed as it is not possible to do something like this in css:
-  // .listbox__options ::slotted(syn-option mark)
-  if (combobox && !combobox?.querySelector('#syn-highlight-style')) {
-    const style = document.createElement('style');
-    style.id = 'syn-highlight-style';
-
-    style.textContent = `
-      syn-option mark {
-        background-color: transparent;
-        color: var(--syn-color-neutral-950);
-        font: var(--syn-body-medium-bold);
-      }
-      syn-option[aria-selected='true'] mark {
-        color: var(--syn-color-neutral-0);
-      }
-    `;
-
-    combobox.appendChild(style);
-  }
-
   const clonedOption = option.cloneNode(true) as SynOption;
   const optionLabel = clonedOption.getTextLabel();
   const queryIndex = optionLabel.toLowerCase().indexOf(query.toLowerCase());
@@ -55,6 +33,7 @@ export const highlightOptionRenderer: OptionRenderer = (option: SynOption, query
 
   const mark = document.createElement('mark');
   mark.textContent = optionLabel.slice(queryIndex, queryIndex + query.length);
+  mark.classList.add('syn-highlight-style');
 
   const exchangedText = optionLabel.replace(new RegExp(query, 'i'), mark.outerHTML);
   const previousContent = clonedOption.innerHTML.slice(0, indexLabel);

--- a/packages/components/src/components/combobox/utils.ts
+++ b/packages/components/src/components/combobox/utils.ts
@@ -1,3 +1,5 @@
+import { type TemplateResult, html, render } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type SynOptGroup from '../optgroup/optgroup.js';
 import type SynOption from '../option/option.component.js';
 
@@ -49,3 +51,46 @@ export const filterOnlyOptgroups = (items: HTMLElement[]) => items.filter(isOptg
  * @returns The normalized string
  */
 export const normalizeString = (str: string) => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+
+/**
+ * Creates a `SynOption` element from a given `TemplateResult`.
+ * We assume that the given `TemplateResult` is a <syn-option>.
+ *
+ * @param template - The `TemplateResult` to be rendered into a `SynOption`.
+ * @returns The created SynOption element
+ */
+export const createElementFromTemplateResult = (template: TemplateResult) => {
+  const container = document.createElement('div');
+  render(template, container);
+  return container.firstElementChild as HTMLElement;
+};
+
+/**
+ * This function takes an input of type `TemplateResult`, `string`, or `HTMLElement`
+ * and creates an SynOption from it.
+ *
+ * @param option - The option which can be of type `TemplateResult`, `string` or `HTMLElement`.
+ * @returns The created SynOption or undefined if the option was not a valid type.
+ */
+export const createOptionFromDifferentTypes = (option: TemplateResult | string | HTMLElement) => {
+  if (!option) return undefined;
+
+  const getOptionOrUndefined = (element: HTMLElement) => (element.tagName.toLocaleLowerCase() === 'syn-option' ? element as SynOption : undefined);
+
+  if (option instanceof HTMLElement) {
+    return getOptionOrUndefined(option);
+  }
+
+  if (typeof option === 'string') {
+    const template = html`${unsafeHTML(option)}`;
+    const element = createElementFromTemplateResult(template);
+    return getOptionOrUndefined(element);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(option, '_$litType$')) {
+    const element = createElementFromTemplateResult(option);
+    return getOptionOrUndefined(element);
+  }
+
+  return undefined;
+};

--- a/packages/components/src/components/combobox/utils.ts
+++ b/packages/components/src/components/combobox/utils.ts
@@ -65,6 +65,8 @@ export const createElementFromTemplateResult = (template: TemplateResult) => {
   return container.firstElementChild as HTMLElement;
 };
 
+const getOptionOrUndefined = (element: HTMLElement) => (element.tagName.toLocaleLowerCase() === 'syn-option' ? element as SynOption : undefined);
+
 /**
  * This function takes an input of type `TemplateResult`, `string`, or `HTMLElement`
  * and creates an SynOption from it.
@@ -74,8 +76,6 @@ export const createElementFromTemplateResult = (template: TemplateResult) => {
  */
 export const createOptionFromDifferentTypes = (option: TemplateResult | string | HTMLElement) => {
   if (!option) return undefined;
-
-  const getOptionOrUndefined = (element: HTMLElement) => (element.tagName.toLocaleLowerCase() === 'syn-option' ? element as SynOption : undefined);
 
   if (option instanceof HTMLElement) {
     return getOptionOrUndefined(option);

--- a/packages/components/src/components/optgroup/optgroup.styles.ts
+++ b/packages/components/src/components/optgroup/optgroup.styles.ts
@@ -52,4 +52,8 @@ export default css`
     color: var(--syn-color-neutral-800);
     font-size: var(--syn-spacing-large);
   }
+
+  .optgroup__options ::slotted(syn-option[hidden]) {
+    display: none;
+  }
 `;

--- a/packages/components/src/components/option/option.component.ts
+++ b/packages/components/src/components/option/option.component.ts
@@ -43,6 +43,8 @@ export default class SynOption extends SynergyElement {
   // @ts-expect-error - Controller is currently unused
   private readonly localize = new LocalizeController(this);
 
+  private isInitialized = false;
+
   @query('.option__label') defaultSlot: HTMLSlotElement;
 
   @state() current = false; // the user has keyed into the option, but hasn't selected it yet (shows a highlight)
@@ -66,19 +68,23 @@ export default class SynOption extends SynergyElement {
   }
 
   private handleDefaultSlotChange() {
-    // When the label changes, tell the controller to update
-    customElements.whenDefined('syn-combobox').then(() => {
-      const controller = this.closest('syn-combobox');
-      if (controller) {
-        controller.handleDefaultSlotChange();
-      }
-    });
-    customElements.whenDefined('syn-select').then(() => {
-      const controller = this.closest('syn-select');
-      if (controller) {
-        controller.handleDefaultSlotChange();
-      }
-    });
+      if(this.isInitialized) {
+      // When the label changes, tell the controller to update
+      customElements.whenDefined('syn-combobox').then(() => {
+        const controller = this.closest('syn-combobox');
+        if (controller) {
+          controller.handleDefaultSlotChange();
+        }
+      });
+      customElements.whenDefined('syn-select').then(() => {
+        const controller = this.closest('syn-select');
+        if (controller) {
+          controller.handleDefaultSlotChange();
+        }
+      });
+    } else {
+      this.isInitialized = true;
+    }
   }
 
   private handleMouseEnter() {

--- a/packages/components/src/components/option/option.custom.styles.ts
+++ b/packages/components/src/components/option/option.custom.styles.ts
@@ -49,4 +49,15 @@ export default css`
   .option--current .option__suffix::slotted(syn-icon) {
     color: var(--syn-color-neutral-0);
   }
+
+  /* This is needed for the highlight styling of the options in syn-combobox */
+  .option__label::slotted(.syn-highlight-style) {
+    background-color: transparent;
+    color: var(--syn-color-neutral-950);
+    font: var(--syn-body-medium-bold);
+  }
+
+  :host([aria-selected='true']) .option__label::slotted(.syn-highlight-style) {
+    color: var(--syn-color-neutral-0);
+  }
 `;

--- a/packages/components/web-test-runner.config.js
+++ b/packages/components/web-test-runner.config.js
@@ -21,6 +21,7 @@ export default {
   testFramework: {
     config: {
       timeout: 3000,
+      forbidOnly: true,
       retries: 1
     }
   },
@@ -44,8 +45,8 @@ export default {
     <html lang="en-US">
       <head></head>
       <body>
-        <link rel="stylesheet" href="node_modules/@synergy-design-system/tokens/dist/themes/light.css">
         <link rel="stylesheet" href="dist/styles/index.css">
+        <link rel="stylesheet" href="node_modules/@synergy-design-system/tokens/dist/themes/light.css">
         <script>
           window.process = {env: { NODE_ENV: "production" }}
         </script>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes multiple issues with the syn-combobox:
- syn-option's do not honor applied styles 
- syn-optgroup not working correctly (e.g. no slot is working, the label property in react)
- toggling open state with the expand icon not always working correctly

the first two issues are fixed by no longer cloning the syn-options and working with the clones, but just working with the syn-options themselves.

Additionally this PR fixes a performance issue, which was added via shoelace update in the syn-option.

### 🎫 Issues
Closes #719 , #712, #714 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

### Issue #719 
When using the combobox within a [MUI dialog](https://mui.com/material-ui/react-dialog/) the open state can now be toggled correctly via expand icon:
To test this install MUI in the react demo application: 
```
pnpm add @mui/material @emotion/react @emotion/styled
```

and use following code, to check that the open state is toggled correctly:

```
import { Dialog, DialogContent } from '@mui/material';
import { SynCombobox, SynOption } from '@synergy-design-system/react';
import type { FC } from 'react';

export const Home: FC = () => (
  <>
    <Dialog open>
      <DialogContent>
        <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
        <SynCombobox>
          <SynOption>opt 1</SynOption>
          <SynOption>opt 2</SynOption>
          <SynOption>opt 3</SynOption>
        </SynCombobox>
      </DialogContent>
    </Dialog>
  </>
);
```

### Issue #712 

The syn-optgroup is now working correctly without the need of workarounds. The label property in react and vue is now working correctly and the all slot (label, prefix, suffix) are also working.

Before: https://codepen.io/kirchsuSICKAG/pen/pvzegMJ?editors=1110
    --> first optgroup uses label slot which is not working
    --> second optgroup uses prefix and suffix slot which are not working

### Issue #714 
Now the applied styles to syn-option are honored as we no longer clone the nodes, but use the original ones.

Before: https://codepen.io/kirchsuSICKAG/pen/pvzegMJ?editors=1110
   --> syn-options should have red text color, but is not applied


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
