### PR TITLE
fix: 🐛 syn-range Various issues for syn-range

### DIFF
--- a/packages/angular/src/components/range.component.ts
+++ b/packages/angular/src/components/range.component.ts
@@ -88,13 +88,13 @@ export class SynRangeComponent {
     });
     this.nativeElement.addEventListener('syn-change', (e: SynChangeEvent) => {
       this.synChangeEvent.emit(e);
+      this.valueChange.emit(this.value);
     });
     this.nativeElement.addEventListener('syn-focus', (e: SynFocusEvent) => {
       this.synFocusEvent.emit(e);
     });
     this.nativeElement.addEventListener('syn-input', (e: SynInputEvent) => {
       this.synInputEvent.emit(e);
-      this.valueChange.emit(this.value);
     });
     this.nativeElement.addEventListener('syn-invalid', (e: SynInvalidEvent) => {
       this.synInvalidEvent.emit(e);

--- a/packages/components/scripts/jobs/shared.js
+++ b/packages/components/scripts/jobs/shared.js
@@ -362,6 +362,8 @@ export const getControlAttributeForTwoWayBinding = (componentName) => {
  */
 export const getEventAttributeForTwoWayBinding = (componentName) => {
   switch (componentName) {
+  // #729: Syn-Range should emit on change as it may be too fast to use it with syn-input
+  case 'range': return 'syn-change';
   default: return 'syn-input';
   }
 };

--- a/packages/components/scripts/jobs/vue/createWrappers.js
+++ b/packages/components/scripts/jobs/vue/createWrappers.js
@@ -67,13 +67,10 @@ const getEmitAttributes = (componentName, componentClass, events = []) => {
   // Add support for custom vue vModel binding
   const eventName = getEventAttributeForTwoWayBinding(componentName);
 
-  // @todo: This would make types more explicit,
-  // however esbuild is not able to compile it unfortunately
-  // ($event.target as ${componentClass}).${getControlAttributeForTwoWayBinding(componentName)
-  const emitterValue = `$emit('update:modelValue', $event.target.${getControlAttributeForTwoWayBinding(componentName)})`;
+  const emitterValue = `$emit('update:modelValue', ($event.target as ${componentClass}).${getControlAttributeForTwoWayBinding(componentName)})`;
 
   // It may very well be that the event we need to hook into is already
-  // declared (e.g. when using syn-input for two way databinding and as a prop, too)
+  // declared (e.g. when using syn-input for two way data-binding and as a prop, too)
   // For this reason, we have to look if there is already a bound event and adjust it
   // accordingly so it includes the calls to update:modelValue, too.
   const vmodelEvents = templateEvents.map((event) => {

--- a/packages/components/src/components/range/range.component.ts
+++ b/packages/components/src/components/range/range.component.ts
@@ -162,6 +162,8 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
 
   @query('.active-track') activeTrack: HTMLDivElement;
 
+  @query('.ticks') ticks: HTMLDivElement;
+
   @queryAll('.thumb') thumbs: NodeListOf<HTMLDivElement>;
 
   @query('.range__validation-input') validationInput: HTMLInputElement;
@@ -171,6 +173,8 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
   private readonly formControlController = new FormControlController(this, { assumeInteractionOn: ['syn-change'] });
 
   private localize = new LocalizeController(this);
+
+  private visibilityObserver: IntersectionObserver;
 
   #value: readonly number[] = [0];
 
@@ -193,7 +197,25 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
     this.tooltipFormatter = this.localize.number.bind(this.localize);
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this?.visibilityObserver?.disconnect();
+  }
+
   firstUpdated() {
+    // #727: Check if the ticks are visible and update the prefix and suffix position when they are.
+    this.visibilityObserver = new IntersectionObserver((entries) => {
+      const entry = entries.at(0);
+      if (entry && entry.isIntersecting && entry.target.checkVisibility()) {
+        this.#updatePrefixSuffixPosition(entry.boundingClientRect.height);
+      }
+    }, {
+      // We bind the root to the parent element of the ticks to make sure we are only called
+      // when the ticks are visible, not when the ticks are scrolled out of the viewport.
+      root: this.ticks.parentElement,
+    });
+    this.visibilityObserver.observe(this.ticks);
+
     this.formControlController.updateValidity();
     // initialize the lastChangeValue with the initial value
     this.#lastChangeValue = Array.from(this.#value);
@@ -326,7 +348,7 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
     return this.#validationError;
   }
 
-  #onClickTrack(event: PointerEvent) {
+  #onClickTrack(event: PointerEvent, focusThumb = true) {
     if (this.disabled) return;
     const { clientX } = event;
 
@@ -370,9 +392,22 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
     }
 
     // #595: Redispatch the original event to start dragging the thumb
-    // whenever the user clicked on the track
+    // whenever the user clicked on the track.
+    // The check for focusThumb makes sure this does not happen when clicking on the track items
     const newEvt = new PointerEvent('pointerdown', event);
-    thumb.dispatchEvent(newEvt);
+    if (focusThumb) {
+      if (thumb.dispatchEvent(newEvt)) {
+        this.#updateTooltip(thumb);
+      }
+    }
+  }
+
+  /**
+   * Special method for handling clicks on track items
+   * When clicking track items, we do not want the thumb to have focus
+   */
+  #onClickTrackItem(event: PointerEvent) {
+    this.#onClickTrack(event, false);
   }
 
   /**
@@ -650,7 +685,7 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
     this.formControlController.emitInvalidEvent(event);
   }
 
-  #updatePrefixSuffixPosition() {
+  #updatePrefixSuffixPosition(height?: number) {
     const hasTicksSlot = this.hasSlotController.test('ticks');
     const hasPrefixSlot = this.hasSlotController.test('prefix');
     const hasSuffixSlot = this.hasSlotController.test('suffix');
@@ -659,7 +694,7 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
       return;
     }
 
-    let ticksHeight = this.shadowRoot?.querySelector('.ticks')?.clientHeight;
+    let ticksHeight = height || this.shadowRoot?.querySelector('.ticks')?.clientHeight;
     if (ticksHeight) {
       // Add two pixels as the 1px margin on top and bottom are not included in the clientHeight
       ticksHeight += 2;
@@ -753,7 +788,6 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
     const hasSuffixSlot = this.hasSlotController.test('suffix');
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHelpText = this.helpText ? true : !!hasHelpTextSlot;
-    this.#updatePrefixSuffixPosition();
 
     return html`
       <div
@@ -814,7 +848,7 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
             <div
               class="ticks"
               part="ticks"
-              @pointerdown=${this.#onClickTrack}
+              @pointerdown=${this.#onClickTrackItem}
               role="presentation"
             >
               <slot name="ticks"></slot>

--- a/packages/components/src/components/range/range.component.ts
+++ b/packages/components/src/components/range/range.component.ts
@@ -368,6 +368,11 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
       this.emit('syn-input');
       this.emit('syn-change');
     }
+
+    // #595: Redispatch the original event to start dragging the thumb
+    // whenever the user clicked on the track
+    const newEvt = new PointerEvent('pointerdown', event);
+    thumb.dispatchEvent(newEvt);
   }
 
   /**

--- a/packages/components/src/components/range/range.styles.ts
+++ b/packages/components/src/components/range/range.styles.ts
@@ -57,9 +57,6 @@ export default css`
 
   .input__wrapper {
     flex: 1 0 auto;
-
-    /* Needed so the active track and thumb do not bleed into other elements like the side-nav because of their z-indices */
-    isolation: isolate;
     position: relative;
   }
 

--- a/packages/components/src/components/range/range.test.ts
+++ b/packages/components/src/components/range/range.test.ts
@@ -602,6 +602,25 @@ describe('<syn-range>', () => {
       expect(changeHandler.called).to.be.true;
       expect(inputHandler.called).to.be.true;
     });
+
+    it('should emit a pointer-down event on the closest thumb when clicking the track so it can be dragged instantly', async () => {
+      const pointerDownHandler = sinon.spy();
+
+      const el = await fixture<SynRange>(html`<syn-range></syn-range>`);
+      const firstThumb = el.shadowRoot!.querySelector('.thumb')!;
+
+      firstThumb.addEventListener('pointerdown', pointerDownHandler);
+
+      const track = el.shadowRoot!.querySelector('.track')!;
+      const rect = track.getBoundingClientRect();
+
+      await sendMouse({
+        position: [rect.left + 120, rect.top],
+        type: 'click',
+      });
+
+      expect(pointerDownHandler.called).to.be.true;
+    });
   });
 
   describe('when using keyboard navigation', () => {

--- a/packages/vue/src/components/SynVueCheckbox.vue
+++ b/packages/vue/src/components/SynVueCheckbox.vue
@@ -168,7 +168,7 @@ export type { SynInvalidEvent } from '@synergy-design-system/components';
     @syn-change="$emit('syn-change', $event)"
     @syn-focus="$emit('syn-focus', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.checked);
+      $emit('update:modelValue', ($event.target as SynCheckbox).checked);
       $emit('syn-input', $event);
     "
     @syn-invalid="$emit('syn-invalid', $event)"

--- a/packages/vue/src/components/SynVueCombobox.vue
+++ b/packages/vue/src/components/SynVueCombobox.vue
@@ -270,7 +270,7 @@ export type { SynErrorEvent } from '@synergy-design-system/components';
     @syn-change="$emit('syn-change', $event)"
     @syn-clear="$emit('syn-clear', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.value);
+      $emit('update:modelValue', ($event.target as SynCombobox).value);
       $emit('syn-input', $event);
     "
     @syn-focus="$emit('syn-focus', $event)"

--- a/packages/vue/src/components/SynVueFile.vue
+++ b/packages/vue/src/components/SynVueFile.vue
@@ -233,7 +233,7 @@ export type { SynInputEvent } from '@synergy-design-system/components';
     @syn-error="$emit('syn-error', $event)"
     @syn-focus="$emit('syn-focus', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.files);
+      $emit('update:modelValue', ($event.target as SynFile).files);
       $emit('syn-input', $event);
     "
     :files="

--- a/packages/vue/src/components/SynVueInput.vue
+++ b/packages/vue/src/components/SynVueInput.vue
@@ -297,7 +297,7 @@ export type { SynInvalidEvent } from '@synergy-design-system/components';
     @syn-clear="$emit('syn-clear', $event)"
     @syn-focus="$emit('syn-focus', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.value);
+      $emit('update:modelValue', ($event.target as SynInput).value);
       $emit('syn-input', $event);
     "
     @syn-invalid="$emit('syn-invalid', $event)"

--- a/packages/vue/src/components/SynVueRadioGroup.vue
+++ b/packages/vue/src/components/SynVueRadioGroup.vue
@@ -140,7 +140,7 @@ export type { SynInvalidEvent } from '@synergy-design-system/components';
   <syn-radio-group
     @syn-change="$emit('syn-change', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.value);
+      $emit('update:modelValue', ($event.target as SynRadioGroup).value);
       $emit('syn-input', $event);
     "
     @syn-invalid="$emit('syn-invalid', $event)"

--- a/packages/vue/src/components/SynVueRange.vue
+++ b/packages/vue/src/components/SynVueRange.vue
@@ -218,12 +218,12 @@ export type { SynMoveEvent } from '@synergy-design-system/components';
 <template>
   <syn-range
     @syn-blur="$emit('syn-blur', $event)"
-    @syn-change="$emit('syn-change', $event)"
-    @syn-focus="$emit('syn-focus', $event)"
-    @syn-input="
-      $emit('update:modelValue', $event.target.value);
-      $emit('syn-input', $event);
+    @syn-change="
+      $emit('update:modelValue', ($event.target as SynRange).value);
+      $emit('syn-change', $event);
     "
+    @syn-focus="$emit('syn-focus', $event)"
+    @syn-input="$emit('syn-input', $event)"
     @syn-invalid="$emit('syn-invalid', $event)"
     @syn-move="$emit('syn-move', $event)"
     :value="

--- a/packages/vue/src/components/SynVueSelect.vue
+++ b/packages/vue/src/components/SynVueSelect.vue
@@ -272,7 +272,7 @@ export type { SynInvalidEvent } from '@synergy-design-system/components';
     @syn-change="$emit('syn-change', $event)"
     @syn-clear="$emit('syn-clear', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.value);
+      $emit('update:modelValue', ($event.target as SynSelect).value);
       $emit('syn-input', $event);
     "
     @syn-focus="$emit('syn-focus', $event)"

--- a/packages/vue/src/components/SynVueSwitch.vue
+++ b/packages/vue/src/components/SynVueSwitch.vue
@@ -159,7 +159,7 @@ export type { SynInvalidEvent } from '@synergy-design-system/components';
     @syn-blur="$emit('syn-blur', $event)"
     @syn-change="$emit('syn-change', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.checked);
+      $emit('update:modelValue', ($event.target as SynSwitch).checked);
       $emit('syn-input', $event);
     "
     @syn-focus="$emit('syn-focus', $event)"

--- a/packages/vue/src/components/SynVueTextarea.vue
+++ b/packages/vue/src/components/SynVueTextarea.vue
@@ -226,7 +226,7 @@ export type { SynInvalidEvent } from '@synergy-design-system/components';
     @syn-change="$emit('syn-change', $event)"
     @syn-focus="$emit('syn-focus', $event)"
     @syn-input="
-      $emit('update:modelValue', $event.target.value);
+      $emit('update:modelValue', ($event.target as SynTextarea).value);
       $emit('syn-input', $event);
     "
     @syn-invalid="$emit('syn-invalid', $event)"


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes a couple of issues reported for `<syn-range>`. As usual, I will provide information about the fixes step by step.

### 🎫 Issues

Closes #741 (Umbrella for tickets below)
Closes #727
Closes #728
Closes #729
Closes #595

All in all those where pretty easy changes that don´t seem to break anything. Just have a look at the current version and compare the the latest main. I tried to keep the commits clean per feature (which didn´t completely work out ^^), but it should give you an idea what was changed and why.

## 👩‍💻 Reviewer Notes (#727)

This was a funny one. When using `<syn-range>` with ticks and slots, it drew the slotted prefix and suffix icons on the same level as the tick. This **only happens** when the ticks have a height reported as `0`. This may happen in the following case (can also be used to test it):

```html
<syn-range label="Count" value="1" min="1" max="9999" class="syn-range-with-tick">
      <nav slot="ticks">
        <syn-range-tick>1pc</syn-range-tick>
        <syn-range-tick>5000 pcs</syn-range-tick>
        <syn-range-tick>9999 pcs</syn-range-tick>
      </nav>
      <syn-input slot="suffix" value="100" type="number" no-spin-buttons="" min="0" max="9999">
        <span slot="suffix">pcs</span>
      </syn-input>
    </syn-range>
    <script>
      const inp = document.querySelector('syn-input');
      const rang = document.querySelector('syn-range');
      rang.addEventListener('syn-input', e => {
        inp.value = e.target.value;
      });
      inp.addEventListener('syn-input', e => {
        console.log('here', e, e.target, e.target.value)
        console.log(rang.value);
        rang.value = e.target.value;
        console.log(rang.value);
      });
    </script>
    <style>
    .syn-range-with-tick nav {
        justify-content: space-between;
        flex-direction: row;
        display: flex;
      }
    </style>
```

Notice that it looks like it should... initially. Now use the same markup and add a `display: none` to the `syn-range`. After making it visible you will notice it has a broken layout. This is because we adjusted the position of the ticks during `render`. When rendered outside the visible viewport (e.g. vis `display: none;`, or in a tab / modal) it reported 0, making the first render without interaction broken.

## 📑 Test Plan

See code sample above. Try this with the current main branch and see how it is broken. Do the same on this branch and notice it went away.

---

## 👩‍💻 Reviewer Notes (#728)

This one was easy: The `isolation: isolate;` setting on the `syn-range` caused this. Originally, we had this implemented because of rendering issues in `syn-side-nav`. As those are now fixed in the latest version, we can get rid of the property. Works fine without it.

This has to be tested in the demos!

---

## 👩‍💻 Reviewer Notes (#729)

Basically the source is just that the events are coming in too fast. I moved them fron `syn-input` to `syn-change` for two way binding and it works fine in all supported frameworks, as well as native. Just have a look at the current vue demo to check.

## 👩‍💻 Reviewer Notes (#595)

This was quite easy. Triggering the `PointerEvent` on the thumb was enough to make it work. Just have a look at any Storybook-Demo, click the track and start dragging. Works with single or multi knobs.

The handling for `<syn-range-tick>` is slightly different because we can not surpress the tooltip from being shown, making every click be overlayn with the tooltip :(. It reuses most of the logic, through. If you are interested you can also play around with this (just adjust `
#onClickTrackItem`).

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
