### PR TITLE
fix: 🐛 Remove warning message in console for syn-header and syn-combobox in dev mode

### DIFF
--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -236,7 +236,11 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   firstUpdated() {
     // initially set the displayLabel if the value was set via property initially
-    this.displayLabel = this.value;
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateComplete.then(() => {
+      this.displayLabel = this.value;
+    });
     this.formControlController.updateValidity();
   }
 

--- a/packages/components/src/components/header/header.component.ts
+++ b/packages/components/src/components/header/header.component.ts
@@ -127,8 +127,11 @@ export default class SynHeader extends SynergyElement {
   firstUpdated() {
     // Search for a side-nav and use the first found in case of the connectSideNavigation method
     // is not used by the user.
-    const sideNav = document.querySelector('syn-side-nav');
-    this.connectSideNavigation(sideNav);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateComplete.then(() => {
+      const sideNav = document.querySelector('syn-side-nav');
+      this.connectSideNavigation(sideNav);
+    });
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR removes the console warning messages of the syn-header and syn-combobox with value.
The warning appears, because changes are done in the `firstUpdated` callback, which lead to updated changes. By waiting for `this.updateComplete` before doing the changes, they are no longer triggering during the update process.

### 🎫 Issues

Closes #753 

## 👩‍💻 Reviewer Notes
Have a look at any syn-header story and check following code for the syn-combobox, that there is no longer this warning message in the console

```html
<syn-combobox value="opt1">
  <syn-option value="opt1">Option 1</syn-option>
  <syn-option value="opt2">Option 2</syn-option>
  <syn-option value="opt3">Option 3</syn-option>
</syn-combobox>
```

Unfortunately there is no way I can test this via unit test 😕
Or at least I have no idea how I could test it

## 📑 Test Plan

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
