### PR TITLE
feat: ✨ syn-nav-item: Allow opening links in new windows

### DIFF
--- a/packages/angular/components/nav-item/nav-item.component.ts
+++ b/packages/angular/components/nav-item/nav-item.component.ts
@@ -105,6 +105,36 @@ accordion behavior.
     return this.nativeElement.href;
   }
 
+  /**
+   * Tells the browser where to open the link.
+   * Only used when `href` is present.
+   */
+  @Input()
+  set target(v: SynNavItem['target']) {
+    this._ngZone.runOutsideAngular(() => (this.nativeElement.target = v));
+  }
+  get target(): SynNavItem['target'] {
+    return this.nativeElement.target;
+  }
+
+  /**
+* When using `href`, this attribute will map to the underlying link's `rel` attribute.
+Unlike regular links, the default is `noreferrer noopener` to prevent security exploits.
+
+However, if you're using `target` to point to a specific tab/window,
+this will prevent that from working correctly.
+
+You can remove or change the default value by setting the attribute
+to an empty string or a value of your choice, respectively.
+ */
+  @Input()
+  set rel(v: SynNavItem['rel']) {
+    this._ngZone.runOutsideAngular(() => (this.nativeElement.rel = v));
+  }
+  get rel(): SynNavItem['rel'] {
+    return this.nativeElement.rel;
+  }
+
   @Input()
   set current(v: '' | SynNavItem['current']) {
     this._ngZone.runOutsideAngular(

--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -107,6 +107,21 @@ export default class SynNavItem extends SynergyElement {
    */
   @property({ reflect: true, type: String }) href: string;
 
+  /** Tells the browser where to open the link. Only used when `href` is present. */
+  @property() target: '_blank' | '_parent' | '_self' | '_top';
+
+  /**
+   * When using `href`, this attribute will map to the underlying link's `rel` attribute.
+   * Unlike regular links, the default is `noreferrer noopener` to prevent security exploits.
+   *
+   * However, if you're using `target` to point to a specific tab/window,
+   * this will prevent that from working correctly.
+   *
+   * You can remove or change the default value by setting the attribute
+   * to an empty string or a value of your choice, respectively.
+   */
+  @property() rel = 'noreferrer noopener';
+
   /*
    * Indicates that the navigation item is currently selected.
    * The aria-current attribute is set to "page" on the host if true.
@@ -398,7 +413,9 @@ export default class SynNavItem extends SynergyElement {
         href=${ifDefined(isLink ? this.href : undefined)}
         part="base"
         role=${isLink ? 'link' : 'button'}
+        rel=${ifDefined(isLink ? this.rel : undefined)}
         tabindex=${this.disabled ? '-1' : '0'}
+        target=${ifDefined(isLink ? this.target : undefined)}
       >
 
         ${this.divider && !this.horizontal

--- a/packages/components/src/components/nav-item/nav-item.test.ts
+++ b/packages/components/src/components/nav-item/nav-item.test.ts
@@ -43,6 +43,8 @@ describe('<syn-nav-item>', () => {
       expect(el.href).to.be.undefined;
       expect(el.open).to.equal(false);
       expect(el.horizontal).to.equal(false);
+      expect(el.rel).to.equal('noreferrer noopener');
+      expect(el.target).to.be.undefined;
     });
 
     it('should render as a button', async () => {
@@ -72,10 +74,21 @@ describe('<syn-nav-item>', () => {
   describe('when the href parameter is provided', () => {
     it('should render as a link', async () => {
       const el = await fixture<SynNavItem>(html`<syn-nav-item href="#">Label</syn-nav-item>`);
+      expect(el.rel).to.equal('noreferrer noopener');
       expect(el.shadowRoot!.querySelector('a')).to.exist;
       expect(el.shadowRoot!.querySelector('a')).to.have.attribute('href', '#');
       expect(el.shadowRoot!.querySelector('button')).not.to.exist;
       expect(el.shadowRoot!.querySelector('summary')).not.to.exist;
+    });
+
+    it('should allow to set an external target for the link', async () => {
+      const el = await fixture<SynNavItem>(html`<syn-nav-item href="#" target="_blank">Label</syn-nav-item>`);
+      expect(el.shadowRoot!.querySelector('a')).to.have.attribute('target', '_blank');
+    });
+
+    it('should allow to set a custom rel for the link', async () => {
+      const el = await fixture<SynNavItem>(html`<syn-nav-item href="#" rel="something">Label</syn-nav-item>`);
+      expect(el.shadowRoot!.querySelector('a')).to.have.attribute('rel', 'something');
     });
 
     it('should disable the link if disabled is set to true', async () => {

--- a/packages/vue/src/components/SynVueNavItem.vue
+++ b/packages/vue/src/components/SynVueNavItem.vue
@@ -77,6 +77,24 @@ accordion behavior.
  */
   href?: SynNavItem['href'];
 
+  /**
+   * Tells the browser where to open the link.
+   * Only used when `href` is present.
+   */
+  target?: SynNavItem['target'];
+
+  /**
+* When using `href`, this attribute will map to the underlying link's `rel` attribute.
+Unlike regular links, the default is `noreferrer noopener` to prevent security exploits.
+
+However, if you're using `target` to point to a specific tab/window,
+this will prevent that from working correctly.
+
+You can remove or change the default value by setting the attribute
+to an empty string or a value of your choice, respectively.
+ */
+  rel?: SynNavItem['rel'];
+
   current?: SynNavItem['current'];
 
   /**


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds the new `target` and `rel` properties as they are currently defined in `<syn-button>` for `<syn-nav-item>`.

### 🎫 Issues

Closes #779

## 👩‍💻 Reviewer Notes

I just ported both properties, together with their logic. Nothing fancy here.

## 📑 Test Plan

Other than playing around with it in Storybook, there is really nothing to do here.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
