### PR TITLE
fix: 🐛 React: style and ref for react19 not working

### DIFF
--- a/packages/components/scripts/jobs/react/intrinsic-elements.js
+++ b/packages/components/scripts/jobs/react/intrinsic-elements.js
@@ -31,7 +31,7 @@ export const runCreateIntrinsicElements = job('React: Creating react intrinsic e
 
   // List of imports needed for the generated types
   const imports = `
-    import type { DOMAttributes, RefObject } from 'react';
+    import type { CSSProperties, DOMAttributes, RefObject } from 'react';
     import type { ${synergyTypes.join(',')} } from '@synergy-design-system/components';
 
     /**
@@ -53,12 +53,13 @@ export const runCreateIntrinsicElements = job('React: Creating react intrinsic e
       SynElement extends HTMLElement,
       Events extends SynEventTuple[] = [],
     > = Partial<
-      SynElement &
+      Omit<SynElement, 'style'> &
       DOMAttributes<SynElement> &
       {
         children?: any;
         key?: any;
         ref?: RefObject<SynElement | null>;
+        style?: CSSProperties | undefined;
       } &
       SynEventMap<Events>
     >;

--- a/packages/components/scripts/jobs/react/intrinsic-elements.js
+++ b/packages/components/scripts/jobs/react/intrinsic-elements.js
@@ -31,7 +31,7 @@ export const runCreateIntrinsicElements = job('React: Creating react intrinsic e
 
   // List of imports needed for the generated types
   const imports = `
-    import type { DOMAttributes } from 'react';
+    import type { DOMAttributes, RefObject } from 'react';
     import type { ${synergyTypes.join(',')} } from '@synergy-design-system/components';
 
     /**
@@ -58,6 +58,7 @@ export const runCreateIntrinsicElements = job('React: Creating react intrinsic e
       {
         children?: any;
         key?: any;
+        ref?: RefObject<SynElement | null>;
       } &
       SynEventMap<Events>
     >;
@@ -91,6 +92,13 @@ export const runCreateIntrinsicElements = job('React: Creating react intrinsic e
     ${componentExports.join('\n')}
 
     declare module 'react' {
+      // #746: Allow synergies custom properties as css variable names
+      // @see https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+      // @see https://stackoverflow.com/questions/65878880/typescript-template-literal-as-interface-key/65879197#65879197
+      interface CSSProperties {
+        [key: \`--\${string}\`]: string | undefined;
+      }
+
       namespace JSX {
         interface IntrinsicElements {
           ${componentTypes.join('\n')}

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------------------
 /* eslint-disable */
 
-import type { DOMAttributes } from 'react';
+import type { DOMAttributes, RefObject } from 'react';
 import type {
   SynShowEvent,
   SynAfterShowEvent,
@@ -102,6 +102,7 @@ export type SynCustomElement<
     DOMAttributes<SynElement> & {
       children?: any;
       key?: any;
+      ref?: RefObject<SynElement | null>;
     } & SynEventMap<Events>
 >;
 
@@ -1470,6 +1471,13 @@ export type SynCustomElement<
  */ export type SynValidateJSXElement = SynCustomElement<SynValidate, []>;
 
 declare module 'react' {
+  // #746: Allow synergies custom properties as css variable names
+  // @see https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+  // @see https://stackoverflow.com/questions/65878880/typescript-template-literal-as-interface-key/65879197#65879197
+  interface CSSProperties {
+    [key: `--${string}`]: string | undefined;
+  }
+
   namespace JSX {
     interface IntrinsicElements {
       /**

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------------------
 /* eslint-disable */
 
-import type { DOMAttributes, RefObject } from 'react';
+import type { CSSProperties, DOMAttributes, RefObject } from 'react';
 import type {
   SynShowEvent,
   SynAfterShowEvent,
@@ -98,11 +98,12 @@ export type SynCustomElement<
   SynElement extends HTMLElement,
   Events extends SynEventTuple[] = [],
 > = Partial<
-  SynElement &
+  Omit<SynElement, 'style'> &
     DOMAttributes<SynElement> & {
       children?: any;
       key?: any;
       ref?: RefObject<SynElement | null>;
+      style?: CSSProperties | undefined;
     } & SynEventMap<Events>
 >;
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes two issues with our new type only react support. IT addresses the following issues:

- `ref` was not a supported property on the wrappers, making it impossible to use `useRef()` with TypeScript
- The generic `styles` property in React does not support css custom properties.

### 🎫 Issues

Closes #746

## 👩‍💻 Reviewer Notes

I was slightly tempered to only include our Synergy Tokens in the allowance list, which would have forced their usage. However, I think as we don´t quite know what other component libraries are used by our customers, I went with a dynamic key in `interface CSSProperties`.

## 📑 Test Plan

Just check out this branch and play around with the react demo. The following code will throw typescript errors:

```jsx
// DemoForm.tsx
import { useRef, useEffect } from 'react';
export const DemoForm = () => {
  // Try to change this to the following to check strong typings here :)
  // const firstInputRef = useRef<HTMLDivElement>(null);
  const firstInputRef = useRef<SynInput>(null);

  useEffect(() => {
    firstInputRef.current!.focus();
  }, []);

  return (
    <div>
      <syn-input
        style={{
          '--syn-color-primary-500': 'white',
        }}
        ref={firstInputRef}
      />
    </div>
  );
```

This should not lead to any errors after this fix.

Check out the branch and copy the example above into the react demo. On a current system without the fix applied, it should produce two errors: ref is an unknown property for `syn-input` and `--syn-color-primary-500` not allowed in StyeMap.

After the fix, everything should work fine and the input should receive focus.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
