### PR TITLE
feat: ✨ Allow to override autofill styles for syn-input

### DIFF
--- a/packages/angular/components/input/input.component.ts
+++ b/packages/angular/components/input/input.component.ts
@@ -61,6 +61,11 @@ import '@synergy-design-system/components/components/input/input.js';
  * @csspart decrement-number-stepper - The decrement number stepper button.
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
+ *
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
  */
 @Component({
   selector: 'syn-input',

--- a/packages/angular/components/input/input.component.ts
+++ b/packages/angular/components/input/input.component.ts
@@ -62,10 +62,10 @@ import '@synergy-design-system/components/components/input/input.js';
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
  *
- * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
- * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
  */
 @Component({
   selector: 'syn-input',

--- a/packages/components/scripts/vendorism/custom/input.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/input.vendorism.js
@@ -229,18 +229,6 @@ const transformStyles = (path, originalContent) => {
   content = content.replaceAll('.input--no-spin-buttons ', '');
 
   // #800: Make sure we allow to override autofill vis css variables
-  content = addSectionAfter(
-    content,
-    `:host {
-    display: block;`,
-    `
-    --syn-input-autofill-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset;
-    --syn-input-autofill-readonly-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset;
-    --syn-input-autofill-text-fill-color: var(--syn-color-primary-500);
-    --syn-input-autofill-caret-color: var(--syn-input-color);
-    `,
-  );
-
   content = replaceSections([
     [
       'box-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset !important;',
@@ -259,6 +247,18 @@ const transformStyles = (path, originalContent) => {
       'box-shadow: var(--syn-input-autofill-readonly-shadow) !important;',
     ],
   ], content);
+
+  content = addSectionAfter(
+    content,
+    `:host {
+    display: block;`,
+    `
+    --syn-input-autofill-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset;
+    --syn-input-autofill-readonly-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset;
+    --syn-input-autofill-text-fill-color: var(--syn-color-primary-500);
+    --syn-input-autofill-caret-color: var(--syn-input-color);
+    `,
+  );
 
   return {
     content,

--- a/packages/components/scripts/vendorism/custom/input.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/input.vendorism.js
@@ -14,9 +14,18 @@ const FILES_TO_TRANSFORM = [
  * @returns
  */
 const transformComponent = (path, originalContent) => {
+  let content = removeSections([
+    ['/** Draws a filled', 'filled = false;'],
+    ['/** Draws a pill-style', 'pill = false;'],
+    ["'input--pill':", ','],
+  ], originalContent);
+
+  // Replace filled with readonly
+  content = content.replaceAll('filled', 'readonly');
+
   // #800: Add documentation for the new css variable tokens
-  let content = addSectionBefore(
-    originalContent,
+  content = addSectionBefore(
+    content,
     ` */
 export`,
     ` *
@@ -26,15 +35,6 @@ export`,
  * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
     `.trimEnd(),
   );
-
-  content = removeSections([
-    ['/** Draws a filled', 'filled = false;'],
-    ['/** Draws a pill-style', 'pill = false;'],
-    ["'input--pill':", ','],
-  ], content);
-
-  // Replace filled with readonly
-  content = content.replaceAll('filled', 'readonly');
 
   // We need to add classes depending on prefix and suffix slots to use them in CSS
   content = content.replace(

--- a/packages/components/scripts/vendorism/custom/input.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/input.vendorism.js
@@ -1,3 +1,4 @@
+import { addSectionAfter, addSectionBefore, replaceSections } from '../replace-section.js';
 import { removeSections } from '../remove-section.js';
 
 const FILES_TO_TRANSFORM = [
@@ -13,11 +14,24 @@ const FILES_TO_TRANSFORM = [
  * @returns
  */
 const transformComponent = (path, originalContent) => {
-  let content = removeSections([
+  // #800: Add documentation for the new css variable tokens
+  let content = addSectionBefore(
+    originalContent,
+    ` */
+export`,
+    ` *
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
+    `.trimEnd(),
+  );
+
+  content = removeSections([
     ['/** Draws a filled', 'filled = false;'],
     ['/** Draws a pill-style', 'pill = false;'],
     ["'input--pill':", ','],
-  ], originalContent);
+  ], content);
 
   // Replace filled with readonly
   content = content.replaceAll('filled', 'readonly');
@@ -213,6 +227,38 @@ const transformStyles = (path, originalContent) => {
 
   // Always hide browser built-in spin buttons
   content = content.replaceAll('.input--no-spin-buttons ', '');
+
+  // #800: Make sure we allow to override autofill vis css variables
+  content = addSectionAfter(
+    content,
+    `:host {
+    display: block;`,
+    `
+    --syn-input-autofill-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset;
+    --syn-input-autofill-readonly-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset;
+    --syn-input-autofill-text-fill-color: var(--syn-color-primary-500);
+    --syn-input-autofill-caret-color: var(--syn-input-color);
+    `,
+  );
+
+  content = replaceSections([
+    [
+      'box-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset !important;',
+      'box-shadow: var(--syn-input-autofill-shadow) !important;',
+    ],
+    [
+      '-webkit-text-fill-color: var(--syn-color-primary-500);',
+      '-webkit-text-fill-color: var(--syn-input-autofill-text-fill-color);',
+    ],
+    [
+      'caret-color: var(--syn-input-color);',
+      'caret-color: var(--syn-input-autofill-caret-color);',
+    ],
+    [
+      'box-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset !important;',
+      'box-shadow: var(--syn-input-autofill-readonly-shadow) !important;',
+    ],
+  ], content);
 
   return {
     content,

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -70,10 +70,10 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
  *
- * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
- * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
  */
 @enableDefaultSettings('SynInput')
 export default class SynInput extends SynergyElement implements SynergyFormControl {

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -69,6 +69,11 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart decrement-number-stepper - The decrement number stepper button.
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
+ *
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
  */
 @enableDefaultSettings('SynInput')
 export default class SynInput extends SynergyElement implements SynergyFormControl {

--- a/packages/components/src/components/input/input.styles.ts
+++ b/packages/components/src/components/input/input.styles.ts
@@ -16,7 +16,7 @@ export default css`
     --syn-input-autofill-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset;
     --syn-input-autofill-readonly-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset;
     --syn-input-autofill-text-fill-color: var(--syn-color-primary-500);
-    --syn-input-autofill-caret-color: var(--syn-input-color);
+    --syn-input-autofill-caret-color: var(--syn-input-autofill-caret-color);
   }
 
   .input {

--- a/packages/components/src/components/input/input.styles.ts
+++ b/packages/components/src/components/input/input.styles.ts
@@ -16,7 +16,7 @@ export default css`
     --syn-input-autofill-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset;
     --syn-input-autofill-readonly-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset;
     --syn-input-autofill-text-fill-color: var(--syn-color-primary-500);
-    --syn-input-autofill-caret-color: var(--syn-input-autofill-caret-color);
+    --syn-input-autofill-caret-color: var(--syn-input-color);
   }
 
   .input {

--- a/packages/components/src/components/input/input.styles.ts
+++ b/packages/components/src/components/input/input.styles.ts
@@ -12,6 +12,11 @@ export default css`
 	/* stylelint-disable */
   :host {
     display: block;
+
+    --syn-input-autofill-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset;
+    --syn-input-autofill-readonly-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset;
+    --syn-input-autofill-text-fill-color: var(--syn-color-primary-500);
+    --syn-input-autofill-caret-color: var(--syn-input-autofill-caret-color);
   }
 
   .input {
@@ -121,16 +126,16 @@ export default css`
   .input__control:-webkit-autofill:hover,
   .input__control:-webkit-autofill:focus,
   .input__control:-webkit-autofill:active {
-    box-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-background-color-hover) inset !important;
-    -webkit-text-fill-color: var(--syn-color-primary-500);
-    caret-color: var(--syn-input-color);
+    box-shadow: var(--syn-input-autofill-shadow) !important;
+    -webkit-text-fill-color: var(--syn-input-autofill-text-fill-color);
+    caret-color: var(--syn-input-autofill-caret-color);
   }
 
   .input--readonly .input__control:-webkit-autofill,
   .input--readonly .input__control:-webkit-autofill:hover,
   .input--readonly .input__control:-webkit-autofill:focus,
   .input--readonly .input__control:-webkit-autofill:active {
-    box-shadow: 0 0 0 var(--syn-input-height-large) var(--syn-input-readonly-background-color) inset !important;
+    box-shadow: var(--syn-input-autofill-readonly-shadow) !important;
   }
 
   .input__control::placeholder {

--- a/packages/react/src/components/input.ts
+++ b/packages/react/src/components/input.ts
@@ -59,10 +59,10 @@ Component.define('syn-input');
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
  *
- * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
- * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
  */
 export const SynInput = createComponent({
   displayName: 'SynInput',

--- a/packages/react/src/components/input.ts
+++ b/packages/react/src/components/input.ts
@@ -58,6 +58,11 @@ Component.define('syn-input');
  * @csspart decrement-number-stepper - The decrement number stepper button.
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
+ *
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
  */
 export const SynInput = createComponent({
   displayName: 'SynInput',

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -725,6 +725,11 @@ export type SynCustomElement<
  * @csspart decrement-number-stepper - The decrement number stepper button.
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
+ *
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
  */ export type SynInputJSXElement = SynCustomElement<
   SynInput,
   [
@@ -1999,6 +2004,11 @@ declare module 'react' {
        * @csspart decrement-number-stepper - The decrement number stepper button.
        * @csspart increment-number-stepper - The increment number stepper button.
        * @csspart divider - The divider between the increment and decrement number stepper buttons.
+       *
+       * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
+       * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
+       * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
+       * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
        */ 'syn-input': SynInputJSXElement;
       /**
        * @summary Menus provide a list of options for the user to choose from.

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -726,10 +726,10 @@ export type SynCustomElement<
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
  *
- * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
- * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
  */ export type SynInputJSXElement = SynCustomElement<
   SynInput,
   [
@@ -2005,10 +2005,10 @@ declare module 'react' {
        * @csspart increment-number-stepper - The increment number stepper button.
        * @csspart divider - The divider between the increment and decrement number stepper buttons.
        *
-       * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
-       * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
-       * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
-       * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
+       * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+       * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+       * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+       * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
        */ 'syn-input': SynInputJSXElement;
       /**
        * @summary Menus provide a list of options for the user to choose from.

--- a/packages/vue/src/components/SynVueInput.vue
+++ b/packages/vue/src/components/SynVueInput.vue
@@ -45,6 +45,11 @@
  * @csspart decrement-number-stepper - The decrement number stepper button.
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
+ *
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
  */
 import { computed, ref } from 'vue';
 import '@synergy-design-system/components/components/input/input.js';

--- a/packages/vue/src/components/SynVueInput.vue
+++ b/packages/vue/src/components/SynVueInput.vue
@@ -46,10 +46,10 @@
  * @csspart increment-number-stepper - The increment number stepper button.
  * @csspart divider - The divider between the increment and decrement number stepper buttons.
  *
- * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autoreadonly.
- * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autoreadonly.
- * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autoreadonly.
+ * @cssproperty --syn-input-autofill-shadow - The shadow to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-readonly-shadow - The shadow to apply when the input is readonly and autofilled.
+ * @cssproperty --syn-input-autofill-text-fill-color - The text fill color to apply when the input is autofilled.
+ * @cssproperty --syn-input-autofill-caret-color - The caret color to apply when the input is autofilled.
  */
 import { computed, ref } from 'vue';
 import '@synergy-design-system/components/components/input/input.js';


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds the possibility to adjust the default coloring of `<syn-input>` when used with user data autofilling enabled.

### 🎫 Issues

Closes #800 

## 👩‍💻 Reviewer Notes

Autofill has some common requirements:

1. You need to have it wrapped in a form
2. You have to have at least two fields for autocomplete to work (e.g. E-Mail and Name, Street...)
3. Your browser must be setup to automatically add your contact information (default for Safari, configurable for the other browsers)

## 📑 Test Plan

Start Storybook and add the following story to `input.stories.ts`:

```typescript
export const FormDemo: Story = {
  render: () => html`
    <form method="post">
      <syn-input name="name" type="text" label="Name"></syn-input>
      <syn-input name="street" type="text" label="Street"></syn-input>
      <syn-input name="email" type="email" label="E-Mail"></syn-input>
      <syn-button>Submit me</syn-button>
    </form>
    <style>
    syn-input {
      --syn-input-autofill-shadow: none;
      --syn-input-autofill-readonly-shadow: none;
      --syn-input-autofill-text-fill-color: red;
      --syn-input-autofill-caret-color: yellow;
    }
    </style>
  `,
};
```

This will add a sample demo form that has already overridden the defaults to none for the border and red for the text. Open in your browser. The autofill symbol should be visible. Let your contact data autofill and notice the text is red and the background yellow (which is the default and the reason for the shadow that is inserted!). Add the `readonly` attribute to the Street field and notice how it changes when you adjust the variable.

Please also read the new documentation in the docs that describes the tokens that where used.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
