### PR TITLE
fix: 🐛 Checkbox and Radio have different disabled styles

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.custom.styles.ts
+++ b/packages/components/src/components/checkbox/checkbox.custom.styles.ts
@@ -45,9 +45,4 @@ export default css`
   .checkbox--large .checkbox__label {
     top: -2px;
   }
-
-  /* Disabled */
-  .checkbox--disabled .checkbox__label {
-    color: var(--syn-color-neutral-700);
-  }
 `;


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes the wrong label color on disabled `<syn-checkbox>` to make it align with `<syn-switch>` and `<syn-radio>`.

### 🎫 Issues

Closes #734

<!--
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

I don´t quite know anymore why we put it there in the first place, but we have overridden the `disabled` state on purpose during the initial vendoring process. Maybe the token was not there initially?

## 📑 Test Plan

Just have a look at the disabled Story of `<yn-checkbox>` in Chromatic. Also, compare this to the version for `<syn-switch>` and `<syn-radio>`.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
