### PR TITLE
fix: 🐛 syn-alert: Not able to import syn-alert when using SSR

### DIFF
--- a/packages/components/scripts/vendorism/custom/alert.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/alert.vendorism.js
@@ -1,4 +1,4 @@
-import { replaceSections } from '../replace-section.js';
+import { addSectionAfter, replaceSections } from '../replace-section.js';
 import { removeSections } from '../remove-section.js';
 
 const FILES_TO_TRANSFORM = [
@@ -31,7 +31,7 @@ const transformStyles = (path, originalContent) => {
 };
 
 const transformComponent = (path, originalContent) => {
-  const content = replaceSections([
+  const contentWithoutCountdown = replaceSections([
     // Begin remove countdown
     [
       "@property({ type: String, reflect: true }) countdown?: 'rtl' | 'ltr';",
@@ -43,6 +43,38 @@ const transformComponent = (path, originalContent) => {
     ],
     // End remove countdown.
   ], originalContent);
+
+  // #762: Remove the global toast stack for a local version in
+  // the alert component to make sure ssr works
+  const contentWithoutToastStack = removeSections([
+    [
+      'const toastStack = Object.assign',
+      ';',
+    ],
+  ], contentWithoutCountdown);
+
+  const contentUsingStaticMethods = replaceSections([
+    // Replace all occurences of tostStack with this.toastStack
+    ['toastStack', 'SynAlert.toastStack'],
+  ], contentWithoutToastStack);
+
+  const content = addSectionAfter(
+    contentUsingStaticMethods,
+    'SynergyElement {',
+    `
+  private static currentToastStack: HTMLDivElement;
+
+  private static get toastStack() {
+    if (!this.currentToastStack) {
+      this.currentToastStack = Object.assign(document.createElement('div'), {
+        className: 'syn-toast-stack',
+      });
+    }
+    return this.currentToastStack;
+  }    
+    `,
+  );
+
   return {
     content,
     path,

--- a/packages/components/src/components/alert/alert.component.ts
+++ b/packages/components/src/components/alert/alert.component.ts
@@ -22,8 +22,6 @@ import styles from './alert.styles.js';
 import customStyles from './alert.custom.styles.js';
 import type { CSSResultGroup } from 'lit';
 
-const toastStack = Object.assign(document.createElement('div'), { className: 'syn-toast-stack' });
-
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
  * @documentation https://synergy.style/components/alert
@@ -196,6 +194,17 @@ export default class SynAlert extends SynergyElement {
     return waitForEvent(this, 'syn-after-hide');
   }
 
+  private static currentToastStack: HTMLDivElement;
+
+  private static get toastStack() {
+    if (!this.currentToastStack) {
+      this.currentToastStack = Object.assign(document.createElement('div'), {
+        className: 'syn-toast-stack',
+      });
+    }
+    return this.currentToastStack;
+  }
+
   /**
    * Displays the alert as a toast notification. This will move the alert out of its position in the DOM and, when
    * dismissed, it will be removed from the DOM completely. By storing a reference to the alert, you can reuse it by
@@ -204,11 +213,11 @@ export default class SynAlert extends SynergyElement {
   async toast() {
     return new Promise<void>(resolve => {
       this.handleCountdownChange();
-      if (toastStack.parentElement === null) {
-        document.body.append(toastStack);
+      if (SynAlert.toastStack.parentElement === null) {
+        document.body.append(SynAlert.toastStack);
       }
 
-      toastStack.appendChild(this);
+      SynAlert.toastStack.appendChild(this);
 
       // Wait for the toast stack to render
       requestAnimationFrame(() => {
@@ -220,12 +229,12 @@ export default class SynAlert extends SynergyElement {
       this.addEventListener(
         'syn-after-hide',
         () => {
-          toastStack.removeChild(this);
+          SynAlert.toastStack.removeChild(this);
           resolve();
 
           // Remove the toast stack from the DOM when there are no more alerts
-          if (toastStack.querySelector('syn-alert') === null) {
-            toastStack.remove();
+          if (SynAlert.toastStack.querySelector('syn-alert') === null) {
+            SynAlert.toastStack.remove();
           }
         },
         { once: true }

--- a/packages/components/src/components/alert/alert.component.ts
+++ b/packages/components/src/components/alert/alert.component.ts
@@ -48,6 +48,17 @@ import type { CSSResultGroup } from 'lit';
  * @animation alert.hide - The animation to use when hiding the alert.
  */
 export default class SynAlert extends SynergyElement {
+
+  private static currentToastStack: HTMLDivElement;
+
+  private static get toastStack() {
+    if (!this.currentToastStack) {
+      this.currentToastStack = Object.assign(document.createElement('div'), {
+        className: 'syn-toast-stack',
+      });
+    }
+    return this.currentToastStack;
+  }
   static styles: CSSResultGroup = [componentStyles, styles, customStyles];
   static dependencies = { 'syn-icon-button': SynIconButton };
 
@@ -192,17 +203,6 @@ export default class SynAlert extends SynergyElement {
 
     this.open = false;
     return waitForEvent(this, 'syn-after-hide');
-  }
-
-  private static currentToastStack: HTMLDivElement;
-
-  private static get toastStack() {
-    if (!this.currentToastStack) {
-      this.currentToastStack = Object.assign(document.createElement('div'), {
-        className: 'syn-toast-stack',
-      });
-    }
-    return this.currentToastStack;
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a small adjustment to `<syn-alert>` to make it possible to use it in ssr environments. When importing the component, it originally outright created the `toastStack`, leading to break the import in server environments.

I opted to make it available as `static private` members of `SynAlert` itself, leading to the same result but making sure it will not crash when imported and creating the toast stack only when the toast method is called.

### 🎫 Issues

Closes #762 

## 👩‍💻 Reviewer Notes

Just have a look at the code changes, they should be pretty self explanationary.

## 📑 Test Plan

Play around with your local version and [enable the imports for Alert and Validate](https://github.com/synergy-design-system/ssr-demos/blob/main/packages/angular/src/AllComponentParts/index.ts#L2) in our angular ssr demo application.

> Tip: This is easiest when using the build in synergy and copying the contents of `alert.component.js` that was created in the dist directory, starting from the comment `// src/components/alert/alert.component.ts`.

It should work fine now without issuing an error message when loading the Angular SSR demo.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
