### PR TITLE
fix: 🐛  syn-card font-size and color of slot content can not be changed 

### DIFF
--- a/packages/components/src/components/card/card.custom.styles.ts
+++ b/packages/components/src/components/card/card.custom.styles.ts
@@ -24,8 +24,7 @@ export default css`
   /**
    * Card body
    */
-  .card__body,
-  .card__body::slotted(*) {
+  .card__body {
     color: var(--syn-typography-color-text);
     font: var(--syn-body-medium-regular);
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description
This problem fixes the issue, that if wrapping the slot content of a syn-card with another html tag (like `<span/>`) the font-size and color of the content in the syn-card can not be changed.

### 🎫 Issues
Closes #789 

## 👩‍💻 Reviewer Notes
There should be no change for the stakeholder with this fix. They would need to overwrite the syn-card::part(body) explicitly to change their content font-size in the syn-card.

Use this test code. Before only the background was applied, but not the color and font-size styling. With the fix now every stylings are applied

```html
    <syn-card class="card-basic">
      <span>
        This is just a basic card. No image, no header, and no footer. Just your content.
      </span>
    </syn-card>
    <style>
    syn-card::part(body) {
      background:green; /* is getting applied */
      color:red; /* is NOT getting applied */
      font-size: 10px; /* is NOT getting applied */
    }
   </style>
```


## 📑 Test Plan

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
