### PR TITLE
fix: 🐛 syn-input is overflowing in flex and grid container with fix size

### DIFF
--- a/packages/components/src/components/input/input.custom.styles.ts
+++ b/packages/components/src/components/input/input.custom.styles.ts
@@ -1,6 +1,12 @@
 import { css } from 'lit';
 
 export default css`
+  /**
+  * Fixes overflowing of the syn-input in flex and grid containers with fix width (https://github.com/synergy-design-system/synergy-design-system/issues/761)
+  */
+  .input__control {
+    width: 100%;
+  }
 
   /**
   * Min-width size adjusted for each size so 2 full digits are shown for type number


### PR DESCRIPTION
# Pull Request

## 📖 Description
Using the syn-input in a flex or grid container leads to overflowing of it over the container.
This PR fixes this issue.

### 🎫 Issues
Closes #761 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan
Check out this code, if the syn-input now no longer overflows with the fix: 

```html
<div class="flex">
  <syn-input></syn-input>
  <syn-input></syn-input>
</div> 
<div class="grid">
  <syn-input></syn-input>
  <syn-input></syn-input>
  <syn-input></syn-input>
  <syn-input></syn-input>
</div> 

<style>
  .flex {
    display: flex;
    gap: 8px;
    width: 200px;
    border: 2px solid red;
    margin-bottom: 24px;
  }
  
  .grid {
    border: 2px solid red;
    display: grid;
    grid-template-columns: 1fr 1fr;
    grid-gap: 8px;
    width: 200px;
  }
  syn-input {
    min-width: unset;
  }
</style>
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
