### PR TITLE
fix: 🐛 syn-validate: Validation message not removed when the slotted input is set to readonly or disabled

### DIFF
--- a/packages/components/src/components/validate/validate.component.ts
+++ b/packages/components/src/components/validate/validate.component.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup } from 'lit';
+import type { CSSResultGroup, PropertyValues } from 'lit';
 import { html } from 'lit';
 import { property, queryAssignedElements, state } from 'lit/decorators.js';
 import componentStyles from '../../styles/component.styles.js';
@@ -38,6 +38,8 @@ export default class SynValidate extends SynergyElement {
   };
 
   controller = new AbortController();
+
+  observer: MutationObserver;
 
   @queryAssignedElements() private slottedChildren: HTMLElement[];
 
@@ -312,7 +314,8 @@ export default class SynValidate extends SynergyElement {
     }
   };
 
-  async firstUpdated() {
+  async firstUpdated(changedProperties: PropertyValues) {
+    super.firstUpdated(changedProperties);
     this.updateEvents();
 
     // Make sure to run validation on mount if eager is set
@@ -324,9 +327,57 @@ export default class SynValidate extends SynergyElement {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+
+    // #717: Make sure to remove to rerun validation when
+    // disabled or readonly properties change on the input
+    this.observer = new MutationObserver(entries => {
+      const input = this.getInput();
+
+      if (!input) {
+        return;
+      }
+
+      const hasDisabledOrReadonly = entries
+        // Only check for changes on the input element
+        .filter(({ target }) => target === input)
+        // Check if the input is disabled or readonly
+        .every(entry => {
+          const target = entry.target as HTMLInputElement;
+          return target.hasAttribute('disabled') || target.hasAttribute('readonly');
+        });
+
+      if (hasDisabledOrReadonly) {
+        this.isValid = true;
+        this.validationMessage = '';
+      } else {
+        // When using a synergy element, we need to check the validity after the element is updated,
+        // as we cannot rely on the validity state of the element itself.
+        // Unfortunately, this depends on used browser :(.
+        const waitForPromise = input instanceof SynergyElement
+          ? input.updateComplete
+          : Promise.resolve();
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        waitForPromise.then(() => {
+          this.isValid = input?.validity?.valid ?? false;
+          this.validationMessage = input?.validationMessage ?? '';
+        });
+      }
+    });
+
+    this.observer.observe(this, {
+      attributeFilter: ['disabled', 'readonly'],
+      attributes: true,
+      subtree: true,
+    });
+  }
+
   disconnectedCallback() {
     super.disconnectedCallback();
     this.controller.abort();
+    this?.observer?.disconnect();
   }
 
   private renderInlineValidation() {


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue with `<syn-validate>` which lead to a visualization problem when setting or removing `disabled` or `readonly` properties on the slotted input field. If rendered with one of those properties initially and eager set, the validation would not show an error message when the property was removed later on.

### 🎫 Issues

Closes #717

## 👩‍💻 Reviewer Notes

Code-wise, I had to use `Element.getAttribute` instead of simple checks like `element.disabled`. This is because Shoelace uses other props than regular html (e.g. `readOnly` instead of `readonly`). As attributes are case insensitive, this lead to easier checks.

I opted to setup the needed `MutationObserver` on `connectedCallback` on the element itself. This was done to make sure that the observer always listens to changed nodes and also picks up complete new ones, e.g. when rendering `<syn-validate>` with asynchronous content it will still work, whereas it would not have worked when setting it up with `this.getInput()` as a target. As I am using an attribute filter, this should have not too many performance overhead.

## 📑 Test Plan

Have a look at [the provided Codepen example](https://codepen.io/schilchSICKAG/pen/RNbBbVJ?editors=1110). It will load the input with `readonly` initially. When the readonly attribute is removed from the element by clicking the "Toggle readonly" button, it will show a red lining (as the input is correctly identified as invalid), but will not show the error message.

Try the same with the changes applied to this branch to see that it will now display the error message correctly.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
