### PR TITLE
fix: 🐛 setGlobalDefaultSettings does overwrite explicitly set default property values with new default size

### DIFF
--- a/packages/components/src/utilities/defaultSettings/defaultSettings.test.ts
+++ b/packages/components/src/utilities/defaultSettings/defaultSettings.test.ts
@@ -41,6 +41,12 @@ describe('GlobalSettings', () => {
       expect(button.size).to.equal('small');
     });
 
+    it('should render the button with its original size when a size=medium property is provided', async () => {
+      setDefaultSettingsForElement<SynButton>('SynButton', { size: 'large' });
+      const button = await fixture<SynButton>(html`<syn-button size="medium">Button</syn-button>`);
+      expect(button.size).to.equal('medium');
+    });
+
     it('should return the changed settings when called', () => {
       const newSettings = setDefaultSettingsForElement<SynButton>('SynButton', { size: 'large' });
       expect(newSettings).to.deep.equal({


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes the issue, that explicitly set properties with their default value (e.g. size="medium" for the syn-button `<syn-button size="medium" />`) is not honored, but overwritten with the new default value.

### 🎫 Issues
Closes #799 

## 👩‍💻 Reviewer Notes

I just found out that the `requestUpdate` callback is called for explicitly set properties, even if the property is set to its default value. If a property is not explicitly set, this callback is not called. This behaves the same for plain webcomponents and for all 3 web frameworks.
Via this mechanism we can find out, if just the default from internal was used or if it was explicitly set.

## 📑 Test Plan

- check out for plain web component and all 3 web frameworks, if the behavior is now correct!

- example code angular: 

```html
<syn-button>default</syn-button>
<syn-button size="small">small</syn-button>
<syn-button size="medium">medium</syn-button>
<syn-button size="large">large</syn-button>
```

- example code vue:

```html
  <SynVueButton>default</SynVueButton>
  <SynVueButton size="small">small</SynVueButton>
  <SynVueButton size="medium">medium</SynVueButton>
  <SynVueButton size="large">large</SynVueButton>
```

- example code react:

```html
    {/* New react way */}
    <syn-button>default</syn-button>
    <syn-button size="small">small</syn-button>
    <syn-button size="medium">medium</syn-button>
    <syn-button size="large">large</syn-button>

    {/* Old react way */}
    <SynButton>default</SynButton>
    <SynButton size="small">small</SynButton>
    <SynButton size="medium">medium</SynButton>
    <SynButton size="large">large</SynButton>
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
