### PR TITLE
fix: 🐛 syn-input has some paddings which are not aligned with design

### DIFF
--- a/packages/components/src/components/input/input.custom.styles.ts
+++ b/packages/components/src/components/input/input.custom.styles.ts
@@ -143,6 +143,16 @@ export default css`
     padding-right: var(--syn-spacing-small);
   }
 
+  .form-control--has-prefix .input__control {
+    padding-left: 0;
+  }
+
+  .form-control--has-suffix .input__control,
+  .input:has(.input__clear) .input__control,
+  .input:has(.input__password-toggle) .input__control {
+    padding-right: 0;
+  }
+
   :host([type='number']) .input--large:not(.input--no-spin-buttons) .input__clear,
   :host([type='number']) .input--large:not(.input--no-spin-buttons) .input__password-toggle {
     padding-right: var(--syn-spacing-medium);

--- a/packages/components/src/components/input/input.custom.styles.ts
+++ b/packages/components/src/components/input/input.custom.styles.ts
@@ -143,10 +143,12 @@ export default css`
     padding-right: var(--syn-spacing-small);
   }
 
+  /* Fixes wrong paddings on some suffix special cases: https://github.com/synergy-design-system/synergy-design-system/issues/817  */
   .form-control--has-prefix .input__control {
     padding-left: 0;
   }
 
+  /* Fixes wrong paddings on some suffix special cases: https://github.com/synergy-design-system/synergy-design-system/issues/817  */
   .form-control--has-suffix .input__control,
   .input:has(.input__clear) .input__control,
   .input:has(.input__password-toggle) .input__control {

--- a/packages/components/src/styles/form-control.custom.styles.ts
+++ b/packages/components/src/styles/form-control.custom.styles.ts
@@ -24,18 +24,6 @@ export default css`
     margin-top: var(--syn-spacing-x-small);
   }
 
-  .form-control--small.form-control--has-prefix .input__control  {
-    padding: var(--syn-spacing-3x-small) 0;
-  }
-
-  .form-control--has-prefix.form-control--medium .input__control {
-    padding: var(--syn-spacing-x-small) 0;
-  }
-
-  .form-control--large.form-control--has-prefix .input__control {
-   padding: var(--syn-input-spacing-small) 0;
-  }
-
     /* ERROR */
   :host([data-user-invalid]:not([disabled])) .form-control__help-text {
     color: var(--syn-input-help-text-color-error);


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes some non-alignment of inner paddings with design.
Non alignment appears if:
- having only a suffix slot
- having clearable property set
- having password-toggle set

### 🎫 Issues
Closes #817.

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Example code for testing:

```html
  <syn-input label="Correct right padding" value="aaaasadasdjasdasdasdasdasdasdasdasdasdasdsdsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdf">
    <span slot="prefix">prefix</span>
    <span slot="suffix">suffix</span>
  </syn-input>
  <syn-input label="Incorrect right padding" value="aaaasadasdjasdasdasdasdasdasdasdasdasdasdsdsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdf">
    <span slot="suffix">suffix</span>
  </syn-input>
<syn-input clearable label="Incorrect right padding" value="aaaasadasdjasdasdasdasdasdasdasdasdasdasdsdsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdf">
  </syn-input>

<syn-input password-toggle label="Incorrect right padding" value="aaaasadasdjasdasdasdasdasdasdasdasdasdasdsdsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdf">
  </syn-input>
 
```


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
