### PR TITLE
fix: 🐛 Only apply min-width styling for syn-input type="number" with spin buttons

### DIFF
--- a/packages/components/src/components/input/input.custom.styles.ts
+++ b/packages/components/src/components/input/input.custom.styles.ts
@@ -6,15 +6,15 @@ export default css`
   * Min-width size adjusted for each size so 2 full digits are shown for type number
   */ 
  
-  :host([size="small"]) {
+  :host([size="small"][type="number"]:not([no-spin-buttons])) {
     min-width: calc(var(--syn-input-font-size-small)*8.3);
   }
 
-  :host([size="medium"]) {
+  :host([size="medium"][type="number"]:not([no-spin-buttons])) {
     min-width: calc(var(--syn-input-font-size-medium)*9.4);
   }
 
-  :host([size="large"]) {
+  :host([size="large"][type="number"]:not([no-spin-buttons])) {
     min-width: calc(var(--syn-input-font-size-large)*10);
   }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description
Currently we add a fix min-width for ALL syn-inputs. The min-width was only meant for type="number" with displayed spin buttons, so there is always a number visible.


### 🎫 Issues
Closes #755 

## 👩‍💻 Reviewer Notes
Unfortunately it is not possible to use something like **2em** or **2rem** for the min-width as the min-width refers to the whole with of the syn-input and not only the `<input/>` element.

## 📑 Test Plan
Check out that following code will no longer restrict ALL syn-inputs to the min-width but only the `<syn-input type="number" />`

```html
    <syn-input type="email" placeholder="Email"></syn-input><br/>
    <syn-input type="number" placeholder="Number" size="small"></syn-input><br/>
    <syn-input type="number" placeholder="Number"></syn-input><br/>
    <syn-input type="number" placeholder="Number" size="large"></syn-input><br/>
    <syn-input type="number" placeholder="Number" no-spin-buttons></syn-input><br/>
    <syn-input type="date" placeholder="Date"></syn-input>
    <style>
      syn-input {
        width: 75px;
      }
    </style>
   ```


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
