### PR TITLE
fix: 🐛 Make the syn-select more robust to allow undefined as value

### DIFF
--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -64,7 +64,7 @@ const transformComponent = (path, originalContent) => {
     ],
     [
       "this.value.join(', ') : this.value",
-      "this.value.join(', ') : this.value.toString()",
+      "this.value.join(', ') : this.value?.toString()",
     ],
     // [
     //   'this.value.join(', ') : this.value}',

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -925,7 +925,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
                 type="text"
                 ?disabled=${this.disabled}
                 ?required=${this.required}
-                .value=${Array.isArray(this.value) ? this.value.join(', ') : this.value.toString()}
+                .value=${Array.isArray(this.value) ? this.value.join(', ') : this.value?.toString()}
                 tabindex="-1"
                 aria-hidden="true"
                 @focus=${() => this.focus()}


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR makes the syn-select more robust. 

### 🎫 Issues
Closes #845 

## 👩‍💻 Reviewer Notes

<!--
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

Check that following code no longer leads to an error in the console:

```html
<syn-select .value=${undefined}> </syn-select>
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
