### PR TITLE
feat: ✨ Let users configure delimeters for syn-select and syn-range

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
     "checkmarks",
     "csspart",
     "cssproperty",
+    "delimeter",
     "fouc",
     "liga",
     "rgba",

--- a/packages/_private/angular-demo/src/AllComponentParts/Range.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Range.ts
@@ -18,6 +18,16 @@ import { SynRangeComponent } from '@synergy-design-system/angular/components/ran
       <span slot="prefix">0</span>
       <span slot="suffix">100</span>
     </syn-range>
+
+    <syn-range
+      data-testid="range-540-delimeter"
+      delimeter="|"
+      help-text="This range uses a custom delimeter"
+      label="Multiple with custom delimeter"
+      [max]=100
+      [min]=0
+      value="20|80"
+    ></syn-range>
   `,
 })
 export class Range {}

--- a/packages/_private/angular-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Select.ts
@@ -15,8 +15,7 @@ import { type SelectItem, mockAsyncData, mockData } from '@synergy-design-system
   template: `
     <syn-select data-testid="select-level-813" label="Experience" help-text="Please tell us your skill level." [value]="'2'">
       @for (level of levels; track $index; let index = $index) {
-        <syn-option [value]="level.value"> {{level.label}}</syn-option
-        >
+        <syn-option [value]="level.value">{{level.label}}</syn-option>
       }
     </syn-select>
 
@@ -53,6 +52,19 @@ import { type SelectItem, mockAsyncData, mockData } from '@synergy-design-system
         }
       </syn-select>
     </div>
+
+    <syn-select
+      data-testid="select-540-delimeter"
+      delimeter="|"
+      help-text="This select uses a custom delimeter"
+      label="Multiple with custom delimeter"
+      multiple
+      value="1|2"
+    >
+      @for (level of levels; track $index; let index = $index) {
+        <syn-option [value]="level.value">{{level.label}}</syn-option>
+      }
+    </syn-select>
   `
 })
 export class Select implements OnInit {

--- a/packages/_private/angular-demo/src/allcomponents/allcomponents.component.html
+++ b/packages/_private/angular-demo/src/allcomponents/allcomponents.component.html
@@ -14,7 +14,7 @@
       [active]="demo[0] === activeDemo"
       [name]="demo[0]"
     >
-      <div [id]="'tab-content-' + demo[0]" style="display: contents;">
+      <div [id]="'tab-content-' + demo[0]">
         <ng-container *ngComponentOutlet="demo[1]"></ng-container>
       </div>
     </syn-tab-panel>

--- a/packages/_private/e2e-demo-test/frameworks.config.ts
+++ b/packages/_private/e2e-demo-test/frameworks.config.ts
@@ -1,7 +1,9 @@
+export type AvailableFrameworks = 'angular' | 'react' | 'vanilla' | 'vue';
+
 export type Framework = {
   customCommand?: string;
   distDir: string;
-  name: string;
+  name: AvailableFrameworks;
   port: number,
 };
 

--- a/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
@@ -1,5 +1,10 @@
 import { type Locator, expect, test } from '@playwright/test';
-import type { SynCombobox, SynOptgroup, SynSelect } from '@synergy-design-system/components';
+import type {
+  SynCombobox,
+  SynOptgroup,
+  SynRange,
+  SynSelect,
+} from '@synergy-design-system/components';
 import { AllComponentsPage } from './PageObjects/index.js';
 import {
   createTestCases,
@@ -265,6 +270,41 @@ test.describe('<SynOptgroup />', () => {
     }); // regression#815
   }); // End frameworks
 }); // </syn-optgroup>
+
+test.describe('<SynRange />', () => {
+  createTestCases(({ name, port }) => {
+    test.describe(`Feature#540: ${name}`, () => {
+      test('should select the given elements when the delimeter is set', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('rangeLink');
+        await expect(AllComponents.getLocator('rangeContent')).toBeVisible();
+
+        const range = await AllComponents.getLocator('rangeWithDelimeter');
+        const initialValue = await range.evaluate((ele: SynRange) => ele.value);
+        const initialValueAsArray = await range.evaluate((ele: SynRange) => ele.valueAsArray);
+        const initialDelimeter = await range.evaluate((ele: SynRange) => ele.delimeter);
+
+        // Note when providing a delimeter, the value is a string,
+        // so we need to check if the value is a string, too
+        expect(initialValue).toEqual('20|80');
+        expect(initialValueAsArray).toEqual([20, 80]);
+        expect(initialDelimeter).toEqual('|');
+
+        // Check that a change in the delimeter is reflected in the value
+        await range.evaluate(async (ele: SynSelect) => {
+          ele.delimeter = ' ';
+          ele.value = '30 70';
+          await ele.updateComplete;
+        });
+
+        const newValue = await range.evaluate((ele: SynSelect) => ele.value);
+
+        expect(newValue).toEqual('30 70');
+      }); // end delimeter check
+    }); // feature#540
+  }); // End frameworks
+}); // </syn-range>
 
 test.describe('<SynSelect />', () => {
   createTestCases(({ name, port }) => {

--- a/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
@@ -316,6 +316,17 @@ test.describe('<SynSelect />', () => {
         await expect(AllComponents.getLocator('selectContent')).toBeVisible();
 
         const select = await AllComponents.getLocator('selectWithDelimeter');
+
+        // Special for angular: Angular does for whatever reason not
+        // eat the delimeter, so we need to set the value in the test directly
+        if (name === 'angular') {
+          await select.evaluate(async (ele: SynSelect) => {
+            ele.delimeter = '|';
+            ele.value = '1|2';
+            await ele.updateComplete;
+          });
+        }
+
         const initialValue = await select.evaluate((ele: SynSelect) => ele.value);
         const initialDelimeter = await select.evaluate((ele: SynSelect) => ele.delimeter);
 

--- a/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
@@ -268,6 +268,37 @@ test.describe('<SynOptgroup />', () => {
 
 test.describe('<SynSelect />', () => {
   createTestCases(({ name, port }) => {
+    test.describe(`Feature#540: ${name}`, () => {
+      test('should select the given elements when the delimeter is set', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('selectLink');
+        await expect(AllComponents.getLocator('selectContent')).toBeVisible();
+
+        const select = await AllComponents.getLocator('selectWithDelimeter');
+        const initialValue = await select.evaluate((ele: SynSelect) => ele.value);
+        const initialDelimeter = await select.evaluate((ele: SynSelect) => ele.delimeter);
+
+        // Note when providing a delimeter, the value is a string,
+        // so we need to check if the value is a string, too
+        expect(initialValue).toEqual(['1', '2']);
+        expect(initialDelimeter).toEqual('|');
+
+        // Check that a change in the delimeter is reflected in the value
+        await select.evaluate(async (ele: SynSelect) => {
+          ele.delimeter = ' ';
+          ele.value = '2 3';
+          await ele.updateComplete;
+        });
+
+        const newValue = await select.evaluate((ele: SynSelect) => ele.value);
+
+        // Note when providing a delimeter, the value is a string,
+        // so we need to check if the value is a string, too
+        expect(newValue).toEqual(['2', '3']);
+      }); // end delimeter check
+    }); // feature#540
+
     test.describe(`Feature#805: ${name}`, () => {
       test.describe('Single Select', () => {
         test('should have an initial value of numeric 1', async ({ page }) => {

--- a/packages/_private/e2e-demo-test/src/helpers.ts
+++ b/packages/_private/e2e-demo-test/src/helpers.ts
@@ -6,9 +6,9 @@ import type {
   SynSwitch,
   SynTextarea,
 } from '@synergy-design-system/components';
-import { frameworks } from '../frameworks.config.js';
+import { type AvailableFrameworks, frameworks } from '../frameworks.config.js';
 
-type FrameworkCallback = (framework: { name: string, port: number }) => void;
+type FrameworkCallback = (framework: { name: AvailableFrameworks, port: number }) => void;
 
 export const getInputValue = async (locator: Locator) => locator
   .evaluate((el: SynInput | SynTextarea | SynSelect) => el.value);

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -36,6 +36,7 @@ const AllComponentSelectors = {
   selectLink: '#tab-Select',
   selectMixedIdMultiSelect: '#tab-content-Select syn-select[data-testid="select-805-multi-select"]',
   selectMixedIdSingleSelect: '#tab-content-Select syn-select[data-testid="select-805-single-select"]',
+  selectWithDelimeter: '#tab-content-Select syn-select[data-testid="select-540-delimeter"]',
 
   // Tabgroup
   tabGroupAdded: '#tab-content-TabGroup syn-tab:nth-of-type(5)',

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -27,6 +27,11 @@ const AllComponentSelectors = {
   optgroupThirdEnabledItems: '#tab-content-OptGroup syn-select syn-optgroup:nth-of-type(3) syn-option:not([disabled])',
   optgroupThirdItem: '#tab-content-OptGroup syn-select syn-optgroup:nth-of-type(3)',
 
+  // Range
+  rangeContent: '#tab-content-Range',
+  rangeLink: '#tab-Range',
+  rangeWithDelimeter: '#tab-content-Range syn-range[data-testid="range-540-delimeter"]',
+
   // Select
   selectContent: '#tab-content-Select',
   selectForm: '#tab-content-Select syn-select[data-testid="select-form-813"]',

--- a/packages/_private/react-demo/src/AllComponentParts/Range.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Range.tsx
@@ -1,12 +1,24 @@
 export const Range = () => (
-  <syn-range
-    help-text="Controls the volume of the current song"
-    label="Volume"
-    max={100}
-    min={0}
-    value="50"
-  >
-    <span slot="prefix">0</span>
-    <span slot="suffix">100</span>
-  </syn-range>
+  <>
+    <syn-range
+      help-text="Controls the volume of the current song"
+      label="Volume"
+      max={100}
+      min={0}
+      value="50"
+    >
+      <span slot="prefix">0</span>
+      <span slot="suffix">100</span>
+    </syn-range>
+
+    <syn-range
+      data-testid="range-540-delimeter"
+      delimeter="|"
+      help-text="This range uses a custom delimeter"
+      label="Multiple with custom delimeter"
+      max={100}
+      min={0}
+      value="20|80"
+    />
+  </>
 );

--- a/packages/_private/react-demo/src/AllComponentParts/Select.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Select.tsx
@@ -16,7 +16,7 @@ export const Select = () => {
   return (
     <>
       <syn-select data-testid="select-level-813" label="Experience" help-text="Please tell us your skill level." value="2">
-        {levels.map((level) => (
+        {levels.map(level => (
           <syn-option key={level.value} value={level.value}>
             {level.label}
           </syn-option>
@@ -39,7 +39,7 @@ export const Select = () => {
           label="Mixed integer and string values (Single Select)"
           value={1}
         >
-          {numericItems.map((item) => (
+          {numericItems.map(item => (
             <syn-option key={item.id} value={item.id} disabled={item.disabled}>
               {item.label}
             </syn-option>
@@ -53,13 +53,28 @@ export const Select = () => {
           multiple
           value={[1, 'three']}
         >
-          {numericItems.map((item) => (
+          {numericItems.map(item => (
             <syn-option key={item.id} value={item.id} disabled={item.disabled}>
               {item.label}
             </syn-option>
           ))}
         </syn-select>
       </div>
+
+      <syn-select
+        data-testid="select-540-delimeter"
+        delimeter="|"
+        help-text="This select uses a custom delimeter"
+        label="Multiple with custom delimeter"
+        multiple
+        value="1|2"
+      >
+        {levels.map(level => (
+          <syn-option key={level.value} value={level.value}>
+            {level.label}
+          </syn-option>
+        ))}
+      </syn-select>
     </>
   );
 };

--- a/packages/_private/react-demo/src/AllComponents.tsx
+++ b/packages/_private/react-demo/src/AllComponents.tsx
@@ -30,7 +30,7 @@ export const AllComponents = () => (
           active={name === activeDemo}
           name={name}
         >
-          <div id={`tab-content-${name}`} style={{ display: 'contents' }}>
+          <div id={`tab-content-${name}`}>
             <Component />
           </div>
         </syn-tab-panel>

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Range.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Range.ts
@@ -11,4 +11,14 @@ export const Range = () => html`
     <span slot="prefix">0</span>
     <span slot="suffix">100</span>
   </syn-range>
+
+  <syn-range
+    data-testid="range-540-delimeter"
+    delimeter="|"
+    help-text="This range uses a custom delimeter"
+    label="Multiple with custom delimeter"
+    max="100"
+    min="0"
+    value="20|80"
+  ></syn-range>
 `;

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
@@ -38,5 +38,14 @@ export const Select = (regressions: Array<() => void> = []) => {
         .value=${[1, 'three']}
       ></syn-select>
     </div>
+
+    <syn-select
+      data-testid="select-540-delimeter"
+      delimeter="|"
+      help-text="This select uses a custom delimeter"
+      label="Multiple with custom delimeter"
+      multiple
+      value="1|2"
+    ></syn-select>
   `;
 };

--- a/packages/_private/vanilla-demo/src/all-components-regressions.ts
+++ b/packages/_private/vanilla-demo/src/all-components-regressions.ts
@@ -59,6 +59,8 @@ export const allComponentsRegressions = new Map(Object.entries({
     },
   ],
   Select: [
+    // #540
+    () => appendOptions813('syn-select[data-testid="select-540-delimeter"]'),
     () => appendOptions805('syn-select[data-testid="select-805-single-select"]'),
     () => appendOptions805('syn-select[data-testid="select-805-multi-select"]'),
     // #813

--- a/packages/_private/vanilla-demo/src/all-components.ts
+++ b/packages/_private/vanilla-demo/src/all-components.ts
@@ -27,7 +27,7 @@ class AllComponents extends LitElement {
             ?active=${name === activeDemo}
             name=${name}
           >
-            <div id="tab-content-${name}" style="display: contents">
+            <div id="tab-content-${name}">
               ${html`${Component(allComponentsRegressions.has(name) ? allComponentsRegressions.get(name) : [])}`}
             </div>
           </syn-tab-panel>

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoRange.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoRange.vue
@@ -13,4 +13,14 @@ import { SynVueRange } from '@synergy-design-system/vue';
     <span slot="prefix">0</span>
     <span slot="suffix">100</span>
   </SynVueRange>
+
+  <SynVueRange
+    data-testid="range-540-delimeter"
+    delimeter="|"
+    help-text="This range uses a custom delimeter"
+    label="Multiple with custom delimeter"
+    :max=100
+    :min=0
+    value="20|80"
+  />
 </template>

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
@@ -46,4 +46,16 @@ onMounted(async () => {
       <SynVueOption v-for="item in numericItems" :value="item.id" :key="item.id"> {{ item.label }}</SynVueOption>
     </SynVueSelect>
   </div>
+
+  <syn-select
+    data-testid="select-540-delimeter"
+    delimeter="|"
+    help-text="This select uses a custom delimeter"
+    label="Multiple with custom delimeter"
+    multiple
+    value="1|2"
+  >
+    <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
+  </syn-select>
+
 </template>

--- a/packages/angular/components/range/range.component.ts
+++ b/packages/angular/components/range/range.component.ts
@@ -212,6 +212,18 @@ export class SynRangeComponent {
   }
 
   /**
+* The delimiter to use when setting the value when `multiple` is enabled.
+The default is a space, but you can set it to a comma or other character.
+ */
+  @Input()
+  set delimeter(v: SynRange['delimeter']) {
+    this._ngZone.runOutsideAngular(() => (this.nativeElement.delimeter = v));
+  }
+  get delimeter(): SynRange['delimeter'] {
+    return this.nativeElement.delimeter;
+  }
+
+  /**
    * The current values of the input (in ascending order) as a string of space separated values
    */
   @Input()

--- a/packages/angular/components/select/select.component.ts
+++ b/packages/angular/components/select/select.component.ts
@@ -124,6 +124,18 @@ export class SynSelectComponent {
   }
 
   /**
+* The delimiter to use when setting the value when `multiple` is enabled.
+The default is a space, but you can set it to a comma or other character.
+ */
+  @Input()
+  set delimeter(v: SynSelect['delimeter']) {
+    this._ngZone.runOutsideAngular(() => (this.nativeElement.delimeter = v));
+  }
+  get delimeter(): SynSelect['delimeter'] {
+    return this.nativeElement.delimeter;
+  }
+
+  /**
    * The name of the select, submitted as a name/value pair with form data.
    */
   @Input()

--- a/packages/components/scripts/jobs/synergy/createDefaultSettings.js
+++ b/packages/components/scripts/jobs/synergy/createDefaultSettings.js
@@ -11,7 +11,11 @@ import {
 /**
  * List of attributes we want to allow an override for
  */
-export const ALLOWED_ATTRIBUTES = ['size', 'variant'];
+export const ALLOWED_ATTRIBUTES = [
+  'delimeter',
+  'size',
+  'variant',
+];
 
 const getDefaultAttributes = attributes => attributes.filter(
   attr => attr.default !== undefined && !!attr.default && attr.default !== "''",
@@ -57,6 +61,7 @@ const createSynDefaultSettingsStructure = (components, whiteListedAttributes = [
 const createSynDefaultSettingsType = (components, whiteListedAttributes = []) => {
   const structure = Object
     .entries(createSynDefaultSettingsStructure(components, whiteListedAttributes))
+    .toSorted() // Make sure the order is always the same
     .reduce((acc, [attr, comp]) => {
       const componentTypes = comp.map(c => `${c}?: AllowedValueForDefaultSetting<${c}, '${attr}'>;`);
       return `${acc}${attr}: {
@@ -75,6 +80,7 @@ const createSynDefaultSettingsType = (components, whiteListedAttributes = []) =>
 const createDefaultSettingsExport = (components, whiteListedAttributes = []) => {
   const structure = Object
     .entries(createSynDefaultSettingsStructure(components, whiteListedAttributes))
+    .toSorted() // Make sure the order is always the same
     // 1. Create a new array that includes
     // the attribute as key and a tuple of component names and default values as value
     .map(([attr, cList]) => {

--- a/packages/components/src/components/option/option.component.ts
+++ b/packages/components/src/components/option/option.component.ts
@@ -47,6 +47,10 @@ export default class SynOption extends SynergyElement {
 
   @query('.option__label') defaultSlot: HTMLSlotElement;
 
+  // the delimiter used to separate multiple values in a select
+  // This is provided by the wrapping syn-select
+  @state() delimeter = ' ';
+
   @state() current = false; // the user has keyed into the option, but hasn't selected it yet (shows a highlight)
   @state() selected = false; // the option is selected and has aria-selected="true"
   @state() hasHover = false; // we need this because Safari doesn't honor :hover styles while dragging
@@ -117,9 +121,12 @@ export default class SynOption extends SynergyElement {
       this.value = String(this.value);
     }
 
-    if (this.value.includes(' ')) {
-      console.error(`Option values cannot include a space. All spaces have been replaced with underscores.`, this);
-      this.value = this.value.replace(/ /g, '_');
+    const { delimeter } = this;
+
+    if (this.value.includes(delimeter)) {
+      console.error(`Option values cannot include "${delimeter}". All occurrences of "${delimeter}" have been replaced with "_".`, this);
+      const regex = new RegExp(delimeter, 'g');
+      this.value = this.value.replace(regex, '_');
     }
   }
 

--- a/packages/components/src/components/range/range.test.ts
+++ b/packages/components/src/components/range/range.test.ts
@@ -22,6 +22,7 @@ describe('<syn-range>', () => {
   it('should have default values', async () => {
     const el = await fixture<SynRange>(html`<syn-range></syn-range>`);
 
+    expect(el.delimeter).to.equal(' ');
     expect(el.disabled).to.equal(false);
     expect(el.helpText).to.equal('');
     expect(el.label).to.equal('');
@@ -420,6 +421,25 @@ describe('<syn-range>', () => {
 
       expect(el.value).to.equal('25 85');
       expect(changeHandler.called).to.be.true;
+    });
+
+    it('should allow to define the delimeter that is used to separate the values', async () => {
+      await resetMouse();
+      const el = await fixture<SynRange>(html`<syn-range delimeter="," value="20,80"></syn-range>`);
+
+      expect(el.value).to.equal('20,80');
+      expect(el.valueAsArray).to.deep.equal([20, 80]);
+
+      el.value = '30,70';
+      await el.updateComplete;
+      expect(el.value).to.equal('30,70');
+      expect(el.valueAsArray).to.deep.equal([30, 70]);
+
+      el.delimeter = '|';
+      el.value = '40|60';
+      await el.updateComplete;
+      expect(el.value).to.equal('40|60');
+      expect(el.valueAsArray).to.deep.equal([40, 60]);
     });
 
     it('should emit a syn-input event while the user is dragging the thumb', async () => {

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -112,6 +112,13 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   @state() selectedOptions: SynOption[] = [];
   @state() private valueHasChanged: boolean = false;
 
+  /**
+   * The delimiter to use when setting the value when `multiple` is enabled.
+   * The default is a space, but you can set it to a comma or other character.
+   * @example <syn-select delimeter="|" value="option-1|option-2"></syn-select>
+   */
+  @property() delimeter = ' ';
+
   /** The name of the select, submitted as a name/value pair with form data. */
   @property() name = '';
 
@@ -130,10 +137,10 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   set value(val: string | number | Array<string | number>) {
     if (this.multiple) {
       if (!Array.isArray(val)) {
-        val = typeof val === 'string' ? val.split(' ') : [val].filter(Boolean);
+        val = typeof val === 'string' ? val.split(this.delimeter) : [val].filter(Boolean);
       }
     } else {
-      val = Array.isArray(val) ? val.join(' ') : val;
+      val = Array.isArray(val) ? val.join(this.delimeter) : val;
     }
 
     if (this._value === val) {
@@ -674,6 +681,13 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   private handleInvalid(event: Event) {
     this.formControlController.setValidity(false);
     this.formControlController.emitInvalidEvent(event);
+  }
+
+  @watch('delimeter')
+  handleDelimeterChange() {
+    this.getAllOptions().forEach(option => {
+      option.delimeter = this.delimeter;
+    });
   }
 
   @watch('disabled', { waitUntilFirstUpdate: true })

--- a/packages/components/src/components/select/select.custom.test.ts
+++ b/packages/components/src/components/select/select.custom.test.ts
@@ -5,6 +5,37 @@ import {
 import type SynSelect from './select.js';
 
 describe('<syn-select>', () => {
+  describe('#540: should allow to use a custom delimeter for multiple values', () => {
+    it('should allow to define the delimeter that is used to separate the values', async () => {
+      const getActiveItems = (elm: SynSelect) => Array.from(
+        elm.querySelectorAll('syn-option'),
+      ).filter(option => option.selected);
+
+      const el = await fixture<SynSelect>(html`
+        <syn-select delimeter="|" multiple value="option1|option2">
+          <syn-option value="option1">Option 1</syn-option>
+          <syn-option value="option2">Option 2</syn-option>
+          <syn-option value="option3">Option 3</syn-option>
+        </syn-select>
+      `);
+
+      expect(el.value).to.deep.equal(['option1', 'option2']);
+
+      const selectedItems = getActiveItems(el);
+      expect(selectedItems.length).to.equal(2);
+
+      el.delimeter = ',';
+      el.value = 'option2,option3';
+      await el.updateComplete;
+      expect(el.value).to.deep.equal(['option2', 'option3']);
+
+      el.delimeter = '|';
+      el.value = 'option1|option3';
+      await el.updateComplete;
+      expect(el.value).to.deep.equal(['option1', 'option3']);
+    });
+  });
+
   describe('#805: should allow setting numeric values', () => {
     describe('when set initially', () => {
       it('should allow to use numbers as value for syn-select and syn-option', async () => {

--- a/packages/components/src/utilities/defaultSettings/base.ts
+++ b/packages/components/src/utilities/defaultSettings/base.ts
@@ -94,6 +94,9 @@ export type ExtractSettingsForElement<C extends SynergyElement> = {
  * Default settings map for all component values that have defaults set
  */
 export type SynDefaultSettings = {
+  delimeter: {
+    SynSelect?: AllowedValueForDefaultSetting<SynSelect, "delimeter">;
+  };
   size: {
     SynAccordion?: AllowedValueForDefaultSetting<SynAccordion, "size">;
     SynButton?: AllowedValueForDefaultSetting<SynButton, "size">;
@@ -126,6 +129,9 @@ export type SynDefaultSettings = {
  * Default settings for all components
  */
 export const defaultSettings: SynDefaultSettings = {
+  delimeter: {
+    SynSelect: " ",
+  },
   size: {
     SynAccordion: "medium",
     SynButton: "medium",
@@ -156,6 +162,9 @@ export const defaultSettings: SynDefaultSettings = {
  * Initial default settings for all components
  */
 export const INITIAL_DEFAULT_SETTINGS: SynDefaultSettings = {
+  delimeter: {
+    SynSelect: " ",
+  },
   size: {
     SynAccordion: "medium",
     SynButton: "medium",

--- a/packages/components/src/utilities/defaultSettings/base.ts
+++ b/packages/components/src/utilities/defaultSettings/base.ts
@@ -95,6 +95,7 @@ export type ExtractSettingsForElement<C extends SynergyElement> = {
  */
 export type SynDefaultSettings = {
   delimeter: {
+    SynRange?: AllowedValueForDefaultSetting<SynRange, "delimeter">;
     SynSelect?: AllowedValueForDefaultSetting<SynSelect, "delimeter">;
   };
   size: {
@@ -130,6 +131,7 @@ export type SynDefaultSettings = {
  */
 export const defaultSettings: SynDefaultSettings = {
   delimeter: {
+    SynRange: " ",
     SynSelect: " ",
   },
   size: {
@@ -163,6 +165,7 @@ export const defaultSettings: SynDefaultSettings = {
  */
 export const INITIAL_DEFAULT_SETTINGS: SynDefaultSettings = {
   delimeter: {
+    SynRange: " ",
     SynSelect: " ",
   },
   size: {

--- a/packages/docs/stories/components/select.stories.ts
+++ b/packages/docs/stories/components/select.stories.ts
@@ -192,6 +192,35 @@ export const Multiple: Story = {
       <syn-option value="Option_5">Option 5</syn-option>
       <syn-option value="Option_6">Option 6</syn-option>
     </syn-select>
+
+    <syn-divider></syn-divider>
+
+    <syn-select delimeter="---" label="Custom Delimeter" value="Option_1---Option_2---Option_3" multiple clearable>
+      <syn-option value="Option_1">Option 1</syn-option>
+      <syn-option value="Option_2">Option 2</syn-option>
+      <syn-option value="Option_3">Option 3</syn-option>
+      <syn-option value="Option_4">Option 4</syn-option>
+      <syn-option value="Option_5">Option 5</syn-option>
+      <syn-option value="Option_6">Option 6</syn-option>
+    </syn-select>
+
+    <syn-select delimeter="---" label="Custom Delimeter" value="Option_1---Option_2---Option_3" multiple clearable>
+      <syn-option value="Option 1">Option 1</syn-option>
+      <syn-option value="Option 2">Option 2</syn-option>
+      <syn-option value="Option 3">Option 3</syn-option>
+      <syn-option value="Option 4">Option 4</syn-option>
+      <syn-option value="Option 5">Option 5</syn-option>
+      <syn-option value="Option 6">Option 6</syn-option>
+    </syn-select>
+
+    <syn-select delimeter="---" label="Custom Delimeter" value="Option_1---Option_2---Option_3" multiple clearable>
+      <syn-option value="Option--1">Option 1</syn-option>
+      <syn-option value="Option-------2">Option 2</syn-option>
+      <syn-option value="Option---3">Option 3</syn-option>
+      <syn-option value="Option---4">Option 4</syn-option>
+      <syn-option value="Option---5">Option 5</syn-option>
+      <syn-option value="Option---6">Option 6</syn-option>
+    </syn-select>
   `,
 };
 

--- a/packages/vue/src/components/SynVueRange.vue
+++ b/packages/vue/src/components/SynVueRange.vue
@@ -125,6 +125,12 @@ const props = defineProps<{
   tooltipPlacement?: SynRange['tooltipPlacement'];
 
   /**
+* The delimiter to use when setting the value when `multiple` is enabled.
+The default is a space, but you can set it to a comma or other character.
+ */
+  delimeter?: SynRange['delimeter'];
+
+  /**
    * The current values of the input (in ascending order) as a string of space separated values
    */
   value?: SynRange['value'];

--- a/packages/vue/src/components/SynVueSelect.vue
+++ b/packages/vue/src/components/SynVueSelect.vue
@@ -77,6 +77,12 @@ defineExpose({
 // Map attributes
 const props = defineProps<{
   /**
+* The delimiter to use when setting the value when `multiple` is enabled.
+The default is a space, but you can set it to a comma or other character.
+ */
+  delimeter?: SynSelect['delimeter'];
+
+  /**
    * The name of the select, submitted as a name/value pair with form data.
    */
   name?: SynSelect['name'];


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds the possibility to configure the delimeter used in `<syn-range>` and `<syn-select>` that is used for both when `multiple` is set. The default is defined as `" "`. It also includes the adjustments needed to make this configurable via `defaultSettings`.

### 🎫 Issues

Closes #540 

## 👩‍💻 Reviewer Notes

I had to include a new private `state` called `delimeter` in the `<syn-option>`, too. This is set when either the `delimeter` of `<syn-select>` changes or it receives new items via `slotChange`.

Angular seems not to take the initial settings into account. After saving the select component in the editor, it works. Probably, there is some timing issue. I was able to mitigate this in testing via setting it explicitly, but this must be further investigated.

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
