### PR TITLE
chore: 🔧 styles: Make build run on Windows

### DIFF
--- a/packages/styles/build/jobs/postcss.js
+++ b/packages/styles/build/jobs/postcss.js
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'fs/promises';
+import { normalize } from 'path';
 import { globby } from 'globby';
 import postcss from 'postcss';
 import atImportPlugin from 'postcss-import';
@@ -13,16 +14,22 @@ import { getDirName, getPath, job } from '../shared.js';
  * @returns {string} outputPath
  */
 const getDistName = (inputPath) => {
-  const dirName = getDirName(inputPath);
+  const normalizedInputPath = normalize(inputPath);
+  const dirName = getDirName(normalizedInputPath);
+
+  // Use a default name of the directory for the output file
+  // Will turn src/typography/index.css into dist/typography.css
+  let distName = `./dist/${dirName}.css`;
 
   // Special case for the root node:
   // We do not want to have a file named src.css, but index.css
   // for this special bundle file.
-  if (inputPath === './src/index.css') {
-    return './dist/index.css';
+  // Turns src/index.css into dist/index.css
+  if (normalizedInputPath === normalize('./src/index.css')) {
+    distName = './dist/index.css';
   }
 
-  return `./dist/${dirName}.css`;
+  return normalize(distName);
 };
 
 /**


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds some fixes for synergy not building on Windows. Cause of the problem was that [getDistName](https://github.com/synergy-design-system/synergy-design-system/blob/main/packages/styles/build/jobs/postcss.js#L15) did not check for proper filesystem variants, making it unable to create the file bundles in the first place.

### 🎫 Issues

Closes #785 

## 👩‍💻 Reviewer Notes

-

## 📑 Test Plan

Just check out this branch and check if you can build the `styles` package on Windows now.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
