### PR TITLE
fix: 🤔 syn-dialog layout broken on small screen estate

### DIFF
--- a/packages/components/src/components/dialog/dialog.custom.styles.ts
+++ b/packages/components/src/components/dialog/dialog.custom.styles.ts
@@ -24,6 +24,14 @@ export default css`
     box-shadow: var(--syn-shadow-large);
   }
 
+  .dialog__body {
+    min-height: 4rem;
+  }
+
+  .dialog__footer {
+    background: var(--syn-panel-background-color);
+  }
+
   .dialog__header-actions {
     align-items: flex-start;
     gap: var(--syn-spacing-x-small);


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes a rendering issue when using dialogs on a very small screen estate. The footer was drawn in a transparent way underneath the dialog contents, making it look ugly. This fix adds a background to the dialog so it appears more in line with the full fledged version. However, keep in mind that the problem cannot be fixed directly as when the screen estate is too low, the dialog itself may be the problem.

This **could** be fixed by using css container queries or media queries, however as this is more of a hypothetical issue, I would leave it with this.

### 🎫 Issues

Closes #532 

## 👩‍💻 Reviewer Notes

Just compare this branches dialog stories in Storybook by opening the default story or the scrolling story and resizing the screen height to a tiny rest (e.g. 100px). In the current version, you will see a transparent footer with a "Close" button. The new version has a white background.

Note that there may still be layout issues (e.g. the border of the dialog will not cover the footer). This cannot be fixed without a deeper rewrite (e.g. using the media/container approach detailed above).

## 📑 Test Plan

Just compare the stories as detailed in Review Notes.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
