### PR TITLE
fix: 🐛 dynamically added active tab in angular does not show any panel content

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/TabGroup.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/TabGroup.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { SynButtonComponent } from '@synergy-design-system/angular';
 import { SynTabComponent } from '@synergy-design-system/angular/components/tab';
 import { SynTabGroupComponent } from '@synergy-design-system/angular/components/tab-group';
 import { SynTabPanelComponent } from '@synergy-design-system/angular/components/tab-panel';
@@ -7,23 +8,40 @@ import { SynTabPanelComponent } from '@synergy-design-system/angular/components/
   selector: 'demo-tabgroup',
   standalone: true,
   imports: [
+    SynButtonComponent,
     SynTabGroupComponent,
     SynTabPanelComponent,
     SynTabComponent,
   ],
   template: `
-    <syn-tab-group contained>
-      <syn-tab-panel name="example-general" active>
-        This is the general tab panel.
-      </syn-tab-panel>
-      <syn-tab-panel name="example-custom">This is the custom tab panel.</syn-tab-panel>
-      <syn-tab-panel name="example-advanced">This is the advanced tab panel.</syn-tab-panel>
-      <syn-tab-panel name="example-disabled">This is the disabled tab panel.</syn-tab-panel>
-      <syn-tab slot="nav" panel="example-general" active>General</syn-tab>
-      <syn-tab slot="nav" panel="example-custom">Custom</syn-tab>
-      <syn-tab slot="nav" panel="example-advanced">Advanced</syn-tab>
-      <syn-tab slot="nav" panel="example-disabled" disabled>Disabled</syn-tab>
-    </syn-tab-group>
+  <syn-tab-group contained>
+    @for (item of items; track $index; let index = $index) {
+      <syn-tab-panel [name]="item.id" > {{ item.description }} </syn-tab-panel>
+      <syn-tab
+        [active]="index === items.length - 1"
+        slot="nav"
+        [panel]="item.id"
+        [disabled]="item.disabled"
+      >{{ item.name }}</syn-tab>
+    }
+  </syn-tab-group>
+  <syn-button (click)="createNewActiveTab()">Add Tab</syn-button>
   `,
 })
-export class TabGroup {}
+export class TabGroup {
+  items = [
+    { id: 'general', description: 'This is the custom tab panel.', name: 'General', disabled: false },
+    { id: 'disabled', description: 'This is the disabled tab panel.', name: 'Disabled', disabled: true },
+    { id: 'custom', description: 'This is the custom tab panel.', name: 'Custom', disabled: false },
+    { id: 'advanced', description: 'This is the advanced tab panel.', name: 'Advanced', disabled: false },
+  ]
+
+  createNewActiveTab() {
+    this.items.push({
+      id: `new-tab-${this.items.length + 1}`,
+      description: `This is the new tab panel ${this.items.length + 1}.`,
+      name: `New Tab ${this.items.length + 1}`,
+      disabled: false,
+    });
+  }
+}

--- a/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
@@ -324,6 +324,7 @@ test.describe('<SynTabGroup />', () => {
         const tabGroupLink = AllComponents.getLocator('tabGroupLink');
         const tabGroupCustom = AllComponents.getLocator('tabGroupCustom');
         const tabGroupGeneral = AllComponents.getLocator('tabGroupGeneral');
+        const tabGroupAdvanced = AllComponents.getLocator('tabGroupAdvanced');
 
         // Check if the active tab is adjusted when navigating
         await expect(tabGroupLink).toHaveJSProperty('active', false);
@@ -334,15 +335,44 @@ test.describe('<SynTabGroup />', () => {
         await expect(tabGroupCustom).toBeVisible();
         await expect(tabGroupCustom).toHaveJSProperty('active', false);
         await expect(tabGroupGeneral).toBeVisible();
-        await expect(tabGroupGeneral).toHaveJSProperty('active', true);
+        await expect(tabGroupGeneral).toHaveJSProperty('active', false);
+        await expect(tabGroupAdvanced).toBeVisible();
+        await expect(tabGroupAdvanced).toHaveJSProperty('active', true);
 
         await tabGroupCustom.click();
         await expect(tabGroupCustom).toHaveJSProperty('active', true);
-        await expect(tabGroupGeneral).toHaveJSProperty('active', false);
+        await expect(tabGroupAdvanced).toHaveJSProperty('active', false);
 
         // Finally, check if the parent tab is still active
         await expect(tabGroupLink).toHaveJSProperty('active', true);
       });
     }); // regression#757
+    test.describe(`Regression#814: ${name}`, () => {
+      test('should show the new added active tab with panel', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('tabGroupLink');
+
+        const tabGroupAdvanced = await AllComponents.getLocator('tabGroupAdvanced');
+        const addTabButton = await AllComponents.getLocator('tabGroupAddTabButton');
+        const tabGroupAdded = await AllComponents.getLocator('tabGroupAdded');
+        const tabGroupAddedPanel = await AllComponents.getLocator('tabGroupAddedPanel');
+
+        await expect(tabGroupAdvanced).toBeVisible();
+        await expect(tabGroupAdvanced).toHaveJSProperty('active', true);
+        await expect(tabGroupAdded).toBeHidden();
+        await expect(tabGroupAddedPanel).toBeHidden();
+
+        await addTabButton.click();
+
+        // Check that the newly added active tab and panel are visible and have property active=true
+        await expect(tabGroupAdvanced).toBeVisible();
+        await expect(tabGroupAdvanced).toHaveJSProperty('active', false);
+        await expect(tabGroupAdded).toBeVisible();
+        await expect(tabGroupAdded).toHaveJSProperty('active', true);
+        await expect(tabGroupAddedPanel).toBeVisible();
+        await expect(tabGroupAddedPanel).toHaveJSProperty('active', true);
+      });
+    }); // regression#814
   }); // End frameworks
 });

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -36,7 +36,12 @@ const AllComponentSelectors = {
   selectLink: '#tab-Select',
 
   // Tabgroup
-  tabGroupCustom: '#tab-content-TabGroup syn-tab:nth-of-type(2)',
+  tabGroupAdded: '#tab-content-TabGroup syn-tab:nth-of-type(5)',
+  tabGroupAddedPanel: '#tab-content-TabGroup syn-tab-panel:nth-of-type(5)',
+  tabGroupAddTabButton: '#tab-content-TabGroup syn-button',
+  tabGroupAdvanced: '#tab-content-TabGroup syn-tab:nth-of-type(4)',
+  tabGroupAdvancedPanel: '#tab-content-TabGroup syn-tab-panel:nth-of-type(4)',
+  tabGroupCustom: '#tab-content-TabGroup syn-tab:nth-of-type(3)',
   tabGroupGeneral: '#tab-content-TabGroup syn-tab:nth-of-type(1)',
   tabGroupLink: '#tab-TabGroup',
 };

--- a/packages/_private/react-demo/src/AllComponentParts/TabGroup.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/TabGroup.tsx
@@ -1,14 +1,53 @@
-export const TabGroup = () => (
-  <syn-tab-group contained>
-    <syn-tab-panel name="example-general" active>
-      This is the general tab panel.
-    </syn-tab-panel>
-    <syn-tab-panel name="example-custom">This is the custom tab panel.</syn-tab-panel>
-    <syn-tab-panel name="example-advanced">This is the advanced tab panel.</syn-tab-panel>
-    <syn-tab-panel name="example-disabled">This is the disabled tab panel.</syn-tab-panel>
-    <syn-tab slot="nav" panel="example-general" active>General</syn-tab>
-    <syn-tab slot="nav" panel="example-custom">Custom</syn-tab>
-    <syn-tab slot="nav" panel="example-advanced">Advanced</syn-tab>
-    <syn-tab slot="nav" panel="example-disabled" disabled>Disabled</syn-tab>
-  </syn-tab-group>
-);
+import { useState } from 'react';
+
+export const TabGroup = () => {
+  const initialItems = [
+    {
+      description: 'This is the custom tab panel.', disabled: false, id: 'general', name: 'General',
+    },
+    {
+      description: 'This is the disabled tab panel.', disabled: true, id: 'disabled', name: 'Disabled',
+    },
+    {
+      description: 'This is the custom tab panel.', disabled: false, id: 'custom', name: 'Custom',
+    },
+    {
+      description: 'This is the advanced tab panel.', disabled: false, id: 'advanced', name: 'Advanced',
+    }];
+
+  const [items, setItems] = useState(initialItems);
+
+  const createNewActiveTab = () => {
+    setItems((prevItems) => [
+      ...prevItems,
+      {
+        description: `This is the new tab panel ${prevItems.length + 1}.`,
+        disabled: false,
+        id: `new-tab-${prevItems.length + 1}`,
+        name: `New Tab ${prevItems.length + 1}`,
+      },
+    ]);
+  };
+  return (
+    <>
+      <syn-tab-group contained>
+        {items.map((item, index) => (
+          <>
+            <syn-tab-panel key={item.id} name={item.id}>
+              {item.description}
+            </syn-tab-panel>
+            <syn-tab
+              slot="nav"
+              panel={item.id}
+              disabled={item.disabled}
+              active={index === items.length - 1}
+            >
+              {item.name}
+            </syn-tab>
+          </>
+        ))}
+      </syn-tab-group>
+      <syn-button onClick={createNewActiveTab}>Add Tab</syn-button>
+    </>
+  );
+};

--- a/packages/_private/vanilla-demo/src/AllComponentParts/TabGroup.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/TabGroup.ts
@@ -1,16 +1,23 @@
 import { html } from 'lit';
 
-export const TabGroup = () => html`
-  <syn-tab-group contained>
-    <syn-tab-panel name="example-general" active>
-      This is the general tab panel.
-    </syn-tab-panel>
-    <syn-tab-panel name="example-custom">This is the custom tab panel.</syn-tab-panel>
-    <syn-tab-panel name="example-advanced">This is the advanced tab panel.</syn-tab-panel>
-    <syn-tab-panel name="example-disabled">This is the disabled tab panel.</syn-tab-panel>
-    <syn-tab slot="nav" panel="example-general" active>General</syn-tab>
-    <syn-tab slot="nav" panel="example-custom">Custom</syn-tab>
-    <syn-tab slot="nav" panel="example-advanced">Advanced</syn-tab>
-    <syn-tab slot="nav" panel="example-disabled" disabled>Disabled</syn-tab>
-  </syn-tab-group>
-`;
+export const TabGroup = (regressions: Array< () => void> = []) => {
+  regressions.forEach((regression) => {
+    regression();
+  });
+
+  return html`
+    <syn-tab-group contained>
+      <syn-tab-panel name="general">
+        This is the general tab panel.
+      </syn-tab-panel>
+      <syn-tab-panel name="custom">This is the custom tab panel.</syn-tab-panel>
+      <syn-tab-panel name="advanced">This is the advanced tab panel.</syn-tab-panel>
+      <syn-tab-panel name="disabled">This is the disabled tab panel.</syn-tab-panel>
+      <syn-tab slot="nav" panel="general">General</syn-tab>
+      <syn-tab slot="nav" panel="disabled" disabled>Disabled</syn-tab>
+      <syn-tab slot="nav" panel="custom">Custom</syn-tab>
+      <syn-tab slot="nav" panel="advanced" active>Advanced</syn-tab>
+    </syn-tab-group>
+    <syn-button>Add Tab</syn-button>
+  `;
+};

--- a/packages/_private/vanilla-demo/src/all-components-regressions.ts
+++ b/packages/_private/vanilla-demo/src/all-components-regressions.ts
@@ -1,4 +1,6 @@
-import { SynDialog, SynTabShowEvent } from '@synergy-design-system/components';
+import type {
+  SynButton, SynDialog, SynTabGroup, SynTabShowEvent,
+} from '@synergy-design-system/components';
 import type { LitElement } from 'lit';
 
 const getAllComponentsElement = async () => {
@@ -49,5 +51,29 @@ export const allComponentsRegressions = new Map(Object.entries({
   Select: [
     // #813
     () => appendOptions813('syn-select[data-testid="select-level-813"]'),
+  ],
+  TabGroup: [
+    // #814
+    async () => {
+      const allComponents = (await getAllComponentsElement()).shadowRoot;
+      const tabGroup = allComponents?.querySelector('#tab-content-TabGroup syn-tab-group') as SynTabGroup;
+      const addTabButton = allComponents?.querySelector('#tab-content-TabGroup syn-button') as SynButton;
+      addTabButton.addEventListener('click', () => {
+        const tabs = tabGroup?.querySelectorAll('syn-tab');
+        const id = `new-tab-${tabs.length + 1}`;
+
+        const newTab = document.createElement('syn-tab');
+        newTab.slot = 'nav';
+        newTab.panel = id;
+        newTab.active = true;
+        newTab.textContent = `New Tab ${tabs.length + 1}`;
+
+        const newTabPanel = document.createElement('syn-tab-panel');
+        newTabPanel.name = id;
+        newTabPanel.textContent = `This is the new tab panel ${tabs.length + 1}.`;
+        tabGroup.appendChild(newTab);
+        tabGroup.appendChild(newTabPanel);
+      });
+    },
   ],
 }));

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoTabGroup.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoTabGroup.vue
@@ -1,18 +1,45 @@
 <script setup lang="ts">
-import { SynVueTabGroup, SynVueTabPanel, SynVueTab } from '@synergy-design-system/vue';
+import { SynVueButton, SynVueTabGroup, SynVueTabPanel, SynVueTab } from '@synergy-design-system/vue';
+import { ref } from 'vue';
+const initialItems = [
+    {
+      description: 'This is the custom tab panel.', disabled: false, id: 'general', name: 'General',
+    },
+    {
+      description: 'This is the disabled tab panel.', disabled: true, id: 'disabled', name: 'Disabled',
+    },
+    {
+      description: 'This is the custom tab panel.', disabled: false, id: 'custom', name: 'Custom',
+    },
+    {
+      description: 'This is the advanced tab panel.', disabled: false, id: 'advanced', name: 'Advanced',
+    }];
+
+const items = ref(initialItems);
+const createNewActiveTab = () => {
+  items.value.push({
+      id: `new-tab-${items.value.length + 1}`,
+      description: `This is the new tab panel ${items.value.length + 1}.`,
+      name: `New Tab ${items.value.length + 1}`,
+      disabled: false,
+    });
+  };
 </script>
 
 <template>
   <SynVueTabGroup contained>
-    <SynVueTabPanel name="example-general" active>
-      This is the general tab panel.
+    <SynVueTabPanel v-for="item in items" :key="item.id" :name="item.id">
+      {{ item.description }}
     </SynVueTabPanel>
-    <SynVueTabPanel name="example-custom">This is the custom tab panel.</SynVueTabPanel>
-    <SynVueTabPanel name="example-advanced">This is the advanced tab panel.</SynVueTabPanel>
-    <SynVueTabPanel name="example-disabled">This is the disabled tab panel.</SynVueTabPanel>
-    <SynVueTab slot="nav" panel="example-general" active>General</SynVueTab>
-    <SynVueTab slot="nav" panel="example-custom">Custom</SynVueTab>
-    <SynVueTab slot="nav" panel="example-advanced">Advanced</SynVueTab>
-    <SynVueTab slot="nav" panel="example-disabled" disabled>Disabled</SynVueTab>
+    <SynVueTab 
+      v-for="(item, index) in items" 
+      :key="item.id"
+      :panel="item.id"
+      :disabled="item.disabled"
+      :active="index === items.length - 1"
+      slot="nav">
+      {{ item.name }}
+    </SynVueTab>
   </SynVueTabGroup>
+  <SynVueButton @click="createNewActiveTab" >Add Tab</SynVueButton>
 </template>

--- a/packages/components/scripts/vendorism/custom/tab-group.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/tab-group.vendorism.js
@@ -146,6 +146,46 @@ const transformComponent = (path, originalContent) => {
     ],
   ], content);
 
+  // #814: Fix problem for angular that new added active tab is not shown correctly
+  content = replaceSections([
+    [
+      "import { eventOptions, property, query, state } from 'lit/decorators.js';",
+      "import { eventOptions, property, query, queryAssignedElements, state } from 'lit/decorators.js';",
+    ],
+    [
+      'private tabs: SynTab[] = []',
+      "@queryAssignedElements({ slot: 'nav', selector: 'syn-tab' }) tabs: SynTab[];",
+    ],
+    [
+      'private panels: SynTabPanel[] = []',
+      "@queryAssignedElements({ selector: 'syn-tab-panel' }) panels: SynTabPanel[];",
+    ],
+    [
+      'const precedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab));',
+      'const precedingTabs = this.tabs.slice(0, this.tabs.indexOf(currentTab));',
+    ],
+  ], content);
+  // #814: remove all occurrences of getAllTabs and getAllPanels
+  content = removeSections([
+    [
+      'private getAllTabs() {',
+      'private getActiveTab()',
+      { preserveEnd: true, removePrecedingWhitespace: false },
+    ],
+    [
+      'const allTabs = this.getAllTabs()',
+      ';',
+    ],
+    [
+      'this.tabs = this.getAllTabs()',
+      ';',
+    ],
+    [
+      'this.panels = this.getAllPanels()',
+      ';',
+    ],
+  ], content);
+
   return {
     content,
     path,

--- a/packages/components/src/components/tab-group/tab-group.component.ts
+++ b/packages/components/src/components/tab-group/tab-group.component.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 import '../../internal/scrollend-polyfill.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { eventOptions, property, query, state } from 'lit/decorators.js';
+import { eventOptions, property, query, queryAssignedElements, state } from 'lit/decorators.js';
 import { html } from 'lit';
 import { LocalizeController } from '../../utilities/localize.js';
 import { scrollIntoView } from '../../internal/scroll.js';
@@ -59,9 +59,9 @@ export default class SynTabGroup extends SynergyElement {
   private activeTab?: SynTab;
   private mutationObserver: MutationObserver;
   private resizeObserver: ResizeObserver;
-  private tabs: SynTab[] = [];
+  @queryAssignedElements({ slot: 'nav', selector: 'syn-tab' }) tabs: SynTab[];;
   private focusableTabs: SynTab[] = [];
-  private panels: SynTabPanel[] = [];
+  @queryAssignedElements({ selector: 'syn-tab-panel' }) panels: SynTabPanel[];;
   private readonly localize = new LocalizeController(this);
 
   @query('.tab-group') tabGroup: HTMLElement;
@@ -181,16 +181,6 @@ export default class SynTabGroup extends SynergyElement {
     if (this.nav) {
       this.resizeObserver?.unobserve(this.nav);
     }
-  }
-
-  private getAllTabs() {
-    const slot = this.shadowRoot!.querySelector<HTMLSlotElement>('slot[name="nav"]')!;
-
-    return slot.assignedElements() as SynTab[];
-  }
-
-  private getAllPanels() {
-    return [...this.body.assignedElements()].filter(el => el.tagName.toLowerCase() === 'syn-tab-panel') as [SynTabPanel];
   }
 
   private getActiveTab() {
@@ -357,8 +347,7 @@ export default class SynTabGroup extends SynergyElement {
 
     // We can't used offsetLeft/offsetTop here due to a shadow parent issue where neither can getBoundingClientRect
     // because it provides invalid values for animating elements: https://bugs.chromium.org/p/chromium/issues/detail?id=920069
-    const allTabs = this.getAllTabs();
-    const precedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab));
+    const precedingTabs = this.tabs.slice(0, this.tabs.indexOf(currentTab));
     const offset = precedingTabs.reduce(
       (previous, current) => ({
         left: previous.left + current.clientWidth,
@@ -385,10 +374,7 @@ export default class SynTabGroup extends SynergyElement {
 
   // This stores tabs and panels so we can refer to a cache instead of calling querySelectorAll() multiple times.
   private syncTabsAndPanels() {
-    this.tabs = this.getAllTabs();
     this.focusableTabs = this.tabs.filter(el => !el.disabled);
-
-    this.panels = this.getAllPanels();
     this.syncIndicator();
 
     // After updating, show or hide scroll controls as needed


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes the problem, that if a new active tab and panel `<syn-tab active />` is added in an angular project, the new panel content is not shown. Instead no panel content at all is shown.

This problem seems to be only appearing with angular, because it handles some timings / lifecycles different than the other frameworks.

Shoelace caches all tab-panels and tabs e.g. on slotchange. But for angular this is not enough. For this bug, the slotchange fires too late.

To fix this problem I decided to no longer cache the tabs and panel but just use the `@queryAssignedElements`


### 🎫 Issues
Closes #814 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

Example code to test this behavior:

```typescript
import { Component } from '@angular/core';

@Component({
  selector: 'home',
  standalone: false,
  template: `
  <syn-tab-group contained>
  @for (item of items; track $index; let index = $index) {
    <syn-tab-panel [name]="'content' + index">
      {{ item.description }}
    </syn-tab-panel>
    <syn-tab [active]="index === items.length - 1" slot="nav" [panel]="'content' + index">{{ item.name}}</syn-tab>
  }
</syn-tab-group>
<syn-button (click)="addTab()">Add</syn-button>
  `,
})
export class Home {
  items = [
    {name: 'Item 1', description: 'Description 1'},
    {name: 'Item 2', description: 'Description 2'},

  ]
  addTab() {
    this.items.push({name: `Item ${this.items.length + 1}`, description: `Description ${this.items.length + 1}`});
  }
}

```


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
