### PR TITLE
fix: 🐛 stepper buttons of reused syn-input type=number node no longer working

### DIFF
--- a/packages/components/src/components/input/input.custom.test.ts
+++ b/packages/components/src/components/input/input.custom.test.ts
@@ -174,6 +174,50 @@ describe('<syn-input>', () => {
         // only emit change event after pointer up
         expect(changeHandler).to.have.been.calledOnce;
       });
+
+      it('should decrement if decrement button is clicked after syn-input was removed and added to DOM again ', async () => {
+        const el = await fixture<SynInput>(html`
+          <div>
+            <syn-input type="number" value="3"></syn-input>
+          </div>
+        `);
+        const input = el.querySelector('syn-input')!;
+        const decrementButton = input.shadowRoot!.querySelector<HTMLButtonElement>('[part~="decrement-number-stepper"]');
+        
+        decrementButton.dispatchEvent(new PointerEvent('pointerdown'));
+        document.dispatchEvent(new PointerEvent('pointerup'));
+        await input.updateComplete;
+        expect(input.value).to.equal('2');
+
+        input.remove();
+        el.appendChild(input);
+        decrementButton.dispatchEvent(new PointerEvent('pointerdown'));
+        document.dispatchEvent(new PointerEvent('pointerup'));
+        await input.updateComplete;
+        expect(input.value).to.equal('1');
+      }); 
+
+      it('should increment if increment button is clicked after syn-input was removed and added to DOM again ', async () => {
+        const el = await fixture<SynInput>(html`
+          <div>
+            <syn-input type="number" value="3"></syn-input>
+          </div>
+        `);
+        const input = el.querySelector('syn-input')!;
+        const incrementButton = input.shadowRoot!.querySelector<HTMLButtonElement>('[part~="increment-number-stepper"]');
+        
+        incrementButton.dispatchEvent(new PointerEvent('pointerdown'));
+        document.dispatchEvent(new PointerEvent('pointerup'));
+        await input.updateComplete;
+        expect(input.value).to.equal('4');
+
+        input.remove();
+        el.appendChild(input);
+        incrementButton.dispatchEvent(new PointerEvent('pointerdown'));
+        document.dispatchEvent(new PointerEvent('pointerup'));
+        await input.updateComplete;
+        expect(input.value).to.equal('5');
+      }); 
     });
   });    
 });

--- a/packages/components/src/internal/longpress.test.ts
+++ b/packages/components/src/internal/longpress.test.ts
@@ -1,0 +1,83 @@
+/* eslint-disable */
+import '../../../dist/synergy.js';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+
+import { longPress } from './longpress.js';
+
+describe('longpress directive', () => {
+
+  it('should call start and end callback once on single click', async () => {
+    const startCallback = sinon.spy();
+    const endCallback = sinon.spy();
+    const button =  await fixture(html`
+      <button
+        ${longPress({ start: startCallback, end: endCallback })}
+      >
+        my button
+      </button>
+    `);
+    button.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
+    document.dispatchEvent(new PointerEvent('pointerup', { button: 0 }));
+    expect(startCallback.callCount).to.equal(1);
+    expect(endCallback.callCount).to.equal(1);
+  });
+
+  it('should call start callback repeatedly on long press', async () => {
+    const startCallback = sinon.spy();
+    const endCallback = sinon.spy();
+    const button =  await fixture(html`
+      <button
+        ${longPress({ start: startCallback, end: endCallback })}
+      >
+        my button
+      </button>
+    `);
+    button.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
+    await aTimeout(700); // wait for long press duration
+    document.dispatchEvent(new PointerEvent('pointerup', { button: 0 }));
+
+    expect(startCallback.callCount).to.be.greaterThan(1);
+    expect(endCallback.callCount).to.equal(1);
+  });
+
+
+  it('should not call callbacks if button is disabled', async () => {
+    const startCallback = sinon.spy();
+    const endCallback = sinon.spy();
+    const button =  await fixture(html`
+      <button
+        disabled
+        ${longPress({ start: startCallback, end: endCallback })}
+      >
+        my button
+      </button>
+    `);
+    button.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
+    document.dispatchEvent(new PointerEvent('pointerup', { button: 0 }));
+
+    expect(startCallback.callCount).to.equal(0);
+    expect(endCallback.callCount).to.equal(0);
+  });
+
+  it('should stop calling start callback if button is disabled during long press', async () => {
+    const startCallback = sinon.spy();
+    const endCallback = sinon.spy();
+    const button = await fixture(html`
+      <button
+        ${longPress({ start: startCallback, end: endCallback })}
+      >
+        my button
+      </button>
+    `) as HTMLButtonElement;
+    button.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
+    await aTimeout(700); // wait for long press duration
+    const currentCallCount = startCallback.callCount;
+    button.disabled = true; // disable the button during long press
+    await aTimeout(100); // wait a bit more to ensure no more calls are made
+    document.dispatchEvent(new PointerEvent('pointerup', { button: 0 }));
+    expect(startCallback.callCount).to.equal(currentCallCount);
+    expect(endCallback.callCount).to.equal(1);
+  });
+
+});

--- a/packages/components/src/internal/longpress.ts
+++ b/packages/components/src/internal/longpress.ts
@@ -58,6 +58,10 @@ class LongPressDirective extends AsyncDirective {
     return noChange;
   }
 
+  reconnected(): void {
+    this.host.addEventListener('pointerdown', this.handlePointerDown);
+  }
+
   protected disconnected(): void {
     this.stopSpinningAndCleanUp();
     this.host.removeEventListener('pointerdown', this.handlePointerDown);


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes the issue that if a `<syn-input type="number"/>` was removed from DOM but appended again, the stepper buttons would no longer work. This is because the `longpress` directive would remove the eventlistener and not append it again, as the directive is not completely new created but RECONNECTED.  Therefore the eventlistener is attached again, if the `reconnected` lifecycle method of the directive is called.

### 🎫 Issues
Closes #795 

## 👩‍💻 Reviewer Notes

Unfortunately I needed to add some test to the syn-input itself as for some reason I was not able to trigger the `disconnected` method of the directive in their unit tests 😕

## 📑 Test Plan
Check out this code if it is working now: 

```html
<div id="wrapper">
      <syn-input id="input" type="number" placeholder="Number"></syn-input>
     <syn-button id="btn">btn</syn-button>
</div>

<script type="module">
const wrapper = document.querySelector('#wrapper');
const button = document.querySelector('#btn');
  const input = document.querySelector('#input');
  
 button.addEventListener('click', () => {
   input.remove();
   wrapper.appendChild(input);
 });
</script>
```

To have a look at the old behavior see this codepen: https://codepen.io/kirchsuSICKAG/pen/WbNpRyB?editors=1110

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
