### PR TITLE
fix: 🐛 syn-details in angular animates incorrectly when it is set to be open initially via property binding

### DIFF
--- a/packages/angular/components/accordion/accordion.component.ts
+++ b/packages/angular/components/accordion/accordion.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynAccordion } from '@synergy-design-system/components';
 
@@ -32,12 +34,13 @@ import '@synergy-design-system/components/components/accordion/accordion.js';
   template: '<ng-content></ng-content>',
 })
 export class SynAccordionComponent {
-  public nativeElement: SynAccordion;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynAccordion;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/alert/alert.component.ts
+++ b/packages/angular/components/alert/alert.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynAlert } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -49,12 +51,13 @@ import '@synergy-design-system/components/components/alert/alert.js';
   template: '<ng-content></ng-content>',
 })
 export class SynAlertComponent {
-  public nativeElement: SynAlert;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynAlert;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/badge/badge.component.ts
+++ b/packages/angular/components/badge/badge.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynBadge } from '@synergy-design-system/components';
 
@@ -31,12 +33,13 @@ import '@synergy-design-system/components/components/badge/badge.js';
   template: '<ng-content></ng-content>',
 })
 export class SynBadgeComponent {
-  public nativeElement: SynBadge;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynBadge;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/packages/angular/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynBreadcrumbItem } from '@synergy-design-system/components';
 
@@ -39,12 +41,13 @@ import '@synergy-design-system/components/components/breadcrumb-item/breadcrumb-
   template: '<ng-content></ng-content>',
 })
 export class SynBreadcrumbItemComponent {
-  public nativeElement: SynBreadcrumbItem;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynBreadcrumbItem;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/breadcrumb/breadcrumb.component.ts
+++ b/packages/angular/components/breadcrumb/breadcrumb.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynBreadcrumb } from '@synergy-design-system/components';
 
@@ -34,12 +36,13 @@ import '@synergy-design-system/components/components/breadcrumb/breadcrumb.js';
   template: '<ng-content></ng-content>',
 })
 export class SynBreadcrumbComponent {
-  public nativeElement: SynBreadcrumb;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynBreadcrumb;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/button-group/button-group.component.ts
+++ b/packages/angular/components/button-group/button-group.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynButtonGroup } from '@synergy-design-system/components';
 
@@ -31,12 +33,13 @@ import '@synergy-design-system/components/components/button-group/button-group.j
   template: '<ng-content></ng-content>',
 })
 export class SynButtonGroupComponent {
-  public nativeElement: SynButtonGroup;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynButtonGroup;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/button/button.component.ts
+++ b/packages/angular/components/button/button.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynButton } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -47,12 +49,13 @@ import '@synergy-design-system/components/components/button/button.js';
   template: '<ng-content></ng-content>',
 })
 export class SynButtonComponent {
-  public nativeElement: SynButton;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynButton;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/card/card.component.ts
+++ b/packages/angular/components/card/card.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynCard } from '@synergy-design-system/components';
 
@@ -43,12 +45,13 @@ import '@synergy-design-system/components/components/card/card.js';
   template: '<ng-content></ng-content>',
 })
 export class SynCardComponent {
-  public nativeElement: SynCard;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynCard;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/checkbox/checkbox.component.ts
+++ b/packages/angular/components/checkbox/checkbox.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynCheckbox } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -51,12 +53,13 @@ import '@synergy-design-system/components/components/checkbox/checkbox.js';
   template: '<ng-content></ng-content>',
 })
 export class SynCheckboxComponent {
-  public nativeElement: SynCheckbox;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynCheckbox;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/combobox/combobox.component.ts
+++ b/packages/angular/components/combobox/combobox.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynCombobox } from '@synergy-design-system/components';
 import type { SynChangeEvent } from '@synergy-design-system/components';
@@ -81,12 +83,13 @@ import '@synergy-design-system/components/components/combobox/combobox.js';
   template: '<ng-content></ng-content>',
 })
 export class SynComboboxComponent {
-  public nativeElement: SynCombobox;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynCombobox;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-change', (e: SynChangeEvent) => {
       this.synChangeEvent.emit(e);
     });

--- a/packages/angular/components/dialog/dialog.component.ts
+++ b/packages/angular/components/dialog/dialog.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynDialog } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -76,12 +78,13 @@ import '@synergy-design-system/components/components/dialog/dialog.js';
   template: '<ng-content></ng-content>',
 })
 export class SynDialogComponent {
-  public nativeElement: SynDialog;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynDialog;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/divider/divider.component.ts
+++ b/packages/angular/components/divider/divider.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynDivider } from '@synergy-design-system/components';
 
@@ -31,12 +33,13 @@ import '@synergy-design-system/components/components/divider/divider.js';
   template: '<ng-content></ng-content>',
 })
 export class SynDividerComponent {
-  public nativeElement: SynDivider;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynDivider;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/drawer/drawer.component.ts
+++ b/packages/angular/components/drawer/drawer.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynDrawer } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -83,12 +85,13 @@ import '@synergy-design-system/components/components/drawer/drawer.js';
   template: '<ng-content></ng-content>',
 })
 export class SynDrawerComponent {
-  public nativeElement: SynDrawer;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynDrawer;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/dropdown/dropdown.component.ts
+++ b/packages/angular/components/dropdown/dropdown.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynDropdown } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -48,12 +50,13 @@ import '@synergy-design-system/components/components/dropdown/dropdown.js';
   template: '<ng-content></ng-content>',
 })
 export class SynDropdownComponent {
-  public nativeElement: SynDropdown;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynDropdown;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/file/file.component.ts
+++ b/packages/angular/components/file/file.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynFile } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -71,12 +73,13 @@ import '@synergy-design-system/components/components/file/file.js';
   template: '<ng-content></ng-content>',
 })
 export class SynFileComponent {
-  public nativeElement: SynFile;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynFile;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/header/header.component.ts
+++ b/packages/angular/components/header/header.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynHeader } from '@synergy-design-system/components';
 import type { SynBurgerMenuClosedEvent } from '@synergy-design-system/components';
@@ -53,12 +55,13 @@ import '@synergy-design-system/components/components/header/header.js';
   template: '<ng-content></ng-content>',
 })
 export class SynHeaderComponent {
-  public nativeElement: SynHeader;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynHeader;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener(
       'syn-burger-menu-closed',
       (e: SynBurgerMenuClosedEvent) => {

--- a/packages/angular/components/icon-button/icon-button.component.ts
+++ b/packages/angular/components/icon-button/icon-button.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynIconButton } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -35,12 +37,13 @@ import '@synergy-design-system/components/components/icon-button/icon-button.js'
   template: '<ng-content></ng-content>',
 })
 export class SynIconButtonComponent {
-  public nativeElement: SynIconButton;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynIconButton;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/icon/icon.component.ts
+++ b/packages/angular/components/icon/icon.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynIcon } from '@synergy-design-system/components';
 import type { SynLoadEvent } from '@synergy-design-system/components';
@@ -34,12 +36,13 @@ import '@synergy-design-system/components/components/icon/icon.js';
   template: '<ng-content></ng-content>',
 })
 export class SynIconComponent {
-  public nativeElement: SynIcon;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynIcon;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-load', (e: SynLoadEvent) => {
       this.synLoadEvent.emit(e);
     });

--- a/packages/angular/components/input/input.component.ts
+++ b/packages/angular/components/input/input.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynInput } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -67,12 +69,13 @@ import '@synergy-design-system/components/components/input/input.js';
   template: '<ng-content></ng-content>',
 })
 export class SynInputComponent {
-  public nativeElement: SynInput;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynInput;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/menu-item/menu-item.component.ts
+++ b/packages/angular/components/menu-item/menu-item.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynMenuItem } from '@synergy-design-system/components';
 
@@ -47,12 +49,13 @@ import '@synergy-design-system/components/components/menu-item/menu-item.js';
   template: '<ng-content></ng-content>',
 })
 export class SynMenuItemComponent {
-  public nativeElement: SynMenuItem;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynMenuItem;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/menu-label/menu-label.component.ts
+++ b/packages/angular/components/menu-label/menu-label.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynMenuLabel } from '@synergy-design-system/components';
 
@@ -37,11 +39,12 @@ import '@synergy-design-system/components/components/menu-label/menu-label.js';
   template: '<ng-content></ng-content>',
 })
 export class SynMenuLabelComponent {
-  public nativeElement: SynMenuLabel;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynMenuLabel;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 }

--- a/packages/angular/components/menu/menu.component.ts
+++ b/packages/angular/components/menu/menu.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynMenu } from '@synergy-design-system/components';
 import type { SynSelectEvent } from '@synergy-design-system/components';
@@ -31,12 +33,13 @@ import '@synergy-design-system/components/components/menu/menu.js';
   template: '<ng-content></ng-content>',
 })
 export class SynMenuComponent {
-  public nativeElement: SynMenu;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynMenu;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-select', (e: SynSelectEvent) => {
       this.synSelectEvent.emit(e);
     });

--- a/packages/angular/components/nav-item/nav-item.component.ts
+++ b/packages/angular/components/nav-item/nav-item.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynNavItem } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -69,12 +71,13 @@ import '@synergy-design-system/components/components/nav-item/nav-item.js';
   template: '<ng-content></ng-content>',
 })
 export class SynNavItemComponent {
-  public nativeElement: SynNavItem;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynNavItem;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/optgroup/optgroup.component.ts
+++ b/packages/angular/components/optgroup/optgroup.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynOptgroup } from '@synergy-design-system/components';
 
@@ -43,12 +45,13 @@ import '@synergy-design-system/components/components/optgroup/optgroup.js';
   template: '<ng-content></ng-content>',
 })
 export class SynOptgroupComponent {
-  public nativeElement: SynOptgroup;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynOptgroup;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/option/option.component.ts
+++ b/packages/angular/components/option/option.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynOption } from '@synergy-design-system/components';
 
@@ -39,12 +41,13 @@ import '@synergy-design-system/components/components/option/option.js';
   template: '<ng-content></ng-content>',
 })
 export class SynOptionComponent {
-  public nativeElement: SynOption;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynOption;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/popup/popup.component.ts
+++ b/packages/angular/components/popup/popup.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynPopup } from '@synergy-design-system/components';
 import type { SynRepositionEvent } from '@synergy-design-system/components';
@@ -50,12 +52,13 @@ import '@synergy-design-system/components/components/popup/popup.js';
   template: '<ng-content></ng-content>',
 })
 export class SynPopupComponent {
-  public nativeElement: SynPopup;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynPopup;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener(
       'syn-reposition',
       (e: SynRepositionEvent) => {

--- a/packages/angular/components/prio-nav/prio-nav.component.ts
+++ b/packages/angular/components/prio-nav/prio-nav.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynPrioNav } from '@synergy-design-system/components';
 
@@ -55,11 +57,12 @@ import '@synergy-design-system/components/components/prio-nav/prio-nav.js';
   template: '<ng-content></ng-content>',
 })
 export class SynPrioNavComponent {
-  public nativeElement: SynPrioNav;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynPrioNav;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 }

--- a/packages/angular/components/progress-bar/progress-bar.component.ts
+++ b/packages/angular/components/progress-bar/progress-bar.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynProgressBar } from '@synergy-design-system/components';
 
@@ -39,12 +41,13 @@ import '@synergy-design-system/components/components/progress-bar/progress-bar.j
   template: '<ng-content></ng-content>',
 })
 export class SynProgressBarComponent {
-  public nativeElement: SynProgressBar;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynProgressBar;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/progress-ring/progress-ring.component.ts
+++ b/packages/angular/components/progress-ring/progress-ring.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynProgressRing } from '@synergy-design-system/components';
 
@@ -39,12 +41,13 @@ import '@synergy-design-system/components/components/progress-ring/progress-ring
   template: '<ng-content></ng-content>',
 })
 export class SynProgressRingComponent {
-  public nativeElement: SynProgressRing;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynProgressRing;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/radio-button/radio-button.component.ts
+++ b/packages/angular/components/radio-button/radio-button.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynRadioButton } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -42,12 +44,13 @@ import '@synergy-design-system/components/components/radio-button/radio-button.j
   template: '<ng-content></ng-content>',
 })
 export class SynRadioButtonComponent {
-  public nativeElement: SynRadioButton;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynRadioButton;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/radio-group/radio-group.component.ts
+++ b/packages/angular/components/radio-group/radio-group.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynRadioGroup } from '@synergy-design-system/components';
 import type { SynChangeEvent } from '@synergy-design-system/components';
@@ -47,12 +49,13 @@ import '@synergy-design-system/components/components/radio-group/radio-group.js'
   template: '<ng-content></ng-content>',
 })
 export class SynRadioGroupComponent {
-  public nativeElement: SynRadioGroup;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynRadioGroup;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-change', (e: SynChangeEvent) => {
       this.synChangeEvent.emit(e);
     });

--- a/packages/angular/components/radio/radio.component.ts
+++ b/packages/angular/components/radio/radio.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynRadio } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -41,12 +43,13 @@ import '@synergy-design-system/components/components/radio/radio.js';
   template: '<ng-content></ng-content>',
 })
 export class SynRadioComponent {
-  public nativeElement: SynRadio;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynRadio;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/range-tick/range-tick.component.ts
+++ b/packages/angular/components/range-tick/range-tick.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynRangeTick } from '@synergy-design-system/components';
 
@@ -35,12 +37,13 @@ import '@synergy-design-system/components/components/range-tick/range-tick.js';
   template: '<ng-content></ng-content>',
 })
 export class SynRangeTickComponent {
-  public nativeElement: SynRangeTick;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynRangeTick;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/range/range.component.ts
+++ b/packages/angular/components/range/range.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynRange } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -77,12 +79,13 @@ import '@synergy-design-system/components/components/range/range.js';
   template: '<ng-content></ng-content>',
 })
 export class SynRangeComponent {
-  public nativeElement: SynRange;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynRange;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/select/select.component.ts
+++ b/packages/angular/components/select/select.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynSelect } from '@synergy-design-system/components';
 import type { SynChangeEvent } from '@synergy-design-system/components';
@@ -77,12 +79,13 @@ import '@synergy-design-system/components/components/select/select.js';
   template: '<ng-content></ng-content>',
 })
 export class SynSelectComponent {
-  public nativeElement: SynSelect;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynSelect;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-change', (e: SynChangeEvent) => {
       this.synChangeEvent.emit(e);
     });

--- a/packages/angular/components/side-nav/side-nav.component.ts
+++ b/packages/angular/components/side-nav/side-nav.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynSideNav } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -72,12 +74,13 @@ import '@synergy-design-system/components/components/side-nav/side-nav.js';
   template: '<ng-content></ng-content>',
 })
 export class SynSideNavComponent {
-  public nativeElement: SynSideNav;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynSideNav;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/spinner/spinner.component.ts
+++ b/packages/angular/components/spinner/spinner.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynSpinner } from '@synergy-design-system/components';
 
@@ -33,11 +35,12 @@ import '@synergy-design-system/components/components/spinner/spinner.js';
   template: '<ng-content></ng-content>',
 })
 export class SynSpinnerComponent {
-  public nativeElement: SynSpinner;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynSpinner;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 }

--- a/packages/angular/components/switch/switch.component.ts
+++ b/packages/angular/components/switch/switch.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynSwitch } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -50,12 +52,13 @@ import '@synergy-design-system/components/components/switch/switch.js';
   template: '<ng-content></ng-content>',
 })
 export class SynSwitchComponent {
-  public nativeElement: SynSwitch;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynSwitch;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/tab-group/tab-group.component.ts
+++ b/packages/angular/components/tab-group/tab-group.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynTabGroup } from '@synergy-design-system/components';
 import type { SynTabShowEvent } from '@synergy-design-system/components';
@@ -51,12 +53,13 @@ import '@synergy-design-system/components/components/tab-group/tab-group.js';
   template: '<ng-content></ng-content>',
 })
 export class SynTabGroupComponent {
-  public nativeElement: SynTabGroup;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynTabGroup;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener(
       'syn-tab-show',
       (e: SynTabShowEvent) => {

--- a/packages/angular/components/tab-panel/tab-panel.component.ts
+++ b/packages/angular/components/tab-panel/tab-panel.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynTabPanel } from '@synergy-design-system/components';
 
@@ -33,12 +35,13 @@ import '@synergy-design-system/components/components/tab-panel/tab-panel.js';
   template: '<ng-content></ng-content>',
 })
 export class SynTabPanelComponent {
-  public nativeElement: SynTabPanel;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynTabPanel;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/components/tab/tab.component.ts
+++ b/packages/angular/components/tab/tab.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynTab } from '@synergy-design-system/components';
 import type { SynCloseEvent } from '@synergy-design-system/components';
@@ -37,12 +39,13 @@ import '@synergy-design-system/components/components/tab/tab.js';
   template: '<ng-content></ng-content>',
 })
 export class SynTabComponent {
-  public nativeElement: SynTab;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynTab;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-close', (e: SynCloseEvent) => {
       this.synCloseEvent.emit(e);
     });

--- a/packages/angular/components/tag/tag.component.ts
+++ b/packages/angular/components/tag/tag.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynTag } from '@synergy-design-system/components';
 import type { SynRemoveEvent } from '@synergy-design-system/components';
@@ -38,12 +40,13 @@ import '@synergy-design-system/components/components/tag/tag.js';
   template: '<ng-content></ng-content>',
 })
 export class SynTagComponent {
-  public nativeElement: SynTag;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynTag;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-remove', (e: SynRemoveEvent) => {
       this.synRemoveEvent.emit(e);
     });

--- a/packages/angular/components/textarea/textarea.component.ts
+++ b/packages/angular/components/textarea/textarea.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynTextarea } from '@synergy-design-system/components';
 import type { SynBlurEvent } from '@synergy-design-system/components';
@@ -47,12 +49,13 @@ import '@synergy-design-system/components/components/textarea/textarea.js';
   template: '<ng-content></ng-content>',
 })
 export class SynTextareaComponent {
-  public nativeElement: SynTextarea;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynTextarea;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-blur', (e: SynBlurEvent) => {
       this.synBlurEvent.emit(e);
     });

--- a/packages/angular/components/tooltip/tooltip.component.ts
+++ b/packages/angular/components/tooltip/tooltip.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynTooltip } from '@synergy-design-system/components';
 import type { SynShowEvent } from '@synergy-design-system/components';
@@ -52,12 +54,13 @@ import '@synergy-design-system/components/components/tooltip/tooltip.js';
   template: '<ng-content></ng-content>',
 })
 export class SynTooltipComponent {
-  public nativeElement: SynTooltip;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynTooltip;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
     this.nativeElement.addEventListener('syn-show', (e: SynShowEvent) => {
       this.synShowEvent.emit(e);
     });

--- a/packages/angular/components/validate/validate.component.ts
+++ b/packages/angular/components/validate/validate.component.ts
@@ -10,6 +10,8 @@ import {
   Input,
   Output,
   EventEmitter,
+  inject,
+  AfterContentInit,
 } from '@angular/core';
 import type { SynValidate } from '@synergy-design-system/components';
 
@@ -38,12 +40,13 @@ import '@synergy-design-system/components/components/validate/validate.js';
   template: '<ng-content></ng-content>',
 })
 export class SynValidateComponent {
-  public nativeElement: SynValidate;
-  private _ngZone: NgZone;
+  private _elementRef = inject(ElementRef);
+  private _ngZone: NgZone = inject(NgZone);
 
-  constructor(e: ElementRef, ngZone: NgZone) {
-    this.nativeElement = e.nativeElement;
-    this._ngZone = ngZone;
+  public nativeElement: SynValidate;
+
+  constructor() {
+    this.nativeElement = this._elementRef.nativeElement;
   }
 
   /**

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -24,7 +24,9 @@
   },
   "version": "2.22.0",
   "scripts": {
-    "_build": "ng-packagr -c tsconfig.lib.json"
+    "_build": "pnpm _clean && ng-packagr -c tsconfig.lib.json",
+    "_clean": "rm -rf ../_private/angular-demo/.angular",
+    "_start": "pnpm _build && pnpm run -C ../_private/angular-demo start"
   },
   "peerDependencies": {
     "@angular/core": "^16.2.12 || ^17.0.0 || ^18.0.0 || ^19.0.0",


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds a workaround for the syn-details angular wrapper by removing the initial open animation and adding it again after the initial load.

### 🎫 Issues
Closes #784 

## 👩‍💻 Reviewer Notes
Unfortunately I haven't found any other solution other than this hack..
We could also hide the syn-details until the animation is done, but this will result in the syn-details is displayed too late (it has a noticeable delay).

## 📑 Test Plan
Have a look at the angular demo, that the syn-details open animation is no longer shown on page change


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
