### PR TITLE
fix: 🐛 Side-nav not working correctly for some production builds

### DIFF
--- a/packages/components/src/components/side-nav/side-nav.component.ts
+++ b/packages/components/src/components/side-nav/side-nav.component.ts
@@ -163,7 +163,7 @@ export default class SynSideNav extends SynergyElement {
   }
 
   private forceDrawerVisibilityForRailMode() {
-    return waitForEvent(this, 'syn-after-hide').then(() => {
+    return waitForEvent(this.drawer, 'syn-after-hide').then(() => {
       this.setDrawerVisibility(true);
       this.isAnimationActive = false;
     });
@@ -233,7 +233,7 @@ export default class SynSideNav extends SynergyElement {
     }
     this.open = true;
 
-    return waitForEvent(this, 'syn-after-show');
+    return waitForEvent(this.drawer, 'syn-after-show');
   }
 
   /** Hides the side-nav */
@@ -244,7 +244,7 @@ export default class SynSideNav extends SynergyElement {
 
     this.open = false;
 
-    return waitForEvent(this, 'syn-after-hide');
+    return waitForEvent(this.drawer, 'syn-after-hide');
   }
 
   constructor() {


### PR DESCRIPTION
# Pull Request

## 📖 Description
Currently our side-nav does not work correctly for specific production builds ( e.g. angular with specific production settings). Until know the actual problem is unknown..
Adding the eventlisteners for the side nav directly on the drawer instead of the side-nav itself so it uses bubbled events, fixes the problem.

### 🎫 Issues

Closes #743 

## 👩‍💻 Reviewer Notes
Can currently only be reproduced in medici-ng project

## 📑 Test Plan



## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
