### PR TITLE
feat: ✨ syn-details exports content_wrapper as CSS part

### DIFF
--- a/packages/angular/components/details/details.component.ts
+++ b/packages/angular/components/details/details.component.ts
@@ -42,7 +42,7 @@ import '@synergy-design-system/components/components/details/details.js';
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
- * @csspart details-body - The container that wraps the details content.
+ * @csspart body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/angular/components/details/details.component.ts
+++ b/packages/angular/components/details/details.component.ts
@@ -42,6 +42,7 @@ import '@synergy-design-system/components/components/details/details.js';
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
+ * @csspart details-body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/components/scripts/vendorism/custom/details.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/details.vendorism.js
@@ -1,5 +1,5 @@
 import { removeSections } from '../remove-section.js';
-import { addSectionsAfter, replaceSections } from '../replace-section.js';
+import { addSectionsAfter, replaceSection, replaceSections } from '../replace-section.js';
 
 const FILES_TO_TRANSFORM = [
   'details.component.ts',
@@ -69,6 +69,19 @@ const transformComponent = (path, originalContent) => {
       '\'details--contained\': this.contained,',
       { tabsBeforeInsertion: 5 },
     ],
+  ], content);
+
+  // #811: Add support for the details-body part
+  content = addSectionsAfter([
+    [
+      '@csspart content - The details content.',
+      ' * @csspart details-body - The container that wraps the details content.',
+    ],
+  ], content);
+
+  content = replaceSection([
+    'class="details__body"',
+    'class="details__body" part="details-body"',
   ], content);
 
   return {

--- a/packages/components/scripts/vendorism/custom/details.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/details.vendorism.js
@@ -75,13 +75,13 @@ const transformComponent = (path, originalContent) => {
   content = addSectionsAfter([
     [
       '@csspart content - The details content.',
-      ' * @csspart details-body - The container that wraps the details content.',
+      ' * @csspart body - The container that wraps the details content.',
     ],
   ], content);
 
   content = replaceSection([
     'class="details__body"',
-    'class="details__body" part="details-body"',
+    'class="details__body" part="body"',
   ], content);
 
   return {

--- a/packages/components/src/components/details/details.component.ts
+++ b/packages/components/src/components/details/details.component.ts
@@ -45,6 +45,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
+ * @csspart details-body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.
@@ -240,7 +241,7 @@ export default class SynDetails extends SynergyElement {
           </span>
         </summary>
 
-        <div class="details__body" role="region" aria-labelledby="header">
+        <div class="details__body" part="details-body" role="region" aria-labelledby="header">
           <slot part="content" id="content" class="details__content"></slot>
         </div>
       </details>

--- a/packages/components/src/components/details/details.component.ts
+++ b/packages/components/src/components/details/details.component.ts
@@ -45,7 +45,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
- * @csspart details-body - The container that wraps the details content.
+ * @csspart body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.
@@ -241,7 +241,7 @@ export default class SynDetails extends SynergyElement {
           </span>
         </summary>
 
-        <div class="details__body" part="details-body" role="region" aria-labelledby="header">
+        <div class="details__body" part="body" role="region" aria-labelledby="header">
           <slot part="content" id="content" class="details__content"></slot>
         </div>
       </details>

--- a/packages/react/src/components/details.ts
+++ b/packages/react/src/components/details.ts
@@ -39,6 +39,7 @@ Component.define('syn-details');
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
+ * @csspart details-body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/react/src/components/details.ts
+++ b/packages/react/src/components/details.ts
@@ -39,7 +39,7 @@ Component.define('syn-details');
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
- * @csspart details-body - The container that wraps the details content.
+ * @csspart body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -381,7 +381,7 @@ export type SynCustomElement<
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
- * @csspart details-body - The container that wraps the details content.
+ * @csspart body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.
@@ -1719,7 +1719,7 @@ declare module 'react' {
        * @csspart summary - The container that wraps the summary.
        * @csspart summary-icon - The container that wraps the expand/collapse icons.
        * @csspart content - The details content.
-       * @csspart details-body - The container that wraps the details content.
+       * @csspart body - The container that wraps the details content.
        *
        * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
        * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -381,6 +381,7 @@ export type SynCustomElement<
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
+ * @csspart details-body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.
@@ -1718,6 +1719,7 @@ declare module 'react' {
        * @csspart summary - The container that wraps the summary.
        * @csspart summary-icon - The container that wraps the expand/collapse icons.
        * @csspart content - The details content.
+       * @csspart details-body - The container that wraps the details content.
        *
        * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
        * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/vue/src/components/SynVueDetails.vue
+++ b/packages/vue/src/components/SynVueDetails.vue
@@ -28,7 +28,7 @@
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
- * @csspart details-body - The container that wraps the details content.
+ * @csspart body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.

--- a/packages/vue/src/components/SynVueDetails.vue
+++ b/packages/vue/src/components/SynVueDetails.vue
@@ -28,6 +28,7 @@
  * @csspart summary - The container that wraps the summary.
  * @csspart summary-icon - The container that wraps the expand/collapse icons.
  * @csspart content - The details content.
+ * @csspart details-body - The container that wraps the details content.
  *
  * @animation details.show - The animation to use when showing details. You can use `height: auto` with this animation.
  * @animation details.hide - The animation to use when hiding details. You can use `height: auto` with this animation.


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a new part `body` that can be used to style the wrapper that holds the default slotted content of a `<syn-detail>` element.

### 🎫 Issues

Closes #811

## 👩‍💻 Reviewer Notes

Regular vendoring process.

## 📑 Test Plan

Just play around with the generated storybook and add some color to it.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
