### PR TITLE
feat: ✨ syn-range should align vertically with other input elements

### DIFF
--- a/packages/components/src/components/range/range.component.ts
+++ b/packages/components/src/components/range/range.component.ts
@@ -527,7 +527,7 @@ export default class SynRange extends SynergyElement implements SynergyFormContr
     thumb.setAttribute('aria-valuetext', this.tooltipFormatter(value));
     const pos = (value - this.min) / (this.max - this.min);
     // eslint-disable-next-line no-param-reassign
-    thumb.style.insetInlineStart = `calc( ${100 * pos}% - var(--full-thumb-size) / 2 )`;
+    thumb.style.insetInlineStart = `calc(${100 * pos}% - var(--half-thumb-size))`;
     this.#updateTooltip(thumb);
   }
 

--- a/packages/components/src/components/range/range.styles.ts
+++ b/packages/components/src/components/range/range.styles.ts
@@ -16,6 +16,13 @@ export default css`
 
     /* This is needed to get the full with of the element, including the border */
     --full-thumb-size: calc(var(--thumb-size) + (var(--syn-focus-ring-width) * 2));
+
+    /*
+     * There are multiple places where we need the half width of the thumb
+     * This is needed for example to position the knob on the track or
+     * provide the spacing to the left and right for the track to make it stand "over"
+     */
+    --half-thumb-size: calc(var(--full-thumb-size) / 2);
   }
 
   /* Sizes */
@@ -46,7 +53,8 @@ export default css`
     justify-content: start;
     letter-spacing: var(--syn-input-letter-spacing);
     position: relative;
-    touch-action: none; /* Prevent misbehaviour in mobile by disabling native touch */
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+    touch-action: none; /* Prevent misbehavior in mobile by disabling native touch */
     -webkit-touch-callout: none;
     transition: var(--syn-transition-fast) color, var(--syn-transition-fast) border, var(--syn-transition-fast) box-shadow, var(--syn-transition-fast) background-color;
     /* stylelint-disable-next-line property-no-vendor-prefix */
@@ -57,6 +65,7 @@ export default css`
 
   .input__wrapper {
     flex: 1 0 auto;
+    margin: 0 var(--half-thumb-size);
     position: relative;
   }
 
@@ -124,7 +133,7 @@ export default css`
 
   /* Internal helper for a better click surface on tracks */
   .track__click-helper {
-    inset: calc(var(--track-hit-area-size) * -1) calc(var(--full-thumb-size) / 2 * -1);
+    inset: calc(var(--track-hit-area-size) * -1) calc(var(--half-thumb-size) * -1);
     position: absolute;
   }
 
@@ -132,13 +141,14 @@ export default css`
     background-color: var(--track-color-inactive);
     border-radius: var(--syn-border-radius-small);
     height: var(--track-height);
-    margin: calc((var(--full-thumb-size) - var(--track-height)) / 2) 0;
+    margin: calc((var(--full-thumb-size) - var(--track-height)) / 2) calc(var(--half-thumb-size) * -1);
   }
 
   .active-track {
     background-color: var(--track-color-active);
     border-radius: var(--syn-border-radius-small);
     height: var(--track-height);
+    margin: 0 calc(var(--half-thumb-size) * -1);
     position: absolute;
     top: 0;
     z-index: 2;
@@ -177,11 +187,13 @@ export default css`
   }
 
   .thumb:hover {
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     cursor: grab;
   }
 
   .thumb.grabbed {
     background: var(--syn-color-primary-950);
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     cursor: grabbing;
   }
 

--- a/packages/components/src/components/range/range.test.ts
+++ b/packages/components/src/components/range/range.test.ts
@@ -595,7 +595,7 @@ describe('<syn-range>', () => {
       const rect = track.getBoundingClientRect();
 
       await sendMouse({
-        position: [rect.left + 120, rect.top],
+        position: [rect.left + 125, rect.top],
         type: 'click',
       });
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adjusts the layout of `<syn-range>`. This is done to prevent the thumb from being drawn outside of the visible area.

### 🎫 Issues

Closes #809 

## 👩‍💻 Reviewer Notes

I just had to add some internal spacing, both negative and positive ones, depending on the element. I added a new internal token named `--half-thumb-size` as the half size of the thumb is now used on at least 3 different places in the code. All original occurrences have been moved to this new token.

## 📑 Test Plan

Have a look at the storybook stories for a visual representation. Notice that the track is still starting on the start of the element, but the know will now happily move to the edge of the visual space when hitting both the left and right boundaries instead of moving over them. This also works when having a prefix or suffix.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
