### PR TITLE
fix: 🐛 syn-validate: Rendered input should be highlighted as error when loading with an invalid state

### DIFF
--- a/packages/components/src/components/validate/validate.component.ts
+++ b/packages/components/src/components/validate/validate.component.ts
@@ -315,9 +315,19 @@ export default class SynValidate extends SynergyElement {
   async firstUpdated() {
     this.updateEvents();
 
+    // #713: Make sure to set the custom validation message on mount
+    // When we have a custom element, we need to wait for it to be ready!
+    const input = this.getInput();
+
+    if (this.customValidationMessage) {
+      if (input instanceof SynergyElement) {
+        await input.updateComplete;
+      }
+      input?.setCustomValidity(this.customValidationMessage);
+    }
+
     // Make sure to run validation on mount if eager is set
     if (this.eager) {
-      const input = this.getInput();
       await this.updateComplete;
       this.isValid = input?.validity?.valid ?? false;
       input?.reportValidity();

--- a/packages/components/src/components/validate/validate.test.ts
+++ b/packages/components/src/components/validate/validate.test.ts
@@ -463,4 +463,53 @@ describe('<syn-validate>', () => {
       expect(input.hasAttribute('data-user-invalid')).to.be.false;
     });
   });
+
+  describe('regression tests', () => {
+    describe('#713: should call setCustomValidity when mounting with a customValidationMessage', () => {
+      // Make sure that we test both our custom elements and native elements
+      ['syn-input', 'input'].forEach((tag) => {
+        it(`Should set the error to "Custom Message" on initial load when using a <${tag}> and a custom-validation-message is provided`, async () => {
+          // Create the input element
+          const inputElm = tag === 'syn-input'
+            ? html`<syn-input name="input"></syn-input>`
+            : html`<input name="input">`;
+
+          const el = await fixture<SynValidate>(html`
+            <syn-validate eager variant="inline" custom-validation-message="Custom Message">
+              ${inputElm}
+            </syn-validate>
+          `);
+
+          const input = el.querySelector<HTMLInputElement>(tag)!;
+
+          await el.updateComplete;
+
+          await expect(el.customValidationMessage).to.equal('Custom Message');
+          expect(input.validity.customError).to.be.true;
+          await expect(input.validationMessage).to.equal('Custom Message');
+        }); // Test for both synergy and native elements
+
+        it(`Should not set the error to "Custom Message" on initial load when using a <${tag}> and no custom-validation-message is provided`, async () => {
+          // Create the input element
+          const inputElm = tag === 'syn-input'
+            ? html`<syn-input name="input"></syn-input>`
+            : html`<input name="input">`;
+
+          const el = await fixture<SynValidate>(html`
+            <syn-validate eager variant="inline">
+              ${inputElm}
+            </syn-validate>
+          `);
+
+          const input = el.querySelector<HTMLInputElement>(tag)!;
+
+          await el.updateComplete;
+
+          await expect(el.customValidationMessage).to.equal('');
+          expect(input.validity.customError).to.be.false;
+          await expect(input.validationMessage).to.equal('');
+        }); // Test for both synergy and native elements
+      }); // Element type (SynInput or HTMLInputElement)
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue when using `<syn-validate>` with a `custom-error-message` and `eager` loading. In this combination, there was no error message shown when the native constraint validation API was not kicking in.

This can be best viewed at [the corresponding codepen](https://codepen.io/schilchSICKAG/pen/RNbYrpr?editors=1110). As can be seen, the validation triggers on the first example, but not on the second one.

The reason for this is that we do not a initial set of the `customValidationMessage` of the internal input before doing our eager check. This is now fixed with this PR.

### 🎫 Issues

Closes #713

## 👩‍💻 Reviewer Notes

I opted to include the test in `firstUpdated` directly so I did not have to mess with changing `handleCustomValidationMessageChange` to trigger another validation run. I found this to be easier to reason about in the future.

The `await` statement is needed as `SynInput` (and other Synergy Instances) may not be finally rendered. This leads to the problem that the inner inputs native input-element is not ready when trying to call `setCustomValidation` on it, leading to a crash :(

## 📑 Test Plan

Have a look at the linked pen. Copy the code to your local version and check if it is now working when copying in Storybook or one of the demos. It should now:

1. Show the error message "This is plain wrong!" for the first input and
2. Show the error message "This should appear" for the second one.


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
