### PR TITLE
fix: 🐛 Z-index order rendering problem with syn-side-nav in rail mode

### DIFF
--- a/packages/angular/src/components/side-nav.component.ts
+++ b/packages/angular/src/components/side-nav.component.ts
@@ -49,9 +49,13 @@ import '@synergy-design-system/components/components/side-nav/side-nav.js';
  * @csspart content-container - The components main content container
  * @csspart content - The components main content
  * @csspart footer-container - The components footer content container
+  (where the footer slot content is rendered)
  * @csspart footer-divider - The components footer divider
  * @csspart footer - The components footer content
  * @csspart overlay - The overlay that covers the screen behind the side-nav.
+ * @csspart panel - The side-nav's panel (where the whole content is rendered).
+ * @csspart body - The side-nav's body (where the default slot content is rendered)
+ * @csspart drawer__base - The drawer's base wrapper
  *
  * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
  *

--- a/packages/components/src/components/side-nav/side-nav.component.ts
+++ b/packages/components/src/components/side-nav/side-nav.component.ts
@@ -46,9 +46,13 @@ import { unlockBodyScrolling } from '../../internal/scroll.js';
  * @csspart content-container - The components main content container
  * @csspart content - The components main content
  * @csspart footer-container - The components footer content container
+(where the footer slot content is rendered)
  * @csspart footer-divider - The components footer divider
  * @csspart footer - The components footer content
  * @csspart overlay - The overlay that covers the screen behind the side-nav.
+ * @csspart panel - The side-nav's panel (where the whole content is rendered).
+ * @csspart body - The side-nav's body (where the default slot content is rendered)
+ * @csspart drawer__base - The drawer's base wrapper
  *
  * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
  *
@@ -339,7 +343,7 @@ export default class SynSideNav extends SynergyElement {
         <syn-drawer
           class="side-nav__drawer"
           ?contained=${this.rail}
-          exportparts="overlay"
+          exportparts="overlay,panel,body,base:drawer__base"
           label=${this.localize.term('sideNav')}
           no-header
           ?open=${this.open}

--- a/packages/components/src/components/side-nav/side-nav.component.ts
+++ b/packages/components/src/components/side-nav/side-nav.component.ts
@@ -46,7 +46,7 @@ import { unlockBodyScrolling } from '../../internal/scroll.js';
  * @csspart content-container - The components main content container
  * @csspart content - The components main content
  * @csspart footer-container - The components footer content container
-(where the footer slot content is rendered)
+  (where the footer slot content is rendered)
  * @csspart footer-divider - The components footer divider
  * @csspart footer - The components footer content
  * @csspart overlay - The overlay that covers the screen behind the side-nav.

--- a/packages/components/src/components/side-nav/side-nav.styles.ts
+++ b/packages/components/src/components/side-nav/side-nav.styles.ts
@@ -32,6 +32,7 @@ export default css`
   
   .side-nav__drawer::part(base){
     position: absolute;
+    z-index: var(--syn-z-index-drawer);
   }
 
   .side-nav__drawer::part(body), .side-nav__drawer::part(footer) {

--- a/packages/react/src/components/side-nav.ts
+++ b/packages/react/src/components/side-nav.ts
@@ -47,9 +47,13 @@ Component.define('syn-side-nav');
  * @csspart content-container - The components main content container
  * @csspart content - The components main content
  * @csspart footer-container - The components footer content container
+  (where the footer slot content is rendered)
  * @csspart footer-divider - The components footer divider
  * @csspart footer - The components footer content
  * @csspart overlay - The overlay that covers the screen behind the side-nav.
+ * @csspart panel - The side-nav's panel (where the whole content is rendered).
+ * @csspart body - The side-nav's body (where the default slot content is rendered)
+ * @csspart drawer__base - The drawer's base wrapper
  *
  * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
  *

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -1230,9 +1230,13 @@ export type SynCustomElement<
  * @csspart content-container - The components main content container
  * @csspart content - The components main content
  * @csspart footer-container - The components footer content container
+  (where the footer slot content is rendered)
  * @csspart footer-divider - The components footer divider
  * @csspart footer - The components footer content
  * @csspart overlay - The overlay that covers the screen behind the side-nav.
+ * @csspart panel - The side-nav's panel (where the whole content is rendered).
+ * @csspart body - The side-nav's body (where the default slot content is rendered)
+ * @csspart drawer__base - The drawer's base wrapper
  *
  * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
  *
@@ -2399,49 +2403,53 @@ declare module 'react' {
        * @csspart expand-icon - The container that wraps the expand icon.
        */ 'syn-select': SynSelectJSXElement;
       /**
-       * @summary The <syn-side-nav /> element contains secondary navigation and fits below the header.
-       * It can be used to group multiple navigation items (<syn-nav-item />s) together.
-       *
-       * @example
-       * <syn-side-nav open>
-       *  <syn-nav-item >Item 1</syn-nav-item>
-       *  <syn-nav-item divider>Item 2</syn-nav-item>
-       * </syn-side-nav>
-       *
-       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-side-nav--docs
-       * @status stable
-       * @since 1.14.0
-       *
-       * @dependency syn-divider
-       * @dependency syn-drawer
-       *
-       * @slot - The main content of the side-nav. Used for <syn-nav-item /> elements.
-       * @slot footer - The footer content of the side-nav. Used for <syn-nav-item /> elements.
-       *    Please avoid having to many nav-items as it can massively influence the user experience.
-       *
-       * @event syn-show - Emitted when the side-nav opens.
-       * @event syn-after-show - Emitted after the side-nav opens and all animations are complete.
-       * @event syn-hide - Emitted when the side-nav closes.
-       * @event syn-after-hide - Emitted after the side-nav closes and all animations are complete.
-       *
-       * @csspart base - The components base wrapper
-       * @csspart drawer - The drawer that is used under the hood for creating the side-nav
-       * @csspart content-container - The components main content container
-       * @csspart content - The components main content
-       * @csspart footer-container - The components footer content container
-       * @csspart footer-divider - The components footer divider
-       * @csspart footer - The components footer content
-       * @csspart overlay - The overlay that covers the screen behind the side-nav.
-       *
-       * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
-       *
-       * @animation sideNav.showNonRail - The animation to use when showing the side-nav in non-rail mode.
-       * @animation sideNav.showRail - The animation to use when showing the side-nav in rail mode.
-       * @animation sideNav.hideNonRail - The animation to use when hiding the side-nav in non-rail mode.
-       * @animation sideNav.hideRail - The animation to use when hiding the side-nav in rail mode.
-       * @animation sideNav.overlay.show - The animation to use when showing the side-nav's overlay.
-       * @animation sideNav.overlay.hide - The animation to use when hiding the side-nav's overlay.
-       */ 'syn-side-nav': SynSideNavJSXElement;
+ * @summary The <syn-side-nav /> element contains secondary navigation and fits below the header.
+ * It can be used to group multiple navigation items (<syn-nav-item />s) together.
+ *
+ * @example
+ * <syn-side-nav open>
+ *  <syn-nav-item >Item 1</syn-nav-item>
+ *  <syn-nav-item divider>Item 2</syn-nav-item>
+ * </syn-side-nav>
+ *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-side-nav--docs
+ * @status stable
+ * @since 1.14.0
+ *
+ * @dependency syn-divider
+ * @dependency syn-drawer
+ *
+ * @slot - The main content of the side-nav. Used for <syn-nav-item /> elements.
+ * @slot footer - The footer content of the side-nav. Used for <syn-nav-item /> elements.
+ *    Please avoid having to many nav-items as it can massively influence the user experience.
+ *
+ * @event syn-show - Emitted when the side-nav opens.
+ * @event syn-after-show - Emitted after the side-nav opens and all animations are complete.
+ * @event syn-hide - Emitted when the side-nav closes.
+ * @event syn-after-hide - Emitted after the side-nav closes and all animations are complete.
+ *
+ * @csspart base - The components base wrapper
+ * @csspart drawer - The drawer that is used under the hood for creating the side-nav
+ * @csspart content-container - The components main content container
+ * @csspart content - The components main content
+ * @csspart footer-container - The components footer content container
+  (where the footer slot content is rendered)
+ * @csspart footer-divider - The components footer divider
+ * @csspart footer - The components footer content
+ * @csspart overlay - The overlay that covers the screen behind the side-nav.
+ * @csspart panel - The side-nav's panel (where the whole content is rendered).
+ * @csspart body - The side-nav's body (where the default slot content is rendered)
+ * @csspart drawer__base - The drawer's base wrapper
+ *
+ * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
+ *
+ * @animation sideNav.showNonRail - The animation to use when showing the side-nav in non-rail mode.
+ * @animation sideNav.showRail - The animation to use when showing the side-nav in rail mode.
+ * @animation sideNav.hideNonRail - The animation to use when hiding the side-nav in non-rail mode.
+ * @animation sideNav.hideRail - The animation to use when hiding the side-nav in rail mode.
+ * @animation sideNav.overlay.show - The animation to use when showing the side-nav's overlay.
+ * @animation sideNav.overlay.hide - The animation to use when hiding the side-nav's overlay.
+ */ 'syn-side-nav': SynSideNavJSXElement;
       /**
        * @summary Spinners are used to show the progress of an indeterminate operation.
        * @documentation https://synergy.style/components/spinner

--- a/packages/vue/src/components/SynVueSideNav.vue
+++ b/packages/vue/src/components/SynVueSideNav.vue
@@ -36,9 +36,13 @@
  * @csspart content-container - The components main content container
  * @csspart content - The components main content
  * @csspart footer-container - The components footer content container
+  (where the footer slot content is rendered)
  * @csspart footer-divider - The components footer divider
  * @csspart footer - The components footer content
  * @csspart overlay - The overlay that covers the screen behind the side-nav.
+ * @csspart panel - The side-nav's panel (where the whole content is rendered).
+ * @csspart body - The side-nav's body (where the default slot content is rendered)
+ * @csspart drawer__base - The drawer's base wrapper
  *
  * @cssproperty  --side-nav-open-width - The width of the side-nav if in open state
  *


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue of the rendering order with syn-side-nav in rail mode and main content with a higher z-index.
Additionally it exports all necessary drawer css parts

### 🎫 Issues

Closes #736 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Add this code to the side-nav story in the main content area and see that the text is no longer shown above the expanded side-nav:

``` html
        <div style="position:absolute; z-index:10; margin-top:100px;">some text with higher z-index</div>
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
