### PR TITLE
fix: 🐛 Combobox and select not working correctly if value was initially set via property binding

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
@@ -12,13 +12,13 @@ import { SynButtonComponent } from '@synergy-design-system/angular/components/bu
     SynButtonComponent
   ],
   template: `
-    <syn-combobox id="combobox-797" value="option-2">
+    <syn-combobox data-testid="combobox-797" value="option-2">
       <syn-option value="option-1">Option 1</syn-option>
       <syn-option value="option-2">Option 2</syn-option>
       <syn-option value="option-3">Option 3</syn-option>
     </syn-combobox>
 
-    <syn-combobox id="level-813" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
+    <syn-combobox data-testid="combobox-level-813" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
       @for (level of levels; track $index; let index = $index) {
         <syn-option [value]="level.value"> {{level.label}}</syn-option
         >
@@ -26,7 +26,7 @@ import { SynButtonComponent } from '@synergy-design-system/angular/components/bu
     </syn-combobox>
 
     <form>
-      <syn-combobox id="form-813" [value]="'option-1'">
+      <syn-combobox data-testid="combobox-form-813" [value]="'option-1'">
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>

--- a/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { SynComboboxComponent } from '@synergy-design-system/angular/components/combobox';
 import { SynOptionComponent } from '@synergy-design-system/angular/components/option';
+import { SynButtonComponent } from '@synergy-design-system/angular/components/button';
 
 @Component({
   selector: 'demo-combobox',
@@ -8,13 +9,43 @@ import { SynOptionComponent } from '@synergy-design-system/angular/components/op
   imports: [
     SynComboboxComponent,
     SynOptionComponent,
+    SynButtonComponent
   ],
   template: `
-    <syn-combobox value="option-2">
+    <syn-combobox id="combobox-797" value="option-2">
       <syn-option value="option-1">Option 1</syn-option>
       <syn-option value="option-2">Option 2</syn-option>
       <syn-option value="option-3">Option 3</syn-option>
     </syn-combobox>
+
+    <syn-combobox id="level-813" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
+      @for (level of levels; track $index; let index = $index) {
+        <syn-option [value]="level.value"> {{level.label}}</syn-option
+        >
+      }
+    </syn-combobox>
+
+    <form>
+      <syn-combobox id="form-813" [value]="'option-1'">
+        <syn-option value="option-1">Option 1</syn-option>
+        <syn-option value="option-2">Option 2</syn-option>
+        <syn-option value="option-3">Option 3</syn-option>
+      </syn-combobox>
+      <syn-button type="reset">Reset</syn-button>
+    </form>
   `,
 })
-export class Combobox {}
+export class Combobox implements OnInit {
+  levels!: Array<{value: string, label: string }>
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.levels = [
+          { value: '1', label: 'Novice' },
+          { value: '2', label: 'Intermediate' },
+          { value: '3', label: 'Advanced' },
+        ];
+    }, 0);
+  }
+}
+

--- a/packages/_private/angular-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Select.ts
@@ -12,7 +12,7 @@ import { SynButtonComponent } from '@synergy-design-system/angular/components/bu
     SynButtonComponent
   ],
   template: `
-    <syn-select id="level" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
+    <syn-select data-testid="select-level-813" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
       @for (level of levels; track $index; let index = $index) {
         <syn-option [value]="level.value"> {{level.label}}</syn-option
         >
@@ -20,7 +20,7 @@ import { SynButtonComponent } from '@synergy-design-system/angular/components/bu
     </syn-select>
 
     <form>
-      <syn-select id="form" [value]="'option-1'">
+      <syn-select data-testid="select-form-813" [value]="'option-1'">
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>

--- a/packages/_private/angular-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Select.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { SynSelectComponent } from '@synergy-design-system/angular/components/select';
 import { SynOptionComponent } from '@synergy-design-system/angular/components/option';
+import { SynButtonComponent } from '@synergy-design-system/angular/components/button';
 
 @Component({
   selector: 'demo-select',
@@ -8,13 +9,36 @@ import { SynOptionComponent } from '@synergy-design-system/angular/components/op
   imports: [
     SynSelectComponent,
     SynOptionComponent,
+    SynButtonComponent
   ],
   template: `
-    <syn-select label="Experience" help-text="Please tell us your skill level.">
-      <syn-option value="1">Novice</syn-option>
-      <syn-option value="2">Intermediate</syn-option>
-      <syn-option value="3">Advanced</syn-option>
+    <syn-select id="level" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
+      @for (level of levels; track $index; let index = $index) {
+        <syn-option [value]="level.value"> {{level.label}}</syn-option
+        >
+      }
     </syn-select>
-  `,
+
+    <form>
+      <syn-select id="form" [value]="'option-1'">
+        <syn-option value="option-1">Option 1</syn-option>
+        <syn-option value="option-2">Option 2</syn-option>
+        <syn-option value="option-3">Option 3</syn-option>
+      </syn-select>
+      <syn-button type="reset">Reset</syn-button>
+    </form>
+  `
 })
-export class Select {}
+export class Select implements OnInit {
+  levels!: Array<{value: string, label: string }>
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.levels = [
+          { value: '1', label: 'Novice' },
+          { value: '2', label: 'Intermediate' },
+          { value: '3', label: 'Advanced' },
+        ];
+    }, 0);
+  }
+}

--- a/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { SynCombobox } from '@synergy-design-system/components';
+import type { SynCombobox, SynSelect } from '@synergy-design-system/components';
 import { AllComponentsPage } from './PageObjects/index.js';
 import {
   createTestCases,
@@ -64,7 +64,7 @@ test.describe('All components tests', () => {
 
           await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
 
-          const combobox = await AllComponents.getLocator('comboboxComponent');
+          const combobox = await AllComponents.getLocator('combobox797');
           // Check that the displayed value is the text content of the option
           const displayedValue = await combobox.evaluate((ele: SynCombobox) => ele.displayLabel);
 
@@ -78,7 +78,7 @@ test.describe('All components tests', () => {
 
           await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
 
-          const combobox = await AllComponents.getLocator('comboboxComponent');
+          const combobox = await AllComponents.getLocator('combobox797');
           await combobox.evaluate((ele: SynCombobox) => {
             // eslint-disable-next-line no-param-reassign
             ele.value = 'option-3';
@@ -96,7 +96,7 @@ test.describe('All components tests', () => {
 
           await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
 
-          const combobox = await AllComponents.getLocator('comboboxComponent');
+          const combobox = await AllComponents.getLocator('combobox797');
           await combobox.evaluate((ele: SynCombobox) => {
             // eslint-disable-next-line no-param-reassign
             ele.value = 'option-4';
@@ -121,7 +121,103 @@ test.describe('All components tests', () => {
           expect(updatedDisplayedValue).toEqual('Option 4');
         });
       }); // regression#797
+
+      test.describe('Regression#813', () => {
+        test('should show the text content of the option, when value was set initially via property binding and options added dynamically', async ({ page }) => {
+          const AllComponents = new AllComponentsPage(page, port);
+          await AllComponents.loadInitialPage();
+          await AllComponents.activateItem('comboboxLink');
+
+          await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
+
+          const combobox = await AllComponents.getLocator('combobox813Level');
+          // Check that the displayed value is the text content of the option
+          const displayedValue = await combobox.evaluate((ele: SynCombobox) => ele.displayLabel);
+
+          expect(displayedValue).toEqual('Intermediate');
+        });
+
+        test('should reset the value of the combobox in a form to the initially set value via property binding', async ({ page }) => {
+          const AllComponents = new AllComponentsPage(page, port);
+          await AllComponents.loadInitialPage();
+          await AllComponents.activateItem('comboboxLink');
+
+          await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
+
+          const combobox = await AllComponents.getLocator('combobox813Form');
+
+          await combobox.evaluate((ele: SynCombobox) => {
+            // eslint-disable-next-line no-param-reassign
+            ele.value = '';
+          });
+
+          await combobox.click();
+          const options = await AllComponents.getLocator('combobox813FormOptions');
+          await options.last().click();
+
+          const [value, displayedValue] = await combobox.evaluate(
+            (ele: SynCombobox) => [ele.value, ele.displayLabel],
+          );
+          expect(value).toEqual('option-3');
+          expect(displayedValue).toEqual('Option 3');
+
+          const reset = await AllComponents.getLocator('comboboxFormReset');
+          await reset.click();
+
+          const [resetValue, resetDisplayedValue] = await combobox.evaluate(
+            (ele: SynSelect) => [ele.value, ele.displayLabel],
+          );
+          expect(resetValue).toEqual('option-1');
+          expect(resetDisplayedValue).toEqual('Option 1');
+        });
+      }); // regression#813
     }); // </syn-combobox>
+
+    test.describe(`${name}: <SynSelect /> ${port}`, () => {
+      test.describe('Regression#813', () => {
+        test('should show the text content of the option, when value was set initially via property binding and options added dynamically', async ({ page }) => {
+          const AllComponents = new AllComponentsPage(page, port);
+          await AllComponents.loadInitialPage();
+          await AllComponents.activateItem('selectLink');
+
+          await expect(AllComponents.getLocator('selectContent')).toBeVisible();
+
+          const select = await AllComponents.getLocator('selectLevel');
+          // Check that the displayed value is the text content of the option
+          const displayedValue = await select.evaluate((ele: SynSelect) => ele.displayLabel);
+
+          expect(displayedValue).toEqual('Intermediate');
+        });
+
+        test('should reset the value of the select in a form to the initially set value via property binding', async ({ page }) => {
+          const AllComponents = new AllComponentsPage(page, port);
+          await AllComponents.loadInitialPage();
+          await AllComponents.activateItem('selectLink');
+
+          await expect(AllComponents.getLocator('selectContent')).toBeVisible();
+
+          const select = await AllComponents.getLocator('selectForm');
+          await select.click();
+          const options = await AllComponents.getLocator('selectFormOptions');
+          await options.last().click();
+
+          const [value, displayedValue] = await select.evaluate(
+            (ele: SynSelect) => [ele.value, ele.displayLabel],
+          );
+          expect(value).toEqual('option-3');
+          expect(displayedValue).toEqual('Option 3');
+
+          const reset = await AllComponents.getLocator('selectFormReset');
+          await reset.click();
+
+          const [resetValue, resetDisplayedValue] = await select.evaluate(
+            (ele: SynSelect) => [ele.value, ele.displayLabel],
+          );
+          expect(resetValue).toEqual('option-1');
+          expect(resetDisplayedValue).toEqual('Option 1');
+        });
+      }); // regression#813
+    }); // </syn-select>
 
     test.describe(`${name}: <SynTabGroup /> ${port}`, () => {
       test.describe('Regression#757', () => {

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -10,9 +10,21 @@ const AllComponentSelectors = {
   alertLink: '#tab-Alert',
 
   // Combobox
-  comboboxComponent: '#tab-content-Combobox syn-combobox',
+  combobox797: '#tab-content-Combobox syn-combobox#combobox-797',
+  combobox813Form: '#tab-content-Combobox syn-combobox#form-813',
+  combobox813FormOptions: '#tab-content-Combobox syn-combobox#form-813 syn-option',
+  combobox813Level: '#tab-content-Combobox syn-combobox#level-813',
   comboboxContent: '#tab-content-Combobox',
+  comboboxFormReset: '#tab-content-Combobox form syn-button',
   comboboxLink: '#tab-Combobox',
+
+  // Combobox
+  selectContent: '#tab-content-Select',
+  selectForm: '#tab-content-Select syn-select#form',
+  selectFormOptions: '#tab-content-Select syn-select#form syn-option',
+  selectFormReset: '#tab-content-Select form syn-button',
+  selectLevel: '#tab-content-Select syn-select#level',
+  selectLink: '#tab-Select',
 
   // Tabgroup
   tabGroupCustom: '#tab-content-TabGroup syn-tab:nth-of-type(2)',

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -10,20 +10,20 @@ const AllComponentSelectors = {
   alertLink: '#tab-Alert',
 
   // Combobox
-  combobox797: '#tab-content-Combobox syn-combobox#combobox-797',
-  combobox813Form: '#tab-content-Combobox syn-combobox#form-813',
-  combobox813FormOptions: '#tab-content-Combobox syn-combobox#form-813 syn-option',
-  combobox813Level: '#tab-content-Combobox syn-combobox#level-813',
+  combobox797: '#tab-content-Combobox syn-combobox[data-testid="combobox-797"]',
+  combobox813Form: '#tab-content-Combobox syn-combobox[data-testid="combobox-form-813"]',
+  combobox813FormOptions: '#tab-content-Combobox syn-combobox[data-testid="combobox-form-813"] syn-option',
+  combobox813Level: '#tab-content-Combobox syn-combobox[data-testid="combobox-level-813"]',
   comboboxContent: '#tab-content-Combobox',
   comboboxFormReset: '#tab-content-Combobox form syn-button',
   comboboxLink: '#tab-Combobox',
 
-  // Combobox
+  // Select
   selectContent: '#tab-content-Select',
-  selectForm: '#tab-content-Select syn-select#form',
-  selectFormOptions: '#tab-content-Select syn-select#form syn-option',
+  selectForm: '#tab-content-Select syn-select[data-testid="select-form-813"]',
+  selectFormOptions: '#tab-content-Select syn-select[data-testid="select-form-813"] syn-option',
   selectFormReset: '#tab-content-Select form syn-button',
-  selectLevel: '#tab-content-Select syn-select#level',
+  selectLevel: '#tab-content-Select syn-select[data-testid="select-level-813"]',
   selectLink: '#tab-Select',
 
   // Tabgroup

--- a/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
@@ -1,7 +1,40 @@
-export const Combobox = () => (
-  <syn-combobox value="option-2">
-    <syn-option value="option-1">Option 1</syn-option>
-    <syn-option value="option-2">Option 2</syn-option>
-    <syn-option value="option-3">Option 3</syn-option>
-  </syn-combobox>
-);
+import { useEffect, useState } from 'react';
+
+export const Combobox = () => {
+  const [levels, setLevels] = useState<Array<{ value: string, label: string }>>([]);
+  useEffect(() => {
+    setTimeout(() => {
+      setLevels([
+        { label: 'Novice', value: '1' },
+        { label: 'Intermediate', value: '2' },
+        { label: 'Advanced', value: '3' },
+      ]);
+    }, 0);
+  }, []);
+  return (
+    <>
+      <syn-combobox id="combobox-797" value="option-2">
+        <syn-option value="option-1">Option 1</syn-option>
+        <syn-option value="option-2">Option 2</syn-option>
+        <syn-option value="option-3">Option 3</syn-option>
+      </syn-combobox>
+
+      <syn-combobox id="level-813" label="Experience" help-text="Please tell us your skill level." value="2">
+        {levels.map((level) => (
+          <syn-option key={level.value} value={level.value}>
+            {level.label}
+          </syn-option>
+        ))}
+      </syn-combobox>
+
+      <form>
+        <syn-combobox id="form-813" value="option-1">
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+        <syn-button type="reset">Reset</syn-button>
+      </form>
+    </>
+  );
+};

--- a/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
@@ -13,13 +13,13 @@ export const Combobox = () => {
   }, []);
   return (
     <>
-      <syn-combobox id="combobox-797" value="option-2">
+      <syn-combobox data-testid="combobox-797" value="option-2">
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>
       </syn-combobox>
 
-      <syn-combobox id="level-813" label="Experience" help-text="Please tell us your skill level." value="2">
+      <syn-combobox data-testid="combobox-level-813" label="Experience" help-text="Please tell us your skill level." value="2">
         {levels.map((level) => (
           <syn-option key={level.value} value={level.value}>
             {level.label}
@@ -28,7 +28,7 @@ export const Combobox = () => {
       </syn-combobox>
 
       <form>
-        <syn-combobox id="form-813" value="option-1">
+        <syn-combobox data-testid="combobox-form-813" value="option-1">
           <syn-option value="option-1">Option 1</syn-option>
           <syn-option value="option-2">Option 2</syn-option>
           <syn-option value="option-3">Option 3</syn-option>

--- a/packages/_private/react-demo/src/AllComponentParts/Select.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Select.tsx
@@ -13,7 +13,7 @@ export const Select = () => {
   }, []);
   return (
     <>
-      <syn-select id="level" label="Experience" help-text="Please tell us your skill level." value="2">
+      <syn-select data-testid="select-level-813" label="Experience" help-text="Please tell us your skill level." value="2">
         {levels.map((level) => (
           <syn-option key={level.value} value={level.value}>
             {level.label}
@@ -22,7 +22,7 @@ export const Select = () => {
       </syn-select>
 
       <form>
-        <syn-select id="form" value="option-1">
+        <syn-select data-testid="select-form-813" value="option-1">
           <syn-option value="option-1">Option 1</syn-option>
           <syn-option value="option-2">Option 2</syn-option>
           <syn-option value="option-3">Option 3</syn-option>

--- a/packages/_private/react-demo/src/AllComponentParts/Select.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Select.tsx
@@ -1,7 +1,34 @@
-export const Select = () => (
-  <syn-select label="Experience" help-text="Please tell us your skill level.">
-    <syn-option value="1">Novice</syn-option>
-    <syn-option value="2">Intermediate</syn-option>
-    <syn-option value="3">Advanced</syn-option>
-  </syn-select>
-);
+import { useEffect, useState } from 'react';
+
+export const Select = () => {
+  const [levels, setLevels] = useState<Array<{ value: string, label: string }>>([]);
+  useEffect(() => {
+    setTimeout(() => {
+      setLevels([
+        { label: 'Novice', value: '1' },
+        { label: 'Intermediate', value: '2' },
+        { label: 'Advanced', value: '3' },
+      ]);
+    }, 0);
+  }, []);
+  return (
+    <>
+      <syn-select id="level" label="Experience" help-text="Please tell us your skill level." value="2">
+        {levels.map((level) => (
+          <syn-option key={level.value} value={level.value}>
+            {level.label}
+          </syn-option>
+        ))}
+      </syn-select>
+
+      <form>
+        <syn-select id="form" value="option-1">
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-select>
+        <syn-button type="reset">Reset</syn-button>
+      </form>
+    </>
+  );
+};

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
@@ -1,26 +1,8 @@
-import { type LitElement, html } from 'lit';
-import type { SynCombobox } from '@synergy-design-system/components';
+import { html } from 'lit';
 
-export const Combobox = () => {
-  const allComponents = document.querySelector('demo-all-components') as LitElement;
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  allComponents.updateComplete.then(() => {
-    const combobox = allComponents?.shadowRoot?.querySelector('syn-combobox[data-testid="combobox-level-813"]') as SynCombobox;
-
-    setTimeout(() => {
-      const option1 = document.createElement('syn-option');
-      option1.value = '1';
-      option1.textContent = 'Novice';
-      const option2 = document.createElement('syn-option');
-      option2.value = '2';
-      option2.textContent = 'Intermediate';
-      const option3 = document.createElement('syn-option');
-      option3.value = '3';
-      option3.textContent = 'Advanced';
-      combobox.appendChild(option1);
-      combobox.appendChild(option2);
-      combobox.appendChild(option3);
-    }, 0);
+export const Combobox = (regressions: Array< () => void> = []) => {
+  regressions.forEach((regression) => {
+    regression();
   });
 
   return html`

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
@@ -1,9 +1,50 @@
 import { html } from 'lit';
+import type { SynCombobox, SynTabShowEvent } from '@synergy-design-system/components';
 
-export const Combobox = () => html`
-  <syn-combobox value="option-2">
-    <syn-option value="option-1">Option 1</syn-option>
-    <syn-option value="option-2">Option 2</syn-option>
-    <syn-option value="option-3">Option 3</syn-option>
-  </syn-combobox>
-`;
+export const Combobox = () => {
+  document.addEventListener('syn-tab-show', (event: SynTabShowEvent) => {
+    if (event.detail.name !== 'Combobox') return;
+
+    const target = event.target as HTMLElement;
+    const combobox = target.shadowRoot?.querySelector('syn-combobox#level-813') as SynCombobox;
+
+    if (combobox.dataset.initialized) return;
+
+    combobox.dataset.initialized = 'true';
+
+    setTimeout(() => {
+      const option1 = document.createElement('syn-option');
+      option1.value = '1';
+      option1.textContent = 'Novice';
+      const option2 = document.createElement('syn-option');
+      option2.value = '2';
+      option2.textContent = 'Intermediate';
+      const option3 = document.createElement('syn-option');
+      option3.value = '3';
+      option3.textContent = 'Advanced';
+      combobox.appendChild(option1);
+      combobox.appendChild(option2);
+      combobox.appendChild(option3);
+    }, 0);
+  });
+
+  return html`
+    <syn-combobox id="combobox-797" value="option-2">
+      <syn-option value="option-1">Option 1</syn-option>
+      <syn-option value="option-2">Option 2</syn-option>
+      <syn-option value="option-3">Option 3</syn-option>
+    </syn-combobox>
+
+    <syn-combobox id="level-813" label="Experience" help-text="Please tell us your skill level." .value=${'2'}>
+    </syn-combobox>
+
+    <form>
+      <syn-combobox id="form-813" .value=${'option-1'}>
+        <syn-option value="option-1">Option 1</syn-option>
+        <syn-option value="option-2">Option 2</syn-option>
+        <syn-option value="option-3">Option 3</syn-option>
+      </syn-combobox>
+      <syn-button type="reset">Reset</syn-button>
+    </form>
+  `;
+};

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
@@ -1,16 +1,11 @@
-import { html } from 'lit';
-import type { SynCombobox, SynTabShowEvent } from '@synergy-design-system/components';
+import { type LitElement, html } from 'lit';
+import type { SynCombobox } from '@synergy-design-system/components';
 
 export const Combobox = () => {
-  document.addEventListener('syn-tab-show', (event: SynTabShowEvent) => {
-    if (event.detail.name !== 'Combobox') return;
-
-    const target = event.target as HTMLElement;
-    const combobox = target.shadowRoot?.querySelector('syn-combobox#level-813') as SynCombobox;
-
-    if (combobox.dataset.initialized) return;
-
-    combobox.dataset.initialized = 'true';
+  const allComponents = document.querySelector('demo-all-components') as LitElement;
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  allComponents.updateComplete.then(() => {
+    const combobox = allComponents?.shadowRoot?.querySelector('syn-combobox[data-testid="combobox-level-813"]') as SynCombobox;
 
     setTimeout(() => {
       const option1 = document.createElement('syn-option');
@@ -29,17 +24,17 @@ export const Combobox = () => {
   });
 
   return html`
-    <syn-combobox id="combobox-797" value="option-2">
+    <syn-combobox data-testid="combobox-797" value="option-2">
       <syn-option value="option-1">Option 1</syn-option>
       <syn-option value="option-2">Option 2</syn-option>
       <syn-option value="option-3">Option 3</syn-option>
     </syn-combobox>
 
-    <syn-combobox id="level-813" label="Experience" help-text="Please tell us your skill level." .value=${'2'}>
+    <syn-combobox data-testid="combobox-level-813" label="Experience" help-text="Please tell us your skill level." .value=${'2'}>
     </syn-combobox>
 
     <form>
-      <syn-combobox id="form-813" .value=${'option-1'}>
+      <syn-combobox data-testid="combobox-form-813" .value=${'option-1'}>
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Dialog.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Dialog.ts
@@ -1,13 +1,19 @@
 import { html } from 'lit';
 
-export const Dialog = () => html`
-  <syn-dialog
-    ?open=${false}
-    label="Dialog"
-  >
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    <syn-button variant="filled" slot="footer">
-      Close
-    </syn-button>
-  </syn-dialog>
-`;
+export const Dialog = (regressions: Array<() => void> = []) => {
+  regressions.forEach((regression) => {
+    regression();
+  });
+
+  return html`
+    <syn-dialog
+      ?open=${false}
+      label="Dialog"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      <syn-button variant="filled" slot="footer">
+        Close
+      </syn-button>
+    </syn-dialog>
+  `;
+};

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
@@ -1,26 +1,8 @@
-import type { SynSelect } from '@synergy-design-system/components';
-import { type LitElement, html } from 'lit';
+import { html } from 'lit';
 
-export const Select = () => {
-  const allComponents = document.querySelector('demo-all-components') as LitElement;
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  allComponents.updateComplete.then(() => {
-    const select = allComponents?.shadowRoot?.querySelector('syn-select[data-testid="select-level-813"]') as SynSelect;
-
-    setTimeout(() => {
-      const option1 = document.createElement('syn-option');
-      option1.value = '1';
-      option1.textContent = 'Novice';
-      const option2 = document.createElement('syn-option');
-      option2.value = '2';
-      option2.textContent = 'Intermediate';
-      const option3 = document.createElement('syn-option');
-      option3.value = '3';
-      option3.textContent = 'Advanced';
-      select.appendChild(option1);
-      select.appendChild(option2);
-      select.appendChild(option3);
-    }, 0);
+export const Select = (regressions: Array< () => void> = []) => {
+  regressions.forEach((regression) => {
+    regression();
   });
 
   return html`

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
@@ -1,16 +1,11 @@
-import type { SynSelect, SynTabShowEvent } from '@synergy-design-system/components';
-import { html } from 'lit';
+import type { SynSelect } from '@synergy-design-system/components';
+import { type LitElement, html } from 'lit';
 
 export const Select = () => {
-  document.addEventListener('syn-tab-show', (event: SynTabShowEvent) => {
-    if (event.detail.name !== 'Select') return;
-
-    const target = event.target as HTMLElement;
-    const select = target.shadowRoot?.querySelector('syn-select#level') as SynSelect;
-
-    if (select.dataset.initialized) return;
-
-    select.dataset.initialized = 'true';
+  const allComponents = document.querySelector('demo-all-components') as LitElement;
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  allComponents.updateComplete.then(() => {
+    const select = allComponents?.shadowRoot?.querySelector('syn-select[data-testid="select-level-813"]') as SynSelect;
 
     setTimeout(() => {
       const option1 = document.createElement('syn-option');
@@ -29,11 +24,11 @@ export const Select = () => {
   });
 
   return html`
-   <syn-select id="level" label="Experience" help-text="Please tell us your skill level." .value=${'2'}>
+   <syn-select data-testid="select-level-813" label="Experience" help-text="Please tell us your skill level." .value=${'2'}>
     </syn-select>
 
     <form>
-      <syn-select id="form" .value=${'option-1'}>
+      <syn-select data-testid="select-form-813" .value=${'option-1'}>
         <syn-option value="option-1">Option 1</syn-option>
         <syn-option value="option-2">Option 2</syn-option>
         <syn-option value="option-3">Option 3</syn-option>

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
@@ -1,9 +1,44 @@
+import type { SynSelect, SynTabShowEvent } from '@synergy-design-system/components';
 import { html } from 'lit';
 
-export const Select = () => html`
-  <syn-select label="Experience" help-text="Please tell us your skill level.">
-    <syn-option value="1">Novice</syn-option>
-    <syn-option value="2">Intermediate</syn-option>
-    <syn-option value="3">Advanced</syn-option>
-  </syn-select>
-`;
+export const Select = () => {
+  document.addEventListener('syn-tab-show', (event: SynTabShowEvent) => {
+    if (event.detail.name !== 'Select') return;
+
+    const target = event.target as HTMLElement;
+    const select = target.shadowRoot?.querySelector('syn-select#level') as SynSelect;
+
+    if (select.dataset.initialized) return;
+
+    select.dataset.initialized = 'true';
+
+    setTimeout(() => {
+      const option1 = document.createElement('syn-option');
+      option1.value = '1';
+      option1.textContent = 'Novice';
+      const option2 = document.createElement('syn-option');
+      option2.value = '2';
+      option2.textContent = 'Intermediate';
+      const option3 = document.createElement('syn-option');
+      option3.value = '3';
+      option3.textContent = 'Advanced';
+      select.appendChild(option1);
+      select.appendChild(option2);
+      select.appendChild(option3);
+    }, 0);
+  });
+
+  return html`
+   <syn-select id="level" label="Experience" help-text="Please tell us your skill level." .value=${'2'}>
+    </syn-select>
+
+    <form>
+      <syn-select id="form" .value=${'option-1'}>
+        <syn-option value="option-1">Option 1</syn-option>
+        <syn-option value="option-2">Option 2</syn-option>
+        <syn-option value="option-3">Option 3</syn-option>
+      </syn-select>
+      <syn-button type="reset">Reset</syn-button>
+    </form>
+  `;
+};

--- a/packages/_private/vanilla-demo/src/all-components-regressions.ts
+++ b/packages/_private/vanilla-demo/src/all-components-regressions.ts
@@ -1,0 +1,53 @@
+import { SynDialog, SynTabShowEvent } from '@synergy-design-system/components';
+import type { LitElement } from 'lit';
+
+const getAllComponentsElement = async () => {
+  const allComponents = document.querySelector('demo-all-components') as LitElement;
+  await allComponents.updateComplete;
+  return allComponents;
+};
+
+const appendOptions813 = async (querySelector: string) => {
+  const allComponents = await getAllComponentsElement();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  const element = allComponents?.shadowRoot?.querySelector(querySelector) as LitElement;
+
+  setTimeout(() => {
+    const option1 = document.createElement('syn-option');
+    option1.value = '1';
+    option1.textContent = 'Novice';
+    const option2 = document.createElement('syn-option');
+    option2.value = '2';
+    option2.textContent = 'Intermediate';
+    const option3 = document.createElement('syn-option');
+    option3.value = '3';
+    option3.textContent = 'Advanced';
+    element.appendChild(option1);
+    element.appendChild(option2);
+    element.appendChild(option3);
+  }, 0);
+};
+
+export const allComponentsRegressions = new Map(Object.entries({
+  Combobox: [
+    // #813
+    () => appendOptions813('syn-combobox[data-testid="combobox-level-813"]'),
+  ],
+  Dialog: [
+    // Open the dialog when dialog tab is clicked
+    async () => {
+      const allComponents = await getAllComponentsElement();
+      allComponents.addEventListener('syn-tab-show', (e: SynTabShowEvent) => {
+        const { name } = e.detail;
+        if (name === 'Dialog') {
+          const dialog = allComponents.shadowRoot?.querySelector('syn-dialog') as SynDialog;
+          dialog.open = true;
+        }
+      });
+    },
+  ],
+  Select: [
+    // #813
+    () => appendOptions813('syn-select[data-testid="select-level-813"]'),
+  ],
+}));

--- a/packages/_private/vanilla-demo/src/all-components.ts
+++ b/packages/_private/vanilla-demo/src/all-components.ts
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'lit';
-import { type SynTabShowEvent } from '@synergy-design-system/components';
 import * as DemoImports from './AllComponentParts/index.js';
+import { allComponentsRegressions } from './all-components-regressions.js';
 
 const Demos = Object.entries(DemoImports);
 const activeDemo = Demos.at(0)?.at(0);
@@ -13,17 +13,7 @@ class AllComponents extends LitElement {
   // eslint-disable-next-line class-methods-use-this
   render() {
     return html`
-      <syn-tab-group
-        @syn-tab-show=${(e: SynTabShowEvent) => {
-          const { name } = e.detail;
-          (e.target as HTMLElement).parentElement?.scrollTo(0, 0);
-
-          const dialog = this.shadowRoot?.querySelector('syn-dialog');
-          if (dialog) {
-            dialog.open = name === 'Dialog';
-          }
-        }}
-      >
+      <syn-tab-group>
         ${Demos.map(([name, Component]) => html`
           <syn-tab
             ?active=${name === activeDemo}
@@ -38,7 +28,7 @@ class AllComponents extends LitElement {
             name=${name}
           >
             <div id="tab-content-${name}" style="display: contents">
-              ${html`${Component()}`}
+              ${html`${Component(allComponentsRegressions.has(name) ? allComponentsRegressions.get(name) : [])}`}
             </div>
           </syn-tab-panel>
         `)}

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
@@ -13,17 +13,17 @@ setTimeout(() => {
 </script>
 
 <template>
-  <SynVueCombobox id="combobox-797" value="option-2">
+  <SynVueCombobox data-testid="combobox-797" value="option-2">
     <SynVueOption value="option-1">Option 1</SynVueOption>
     <SynVueOption value="option-2">Option 2</SynVueOption>
     <SynVueOption value="option-3">Option 3</SynVueOption>
   </SynVueCombobox>
 
-  <SynVueCombobox :value="'2'" id="level-813">
+  <SynVueCombobox :value="'2'" data-testid="combobox-level-813">
     <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
   </SynVueCombobox>
   <form>
-    <SynVueCombobox value="option-1" id="form-813">
+    <SynVueCombobox value="option-1" data-testid="combobox-form-813">
       <SynVueOption value="option-1">Option 1</SynVueOption>
       <SynVueOption value="option-2">Option 2</SynVueOption>
       <SynVueOption value="option-3">Option 3</SynVueOption>

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
@@ -1,10 +1,33 @@
 <script setup lang="ts">
-import { SynVueCombobox, SynVueOption } from '@synergy-design-system/vue';
+import { SynVueButton, SynVueCombobox, SynVueOption } from '@synergy-design-system/vue';
+import { ref } from 'vue';
+const levels = ref<Array<{ value: string, label: string }>>([]);
+
+setTimeout(() => {
+  levels.value = [
+    { label: 'Novice', value: '1' },
+    { label: 'Intermediate', value: '2' },
+    { label: 'Advanced', value: '3' },
+  ];
+}, 0);
 </script>
+
 <template>
-  <SynVueCombobox value="option-2">
+  <SynVueCombobox id="combobox-797" value="option-2">
     <SynVueOption value="option-1">Option 1</SynVueOption>
     <SynVueOption value="option-2">Option 2</SynVueOption>
     <SynVueOption value="option-3">Option 3</SynVueOption>
   </SynVueCombobox>
+
+  <SynVueCombobox :value="'2'" id="level-813">
+    <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
+  </SynVueCombobox>
+  <form>
+    <SynVueCombobox value="option-1" id="form-813">
+      <SynVueOption value="option-1">Option 1</SynVueOption>
+      <SynVueOption value="option-2">Option 2</SynVueOption>
+      <SynVueOption value="option-3">Option 3</SynVueOption>
+    </SynVueCombobox>
+    <SynVueButton type="reset">reset</SynVueButton>
+  </form>
 </template>

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
@@ -13,11 +13,11 @@ setTimeout(() => {
 </script>
 
 <template>
-  <SynVueSelect :value="'2'" id="level">
+  <SynVueSelect :value="'2'" data-testid="select-level-813">
     <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
   </SynVueSelect>
   <form>
-    <SynVueSelect value="option-1" id="form">
+    <SynVueSelect value="option-1" data-testid="select-form-813">
       <SynVueOption value="option-1">Option 1</SynVueOption>
       <SynVueOption value="option-2">Option 2</SynVueOption>
       <SynVueOption value="option-3">Option 3</SynVueOption>

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
@@ -1,11 +1,27 @@
 <script setup lang="ts">
-import { SynVueSelect, SynVueOption } from '@synergy-design-system/vue';
+import { SynVueButton, SynVueSelect, SynVueOption } from '@synergy-design-system/vue';
+import { ref } from 'vue';
+const levels = ref<Array<{ value: string, label: string }>>([]);
+
+setTimeout(() => {
+  levels.value = [
+    { label: 'Novice', value: '1' },
+    { label: 'Intermediate', value: '2' },
+    { label: 'Advanced', value: '3' },
+  ];
+}, 0);
 </script>
 
 <template>
-  <SynVueSelect label="Experience" help-text="Please tell us your skill level.">
-    <SynVueOption value="1">Novice</SynVueOption>
-    <SynVueOption value="2">Intermediate</SynVueOption>
-    <SynVueOption value="3">Advanced</SynVueOption>
+  <SynVueSelect :value="'2'" id="level">
+    <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
   </SynVueSelect>
+  <form>
+    <SynVueSelect value="option-1" id="form">
+      <SynVueOption value="option-1">Option 1</SynVueOption>
+      <SynVueOption value="option-2">Option 2</SynVueOption>
+      <SynVueOption value="option-3">Option 3</SynVueOption>
+    </SynVueSelect>
+    <SynVueButton type="reset">reset</SynVueButton>
+  </form>
 </template>

--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -42,16 +42,14 @@ const transformComponent = (path, originalContent) => {
       'private isInitialized: boolean = false;',
       { tabsAfterInsertion: 1 },
     ],
-    // Set isInitialized variable to true after first render call
-    [
-      "const hasLabelSlot = this.hasSlotController.test('label');",
-      'this.isInitialized = true;',
-      { tabsAfterInsertion: 2 },
-    ],
     // Add the defaultValue handling if value was initially set via property
     [
       'attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null)',
-       `protected override willUpdate(changedProperties: PropertyValues) {
+       `firstUpdated() {
+    this.isInitialized = true;
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
 
     if(!this.isInitialized && !this.defaultValue && this.value) {

--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -36,13 +36,25 @@ const transformComponent = (path, originalContent) => {
   ], content);
 
   content = addSectionsBefore([
+    // Define the isInitialized variable
+    [
+      "private typeToSelectString = '';",
+      'private isInitialized: boolean = false;',
+      { tabsAfterInsertion: 1 },
+    ],
+    // Set isInitialized variable to true after first render call
+    [
+      "const hasLabelSlot = this.hasSlotController.test('label');",
+      'this.isInitialized = true;',
+      { tabsAfterInsertion: 2 },
+    ],
     // Add the defaultValue handling if value was initially set via property
     [
       'attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null)',
        `protected override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
 
-    if(!this.defaultValue && this.value) {
+    if(!this.isInitialized && !this.defaultValue && this.value) {
       // If the value was set initially via property binding instead of attribute, we need to set the defaultValue manually
       // to be able to reset forms and the dynamic loading of options are working correctly.
       this.defaultValue = this.value

--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -1,5 +1,5 @@
 import { removeSections } from '../remove-section.js';
-import { replaceSections } from '../replace-section.js';
+import { addSectionsBefore, replaceSections } from '../replace-section.js';
 
 const FILES_TO_TRANSFORM = [
   'select.component.ts',
@@ -14,7 +14,7 @@ const FILES_TO_TRANSFORM = [
  * @returns
  */
 const transformComponent = (path, originalContent) => {
-  const contentWithRemovedStyles = removeSections([
+  let content = removeSections([
     ['/** Draws a filled', 'filled = false;'],
     ["'select--filled", ','],
     ['/** Draws a pill-style', ';'],
@@ -22,14 +22,36 @@ const transformComponent = (path, originalContent) => {
     ["'select--pill'", ','],
   ], originalContent);
 
-  const content = replaceSections([
+  content = replaceSections([
     [
       "val = Array.isArray(val) ? val : val.split(' ');",
       `if (!Array.isArray(val)) {
         val = typeof val === 'string' ? val.split(' ') : [val].filter(Boolean);
       }`,
     ],
-  ], contentWithRemovedStyles);
+    [
+      "import type { CSSResultGroup, TemplateResult } from 'lit';",
+      "import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';",
+    ],
+  ], content);
+
+  content = addSectionsBefore([
+    // Add the defaultValue handling if value was initially set via property
+    [
+      'attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null)',
+       `protected override willUpdate(changedProperties: PropertyValues) {
+    super.willUpdate(changedProperties);
+
+    if(!this.defaultValue && this.value) {
+      // If the value was set initially via property binding instead of attribute, we need to set the defaultValue manually
+      // to be able to reset forms and the dynamic loading of options are working correctly.
+      this.defaultValue = this.value
+      this.valueHasChanged = false;
+    }
+  }`,
+       { newlinesAfterInsertion: 2, tabsAfterInsertion: 1 },
+    ],
+  ], content);
 
   return {
     content,

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -244,6 +244,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   }
 
   firstUpdated() {
+    this.isInitialized = true;
     this.formControlController.updateValidity();
   }
 
@@ -859,7 +860,6 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   /* eslint-disable @typescript-eslint/unbound-method */
   // eslint-disable-next-line complexity
   render() {
-    this.isInitialized = true;
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -109,6 +109,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   private isOptionRendererTriggered = false;
 
+  private isInitialized: boolean = false;
+
   @query('.combobox') popup: SynPopup;
 
   @query('.combobox__inputs') combobox: HTMLSlotElement;
@@ -248,7 +250,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   protected override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
 
-    if (!this.defaultValue && this.value) {
+    if (!this.isInitialized && !this.defaultValue && this.value) {
       // If the value was set initially via property binding instead of attribute, we need to set
       // the defaultValue manually to be able to reset forms and the dynamic loading of options
       // are working correctly.
@@ -857,6 +859,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   /* eslint-disable @typescript-eslint/unbound-method */
   // eslint-disable-next-line complexity
   render() {
+    this.isInitialized = true;
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -847,6 +847,30 @@ describe('<syn-combobox>', () => {
       await combobox.updateComplete;
       expect(combobox.value).to.equal('option-1');
     });
+
+    it('#813: should reset the element to its initial value, which was set over property binding', async () => {
+      const form = await fixture<HTMLFormElement>(html`
+        <form>
+          <syn-combobox .value=${'option-1'}>
+            <syn-option value="option-1">Option 1</syn-option>
+            <syn-option value="option-2">Option 2</syn-option>
+          </syn-combobox>
+          <syn-button type="reset">Reset</syn-button>
+        </form>
+      `);
+
+      const resetButton = form.querySelector('syn-button')!;
+      const combobox = form.querySelector('syn-combobox')!;
+      combobox.value = 'option-2';
+      await combobox.updateComplete;
+
+      await expect(combobox.value).to.equal('option-2');
+
+      setTimeout(() => resetButton.click());
+      await oneEvent(form, 'reset');
+      await combobox.updateComplete;
+      await expect(combobox.value).to.equal('option-1');
+    });
   });
 
   describe('when calling HTMLFormElement.reportValidity()', () => {
@@ -1295,6 +1319,31 @@ describe('<syn-combobox>', () => {
       });
       expect(getOptionHandler).to.have.been.calledThrice;
     });
+  });
+
+  it('#813: should show the value of the dynamically added option if value was set via property binding', async () => {
+    const el = await fixture<SynCombobox>(html`
+      <syn-combobox .value=${'option-1'}>
+      </syn-combobox>
+    `);
+
+    await el.updateComplete;
+
+    await expect(el.value).to.equal('option-1');
+    await expect(el.displayLabel).to.equal('option-1');
+
+    // wait a short time until adding options dynamically
+    await aTimeout(10);
+    const option = document.createElement('syn-option');
+    option.value = 'option-1';
+    option.textContent = 'Option 1';
+    el.appendChild(option);
+    await el.updateComplete;
+    // we need to wait a short time until everything is set correctly
+    await aTimeout(0);
+
+    await expect(el.value).to.equal('option-1');
+    await expect(el.displayLabel).to.equal('Option 1');
   });
 
   runFormControlBaseTests('syn-combobox');

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -679,6 +679,10 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     }
   }
 
+  firstUpdated() {
+    this.isInitialized = true;
+  }
+
   protected override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
 
@@ -817,7 +821,6 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   }
 
   render() {
-    this.isInitialized = true;
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -678,20 +678,6 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     }
   }
 
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null) {
-    super.attributeChangedCallback(name, oldVal, newVal);
-
-    /** This is a backwards compatibility call needed for setting a new value via attribute (e.g. .setAttribute('value',...)). In a new major version we should make a clean separation between "value" the attribute mapping to "defaultValue" property and "value" the property not reflecting. */
-    if (name === 'value') {
-      const cachedValueHasChanged = this.valueHasChanged;
-      this.value = this.defaultValue;
-
-      // Set it back to false since this isn't an interaction.
-      this.valueHasChanged = cachedValueHasChanged;
-    }
-  }
-
-
   protected override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
 
@@ -700,6 +686,19 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
       // to be able to reset forms and the dynamic loading of options are working correctly.
       this.defaultValue = this.value
       this.valueHasChanged = false;
+    }
+  }
+
+  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null) {
+    super.attributeChangedCallback(name, oldVal, newVal);
+
+    /** This is a backwards compatibility call. In a new major version we should make a clean separation between "value" the attribute mapping to "defaultValue" property and "value" the property not reflecting. */
+    if (name === 'value') {
+      const cachedValueHasChanged = this.valueHasChanged;
+      this.value = this.defaultValue;
+
+      // Set it back to false since this isn't an interaction.
+      this.valueHasChanged = cachedValueHasChanged;
     }
   }
 

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -94,6 +94,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   });
   private readonly hasSlotController = new HasSlotController(this, 'help-text', 'label');
   private readonly localize = new LocalizeController(this);
+  private isInitialized: boolean = false;
   private typeToSelectString = '';
   private typeToSelectTimeout: number;
   private closeWatcher: CloseWatcher | null;
@@ -681,7 +682,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   protected override willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
 
-    if(!this.defaultValue && this.value) {
+    if(!this.isInitialized && !this.defaultValue && this.value) {
       // If the value was set initially via property binding instead of attribute, we need to set the defaultValue manually
       // to be able to reset forms and the dynamic loading of options are working correctly.
       this.defaultValue = this.value
@@ -816,6 +817,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   }
 
   render() {
+    this.isInitialized = true;
     const hasLabelSlot = this.hasSlotController.test('label');
     const hasHelpTextSlot = this.hasSlotController.test('help-text');
     const hasLabel = this.label ? true : !!hasLabelSlot;

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -27,7 +27,7 @@ import SynPopup from '../popup/popup.component.js';
 import SynTag from '../tag/tag.component.js';
 import styles from './select.styles.js';
 import customStyles from './select.custom.styles.js';
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import type { SynergyFormControl } from '../../internal/synergy-element.js';
 import type { SynRemoveEvent } from '../../events/syn-remove.js';
 import type SynOption from '../option/option.component.js';
@@ -681,13 +681,25 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null) {
     super.attributeChangedCallback(name, oldVal, newVal);
 
-    /** This is a backwards compatibility call. In a new major version we should make a clean separation between "value" the attribute mapping to "defaultValue" property and "value" the property not reflecting. */
+    /** This is a backwards compatibility call needed for setting a new value via attribute (e.g. .setAttribute('value',...)). In a new major version we should make a clean separation between "value" the attribute mapping to "defaultValue" property and "value" the property not reflecting. */
     if (name === 'value') {
       const cachedValueHasChanged = this.valueHasChanged;
       this.value = this.defaultValue;
 
       // Set it back to false since this isn't an interaction.
       this.valueHasChanged = cachedValueHasChanged;
+    }
+  }
+
+
+  protected override willUpdate(changedProperties: PropertyValues) {
+    super.willUpdate(changedProperties);
+
+    if(!this.defaultValue && this.value) {
+      // If the value was set initially via property binding instead of attribute, we need to set the defaultValue manually
+      // to be able to reset forms and the dynamic loading of options are working correctly.
+      this.defaultValue = this.value
+      this.valueHasChanged = false;
     }
   }
 

--- a/packages/components/src/components/select/select.custom.test.ts
+++ b/packages/components/src/components/select/select.custom.test.ts
@@ -1,5 +1,7 @@
 import '../../../dist/synergy.js';
-import { expect, fixture } from '@open-wc/testing';
+import {
+  aTimeout, expect, fixture, html, oneEvent,
+} from '@open-wc/testing';
 import type SynSelect from './select.js';
 
 describe('<syn-select>', () => {
@@ -42,6 +44,55 @@ describe('<syn-select>', () => {
         const el = await fixture<SynSelect>('<syn-select multiple></syn-select>');
         el.value = ['a', 'b', 'c'];
         await expect(el.value).to.eql(['a', 'b', 'c']);
+      });
+    });
+
+    // TODO: could be removed if shoelace accepts the PR and the tests are added there
+    describe('#813: should work correctly if `value` was set via property binding', () => {
+      it('should show the value of the dynamically added option', async () => {
+        const el = await fixture<SynSelect>(html`
+          <syn-select .value=${'option-1'}></syn-select>
+        `);
+
+        await el.updateComplete;
+
+        await expect(el.value).to.equal('option-1');
+        await expect(el.displayLabel).to.equal('');
+
+        // wait a short time until adding options dynamically
+        await aTimeout(10);
+        const option = document.createElement('syn-option');
+        option.value = 'option-1';
+        option.textContent = 'Option 1';
+        el.appendChild(option);
+        await el.updateComplete;
+
+        await expect(el.value).to.equal('option-1');
+        await expect(el.displayLabel).to.equal('Option 1');
+      });
+
+      it('should reset the value of the select in a form to the initially set value', async () => {
+        const form = await fixture<HTMLFormElement>(html`
+          <form>
+            <syn-select .value=${'option-1'}>
+              <syn-option value="option-1">Option 1</syn-option>
+              <syn-option value="option-2">Option 2</syn-option>
+            </syn-select>
+            <syn-button type="reset">Reset</syn-button>
+          </form>
+        `);
+
+        const resetButton = form.querySelector('syn-button')!;
+        const select = form.querySelector('syn-select')!;
+        select.value = 'option-2';
+        await select.updateComplete;
+
+        await expect(select.value).to.equal('option-2');
+
+        setTimeout(() => resetButton.click());
+        await oneEvent(form, 'reset');
+        await select.updateComplete;
+        await expect(select.value).to.equal('option-1');
       });
     });
   });


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes problems, when the value of syn-select or syn-combobox was initially set via property binding. 

### 🎫 Issues
Closes #813 

## 👩‍💻 Reviewer Notes
The `defaultValue` of the combobox and select is used for setting the new value of the component on slotChange event or if resetting the component value in a form.

But the mechanism behind `defaultValue` was only working if the value was set via attribute binding but not for property binding!

### Note:
It just came to my mind, that we should check all the other form elements... not just select and combobox.
I will have a look into it.

## 📑 Test Plan
For the frameworks have a look at the `combobox` and `select` parts of the `AllComponents` section.

For storybook use following code snippets.

### Select
```js
export const SelectBug: Story = {
  parameters: {
    docs: {
      description: {
        story: generateStoryDescription('select', 'labels'),
      },
    },
  },
  render: () => html`
    <!-- Property binding + dynamic adding was not working -->
    <syn-select id="bla" .value=${'option-1'}></syn-select>

    <!-- 
      property binding + form reset was not working
      steps to reproduce:
      - select Option 2
      - click reset button
    -->
    <form>
      <syn-select .value=${'option-1'}>
        <syn-option value="option-1">Option 1</syn-option>
        <syn-option value="option-2">Option 2</syn-option>
      </syn-select>
      <syn-button type="reset">reset</syn-button>
    </form>
    <script type="module">
      const select = document.querySelector('#bla');
      const opt1 = document.createElement('syn-option');
      opt1.value = 'option-1';
      opt1.textContent = 'Option 1';  
      const opt2 = document.createElement('syn-option');
      opt2.value = 'option-2';
      opt2.textContent = 'Option 2';
      setTimeout(() => {
        select.appendChild(opt1);
        select.appendChild(opt2);
      }, 0);    
    </script>
  `,
};
```

### Combobox
```js
export const ComboboxBug: Story = {
  parameters: {
    docs: {
      description: {
        story: generateStoryDescription('select', 'labels'),
      },
    },
  },
  render: () => html`
    <!-- Property binding + dynamic adding was already working for the combobox -->
    <syn-combobox id="bla" .value=${'option-2'}></syn-combobox>

    <!-- 
      property binding + form reset was not working
      steps to reproduce:
      - select Option 2
      - click reset button
      -->
     <form>
      <syn-combobox .value=${'option-1'}>
        <syn-option value="option-1">Option 1</syn-option>
        <syn-option value="option-2">Option 2</syn-option>
      </syn-combobox>
      <syn-button type="reset">reset</syn-button>
     </form>

    <script type="module">
      const combobox = document.querySelector('#bla');
      const opt1 = document.createElement('syn-option');
      opt1.value = 'option-1';
      opt1.textContent = 'Option 1';  
      const opt2 = document.createElement('syn-option');
      opt2.value = 'option-2';
      opt2.textContent = 'Option 2';
      setTimeout(() => {
        combobox.appendChild(opt1);
        combobox.appendChild(opt2);
      }, 0);    
    </script>
  `,
};
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
