### PR TITLE
fix: 🐛 Accessibility error in console when using syn-side-nav as rail

### DIFF
--- a/packages/components/src/components/side-nav/side-nav.component.ts
+++ b/packages/components/src/components/side-nav/side-nav.component.ts
@@ -204,6 +204,11 @@ export default class SynSideNav extends SynergyElement {
       this.isAnimationActive = true;
 
       if (!this.open) {
+        // Fix for accessibility error in console. see also: https://github.com/shoelace-style/shoelace/issues/2283
+        const { activeElement } = document;
+        if (activeElement && this.contains(activeElement)) {
+          (document.activeElement as HTMLElement)?.blur();
+        }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.forceDrawerVisibilityForRailMode();
       } else {


### PR DESCRIPTION

# Pull Request

## 📖 Description

This PR removes an accessibility error, which potentially occurs in the console if using the syn-side-nav.
It is related to an error in the drawer (even in shoelace see https://github.com/shoelace-style/shoelace/issues/2283 )

### 🎫 Issues

Closes #750 

## 👩‍💻 Reviewer Notes



## 📑 Test Plan


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
