### PR TITLE
feat: ✨ range: restrain knobs via property

### DIFF
--- a/packages/angular/src/components/range.component.ts
+++ b/packages/angular/src/components/range.component.ts
@@ -217,6 +217,19 @@ export class SynRangeComponent {
   }
 
   /**
+   * Set to true to restrict the movement of knobs
+   */
+  @Input()
+  set restrictMovement(v: '' | SynRange['restrictMovement']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.restrictMovement = v === '' || v),
+    );
+  }
+  get restrictMovement(): SynRange['restrictMovement'] {
+    return this.nativeElement.restrictMovement;
+  }
+
+  /**
 * By default, form controls are associated with the nearest containing `<form>` element.
 This attribute allows you to place the form control outside of a form
 and associate it with the form that has this `id`.

--- a/packages/docs/stories/components/range.stories.ts
+++ b/packages/docs/stories/components/range.stories.ts
@@ -377,37 +377,13 @@ export const MultiThumbWithRestrictedMovement = {
   },
   render: () => html`
     <syn-range
-      class="range-restrict-movement"
       value="30 70"
       label="Demo of restricting values"
       min="0"
       max="100"
+      restrict
       step="1"
     ></syn-range>
-    <script type="module">
-      Array
-        .from(document.querySelectorAll('.range-restrict-movement'))
-        .forEach((el) => {
-          el.addEventListener('syn-move', e => {
-            const { detail, target } = e;
-            const values = target.valueAsArray;
-            const { element, value } = detail;
-
-            const [firstThumb, lastThumb] = target.thumbs;
-            const [firstValue, lastValue] = values;
-
-            if (element === firstThumb && value > lastValue) {
-              e.preventDefault();
-              target.valueAsArray = [lastValue, lastValue];
-            }
-            
-            if (element === lastThumb && value < firstValue) {
-              e.preventDefault();
-              target.valueAsArray = [firstValue, firstValue];
-            }
-          });
-        });
-    </script>
   `,
 };
 

--- a/packages/vue/src/components/SynVueRange.vue
+++ b/packages/vue/src/components/SynVueRange.vue
@@ -125,6 +125,11 @@ const props = defineProps<{
   value?: SynRange['value'];
 
   /**
+   * Set to true to restrict the movement of knobs
+   */
+  restrictMovement?: SynRange['restrictMovement'];
+
+  /**
 * By default, form controls are associated with the nearest containing `<form>` element.
 This attribute allows you to place the form control outside of a form
 and associate it with the form that has this `id`.


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a new `restrictMovement` property and corresponding `restrict` attribute to `<syn-range>`. When set to true, the range component will restrict movement of knobs to their next boundaries. If no boundaries are given in any direction, the movement will not be restricted (e.g. the left most knob will be moveable to the `min` position, the right most one to the `right`).

### 🎫 Issues

Closes #602 

## 👩‍💻 Reviewer Notes

I just had to port the custom logic and adjust the already provided story in storybook to make this work.

## 📑 Test Plan

Have a look at the storybook stories. Also play around with the default story (e.g. by setting `restrict` to true and adding multiple knobs).

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
