### PR TITLE
fix: 🐛 syn-select with multiple should not error when value is set to a falsy value

### DIFF
--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -1,4 +1,5 @@
 import { removeSections } from '../remove-section.js';
+import { replaceSections } from '../replace-section.js';
 
 const FILES_TO_TRANSFORM = [
   'select.component.ts',
@@ -21,11 +22,14 @@ const transformComponent = (path, originalContent) => {
     ["'select--pill'", ','],
   ], originalContent);
 
-  // Quickfix, needed until shoelace updates the select components whenDefined selector
-  const content = contentWithRemovedStyles.replaceAll(
-    'wa-option',
-    'syn-option',
-  );
+  const content = replaceSections([
+    [
+      "val = Array.isArray(val) ? val : val.split(' ');",
+      `if (!Array.isArray(val)) {
+        val = typeof val === 'string' ? val.split(' ') : [val].filter(Boolean);
+      }`,
+    ],
+  ], contentWithRemovedStyles);
 
   return {
     content,

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -127,7 +127,9 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   @state()
   set value(val: string | string[]) {
     if (this.multiple) {
-      val = Array.isArray(val) ? val : val.split(' ');
+      if (!Array.isArray(val)) {
+        val = typeof val === 'string' ? val.split(' ') : [val].filter(Boolean);
+      }
     } else {
       val = Array.isArray(val) ? val.join(' ') : val;
     }

--- a/packages/components/src/components/select/select.custom.test.ts
+++ b/packages/components/src/components/select/select.custom.test.ts
@@ -1,0 +1,48 @@
+import '../../../dist/synergy.js';
+import { expect, fixture } from '@open-wc/testing';
+import type SynSelect from './select.js';
+
+describe('<syn-select>', () => {
+  describe('regression tests', () => {
+    describe('#780: should not break on invalid values of the "value" prop when "multiple" is set', () => {
+      it('should support an empty string', async () => {
+        const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
+        el.value = '';
+        await expect(el.value).to.eql(['']);
+      });
+
+      it('should support a string', async () => {
+        const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
+        el.value = 'value';
+        await expect(el.value).to.eql(['value']);
+      });
+
+      it('should support none falsy values', async () => {
+        const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
+        // @ts-expect-error Testing for invalid values
+        el.value = 1;
+        await expect(el.value).to.eql([1]);
+      });
+
+      it('should not allow falsy values', async () => {
+        const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
+        // @ts-expect-error Testing for invalid values
+        el.value = false;
+        await expect(el.value).to.eql([]);
+      });
+
+      it('should not allow undefined values', async () => {
+        const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
+        // @ts-expect-error Testing for invalid values
+        el.value = undefined;
+        await expect(el.value).to.eql([]);
+      });
+
+      it('should support an array of strings', async () => {
+        const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
+        el.value = ['a', 'b', 'c'];
+        await expect(el.value).to.eql(['a', 'b', 'c']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes the issues described in #780. It does so by adjusting the setter for `value` in case of `multiple` is set to true.

### 🎫 Issues

Closes #780 

## 👩‍💻 Reviewer Notes

I opted to allow non falsy values, too, so a value of `1` (Number) will result in `[1]`. However, falsy values will be removed, e.g. a value of `undefined` or `false` will `[]`. 

## 📑 Test Plan

```javascript
// Test script
const sel = document.querySelector('syn-select')
sel.multiple = true;
sel.value = false;
console.log(sel.value);
```

1. Open https://synergy-design-system.github.io/iframe.html?globals=viewport%3AdefaultViewPort&args=&id=components-syn-select--multiple&viewMode=story
2. Run the code displayed above in the console. See that there is an error `t.split is not a function`.
3. Run the same with the code changes in this PR (e.g. on Chromatic Storybook)
4. There should not be an error anymore. The value property should be set to `[]`.
5. Test this with `sel.value = undefined` or any other value as you like. Everything falsy should lead to an empty array.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
