### PR TITLE
fix: 🤔 Vendorism rewrites inline comment tickets to github to synergy account

### DIFF
--- a/packages/angular/components/alert/alert.component.ts
+++ b/packages/angular/components/alert/alert.component.ts
@@ -21,7 +21,7 @@ import '@synergy-design-system/components/components/alert/alert.js';
 
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
- * @documentation https://synergy.style/components/alert
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-alert--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/badge/badge.component.ts
+++ b/packages/angular/components/badge/badge.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/badge/badge.js';
 
 /**
  * @summary Badges are used to draw attention and display statuses or counts.
- * @documentation https://synergy.style/components/badge
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-badge--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/packages/angular/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/breadcrumb-item/breadcrumb-
 
 /**
  * @summary Breadcrumb Items are used inside [breadcrumbs](/components/breadcrumb) to represent different links.
- * @documentation https://synergy.style/components/breadcrumb-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/breadcrumb/breadcrumb.component.ts
+++ b/packages/angular/components/breadcrumb/breadcrumb.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/breadcrumb/breadcrumb.js';
 
 /**
  * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
- * @documentation https://synergy.style/components/breadcrumb
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/button-group/button-group.component.ts
+++ b/packages/angular/components/button-group/button-group.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/button-group/button-group.j
 
 /**
  * @summary Button groups can be used to group related buttons into sections.
- * @documentation https://synergy.style/components/button-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/button/button.component.ts
+++ b/packages/angular/components/button/button.component.ts
@@ -20,7 +20,7 @@ import '@synergy-design-system/components/components/button/button.js';
 
 /**
  * @summary Buttons represent actions that are available to the user.
- * @documentation https://synergy.style/components/button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/card/card.component.ts
+++ b/packages/angular/components/card/card.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/card/card.js';
 
 /**
  * @summary Cards can be used to group related subjects in a container.
- * @documentation https://synergy.style/components/card
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-card--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/checkbox/checkbox.component.ts
+++ b/packages/angular/components/checkbox/checkbox.component.ts
@@ -22,7 +22,7 @@ import '@synergy-design-system/components/components/checkbox/checkbox.js';
 
 /**
  * @summary Checkboxes allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/checkbox
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-checkbox--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/details/details.component.ts
+++ b/packages/angular/components/details/details.component.ts
@@ -21,7 +21,7 @@ import '@synergy-design-system/components/components/details/details.js';
 
 /**
  * @summary Details show a brief summary and expand to show additional content.
- * @documentation https://synergy.style/components/details
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-details--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/dialog/dialog.component.ts
+++ b/packages/angular/components/dialog/dialog.component.ts
@@ -23,7 +23,7 @@ import '@synergy-design-system/components/components/dialog/dialog.js';
 
 /**
  * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
- * @documentation https://synergy.style/components/dialog
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dialog--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/divider/divider.component.ts
+++ b/packages/angular/components/divider/divider.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/divider/divider.js';
 
 /**
  * @summary Dividers are used to visually separate or group elements.
- * @documentation https://synergy.style/components/divider
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-divider--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/drawer/drawer.component.ts
+++ b/packages/angular/components/drawer/drawer.component.ts
@@ -23,7 +23,7 @@ import '@synergy-design-system/components/components/drawer/drawer.js';
 
 /**
  * @summary Drawers slide in from a container to expose additional options and information.
- * @documentation https://synergy.style/components/drawer
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-drawer--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/dropdown/dropdown.component.ts
+++ b/packages/angular/components/dropdown/dropdown.component.ts
@@ -21,7 +21,7 @@ import '@synergy-design-system/components/components/dropdown/dropdown.js';
 
 /**
  * @summary Dropdowns expose additional content that "drops down" in a panel.
- * @documentation https://synergy.style/components/dropdown
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dropdown--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/file/file.component.ts
+++ b/packages/angular/components/file/file.component.ts
@@ -22,6 +22,7 @@ import '@synergy-design-system/components/components/file/file.js';
 
 /**
  * @summary File controls allow selecting an arbitrary number of files for uploading.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-file--docs
  * @status stable
  *
  * @dependency syn-button

--- a/packages/angular/components/icon-button/icon-button.component.ts
+++ b/packages/angular/components/icon-button/icon-button.component.ts
@@ -19,7 +19,7 @@ import '@synergy-design-system/components/components/icon-button/icon-button.js'
 
 /**
  * @summary Icons buttons are simple, icon-only buttons that can be used for actions and in toolbars.
- * @documentation https://synergy.style/components/icon-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/icon/icon.component.ts
+++ b/packages/angular/components/icon/icon.component.ts
@@ -19,7 +19,7 @@ import '@synergy-design-system/components/components/icon/icon.js';
 
 /**
  * @summary Icons are symbols that can be used to represent various options within an application.
- * @documentation https://synergy.style/components/icon
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/input/input.component.ts
+++ b/packages/angular/components/input/input.component.ts
@@ -23,7 +23,7 @@ import '@synergy-design-system/components/components/input/input.js';
 
 /**
  * @summary Inputs collect data from the user.
- * @documentation https://synergy.style/components/input
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-input--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/menu-item/menu-item.component.ts
+++ b/packages/angular/components/menu-item/menu-item.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/menu-item/menu-item.js';
 
 /**
  * @summary Menu items provide options for the user to pick from in a menu.
- * @documentation https://synergy.style/components/menu-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/menu-label/menu-label.component.ts
+++ b/packages/angular/components/menu-label/menu-label.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/menu-label/menu-label.js';
 
 /**
  * @summary Menu labels are used to describe a group of menu items.
- * @documentation https://synergy.style/components/menu-label
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-label--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/menu/menu.component.ts
+++ b/packages/angular/components/menu/menu.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/menu/menu.js';
 
 /**
  * @summary Menus provide a list of options for the user to choose from.
- * @documentation https://synergy.style/components/menu
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/nav-item/nav-item.component.ts
+++ b/packages/angular/components/nav-item/nav-item.component.ts
@@ -21,6 +21,7 @@ import '@synergy-design-system/components/components/nav-item/nav-item.js';
 
 /**
  * @summary Flexible button / link component that can be used to quickly build navigations.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-nav-item--docs
  * Takes one of 3 forms:
  * - button (default),
  * - link (overrides button if a 'href' is provided),

--- a/packages/angular/components/option/option.component.ts
+++ b/packages/angular/components/option/option.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/option/option.js';
 
 /**
  * @summary Options define the selectable items within various form controls such as [select](/components/select).
- * @documentation https://synergy.style/components/option
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-option--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/popup/popup.component.ts
+++ b/packages/angular/components/popup/popup.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/popup/popup.js';
 
 /**
  * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
- * @documentation https://synergy.style/components/popup
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-popup--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/prio-nav/prio-nav.component.ts
+++ b/packages/angular/components/prio-nav/prio-nav.component.ts
@@ -22,6 +22,7 @@ import '@synergy-design-system/components/components/prio-nav/prio-nav.js';
  * together. It will automatically group all items not visible in the viewport into a custom
  * priority menu.
  *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-prio-nav--docs
  * @example
  * <syn-prio-nav>
  *  <syn-nav-item current horizontal>Item 1</syn-nav-item>

--- a/packages/angular/components/progress-bar/progress-bar.component.ts
+++ b/packages/angular/components/progress-bar/progress-bar.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/progress-bar/progress-bar.j
 
 /**
  * @summary Progress bars are used to show the status of an ongoing operation.
- * @documentation https://synergy.style/components/progress-bar
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-bar--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/progress-ring/progress-ring.component.ts
+++ b/packages/angular/components/progress-ring/progress-ring.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/progress-ring/progress-ring
 
 /**
  * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
- * @documentation https://synergy.style/components/progress-ring
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-ring--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/radio-button/radio-button.component.ts
+++ b/packages/angular/components/radio-button/radio-button.component.ts
@@ -19,7 +19,7 @@ import '@synergy-design-system/components/components/radio-button/radio-button.j
 
 /**
  * @summary Radios buttons allow the user to select a single option from a group using a button-like control.
- * @documentation https://synergy.style/components/radio-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/radio-group/radio-group.component.ts
+++ b/packages/angular/components/radio-group/radio-group.component.ts
@@ -20,7 +20,7 @@ import '@synergy-design-system/components/components/radio-group/radio-group.js'
 
 /**
  * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
- * @documentation https://synergy.style/components/radio-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/radio/radio.component.ts
+++ b/packages/angular/components/radio/radio.component.ts
@@ -19,7 +19,7 @@ import '@synergy-design-system/components/components/radio/radio.js';
 
 /**
  * @summary Radios allow the user to select a single option from a group.
- * @documentation https://synergy.style/components/radio
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/range-tick/range-tick.component.ts
+++ b/packages/angular/components/range-tick/range-tick.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/range-tick/range-tick.js';
 
 /**
  * @summary Ticks visually improve positioning on range sliders.
- * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range-tick--docs
  * @status stable
  *
  * @slot - The tick's label

--- a/packages/angular/components/select/select.component.ts
+++ b/packages/angular/components/select/select.component.ts
@@ -27,7 +27,7 @@ import '@synergy-design-system/components/components/select/select.js';
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
- * @documentation https://synergy.style/components/select
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-select--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/spinner/spinner.component.ts
+++ b/packages/angular/components/spinner/spinner.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/spinner/spinner.js';
 
 /**
  * @summary Spinners are used to show the progress of an indeterminate operation.
- * @documentation https://synergy.style/components/spinner
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-spinner--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/switch/switch.component.ts
+++ b/packages/angular/components/switch/switch.component.ts
@@ -22,7 +22,7 @@ import '@synergy-design-system/components/components/switch/switch.js';
 
 /**
  * @summary Switches allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/switch
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-switch--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/tab-group/tab-group.component.ts
+++ b/packages/angular/components/tab-group/tab-group.component.ts
@@ -19,7 +19,7 @@ import '@synergy-design-system/components/components/tab-group/tab-group.js';
 
 /**
  * @summary Tab groups organize content into a container that shows one section at a time.
- * @documentation https://synergy.style/components/tab-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/tab-panel/tab-panel.component.ts
+++ b/packages/angular/components/tab-panel/tab-panel.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/tab-panel/tab-panel.js';
 
 /**
  * @summary Tab panels are used inside [tab groups](/components/tab-group) to display tabbed content.
- * @documentation https://synergy.style/components/tab-panel
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-panel--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/tab/tab.component.ts
+++ b/packages/angular/components/tab/tab.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/tab/tab.js';
 
 /**
  * @summary Tabs are used inside [tab groups](/components/tab-group) to represent and activate [tab panels](/components/tab-panel).
- * @documentation https://synergy.style/components/tab
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/tag/tag.component.ts
+++ b/packages/angular/components/tag/tag.component.ts
@@ -18,7 +18,7 @@ import '@synergy-design-system/components/components/tag/tag.js';
 
 /**
  * @summary Tags are used as labels to organize things or to indicate a selection.
- * @documentation https://synergy.style/components/tag
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tag--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/textarea/textarea.component.ts
+++ b/packages/angular/components/textarea/textarea.component.ts
@@ -22,7 +22,7 @@ import '@synergy-design-system/components/components/textarea/textarea.js';
 
 /**
  * @summary Textareas collect data from the user and allow multiple lines of text.
- * @documentation https://synergy.style/components/textarea
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-textarea--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/tooltip/tooltip.component.ts
+++ b/packages/angular/components/tooltip/tooltip.component.ts
@@ -21,7 +21,7 @@ import '@synergy-design-system/components/components/tooltip/tooltip.js';
 
 /**
  * @summary Tooltips display additional information based on a specific action.
- * @documentation https://synergy.style/components/tooltip
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tooltip--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/angular/components/validate/validate.component.ts
+++ b/packages/angular/components/validate/validate.component.ts
@@ -20,7 +20,7 @@ import '@synergy-design-system/components/components/validate/validate.js';
  * @summary Validate provides form field validation messages in a unified way.
  * It does this by using [the native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
  * and showing the validation message in a consistent, user defined way.
- *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-validate--docs
  * @dependency syn-alert
  *
  * @slot - The form field that should be validated.

--- a/packages/components/custom-elements-manifest.config.js
+++ b/packages/components/custom-elements-manifest.config.js
@@ -251,12 +251,15 @@ export default {
     customElementVsCodePlugin({
       outdir,
       cssFileName: null,
-      referencesTemplate: (_, tag) => [
-        {
-          name: 'Documentation',
-          url: `https://synergy.style/components/${tag.replace('syn-', '')}`
-        }
-      ]
+      referencesTemplate: (_, tag) => {
+        const documentationUrl = `https://synergy-design-system.github.io/?path=/docs/components-${tag}--docs`;
+        return [
+          {
+            name: 'Documentation',
+            url: documentationUrl,
+          }
+        ];
+      }
     })
   ]
 };

--- a/packages/components/scripts/vendorism.js
+++ b/packages/components/scripts/vendorism.js
@@ -216,7 +216,12 @@ const config = {
           .replace(/(?<!https:\/\/)Shoelace/g, capitalizedLibraryName)
           .replace(/(?<!https:\/\/)shoelace/g, lowerLibraryName)
           .replace('__SHOELACE_VERSION__', '__PACKAGE_VERSION__')
-          .replace(regexPattern, '@shoelace-style/');
+          .replace(regexPattern, '@shoelace-style/')
+          // #471: Make sure to set a correct issue urls
+          .replaceAll(
+            'https://github.com/synergy-design-system/synergy/',
+            'https://github.com/shoelace-style/shoelace/',
+          );
 
         return {
           content: replace(content),

--- a/packages/components/src/components/alert/alert.component.ts
+++ b/packages/components/src/components/alert/alert.component.ts
@@ -26,7 +26,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
- * @documentation https://synergy.style/components/alert
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-alert--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/badge/badge.component.ts
+++ b/packages/components/src/components/badge/badge.component.ts
@@ -19,7 +19,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Badges are used to draw attention and display statuses or counts.
- * @documentation https://synergy.style/components/badge
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-badge--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/breadcrumb-item/breadcrumb-item.component.ts
+++ b/packages/components/src/components/breadcrumb-item/breadcrumb-item.component.ts
@@ -20,7 +20,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Breadcrumb Items are used inside [breadcrumbs](/components/breadcrumb) to represent different links.
- * @documentation https://synergy.style/components/breadcrumb-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/breadcrumb/breadcrumb.component.ts
+++ b/packages/components/src/components/breadcrumb/breadcrumb.component.ts
@@ -19,7 +19,7 @@ import type SynBreadcrumbItem from '../breadcrumb-item/breadcrumb-item.js';
 
 /**
  * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
- * @documentation https://synergy.style/components/breadcrumb
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/button-group/button-group.component.ts
+++ b/packages/components/src/components/button-group/button-group.component.ts
@@ -15,7 +15,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Button groups can be used to group related buttons into sections.
- * @documentation https://synergy.style/components/button-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/button/button.component.ts
+++ b/packages/components/src/components/button/button.component.ts
@@ -26,7 +26,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Buttons represent actions that are available to the user.
- * @documentation https://synergy.style/components/button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/card/card.component.ts
+++ b/packages/components/src/components/card/card.component.ts
@@ -18,7 +18,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Cards can be used to group related subjects in a container.
- * @documentation https://synergy.style/components/card
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-card--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/checkbox/checkbox.component.ts
+++ b/packages/components/src/components/checkbox/checkbox.component.ts
@@ -28,7 +28,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Checkboxes allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/checkbox
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-checkbox--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/checkbox/checkbox.test.ts
+++ b/packages/components/src/components/checkbox/checkbox.test.ts
@@ -107,7 +107,7 @@ describe('<syn-checkbox>', () => {
 
   it('should hide the native input with the correct positioning to scroll correctly when contained in an overflow', async () => {
     //
-    // See: https://github.com/synergy-design-system/synergy/issues/1169
+    // See: https://github.com/shoelace-style/shoelace/issues/1169
     //
     const el = await fixture<SynCheckbox>(html` <syn-checkbox></syn-checkbox> `);
     const label = el.shadowRoot!.querySelector('.checkbox')!;
@@ -286,7 +286,7 @@ describe('<syn-checkbox>', () => {
     });
 
     it('should not jump the page to the bottom when focusing a checkbox at the bottom of an element with overflow: auto;', async () => {
-      // https://github.com/synergy-design-system/synergy/issues/1169
+      // https://github.com/shoelace-style/shoelace/issues/1169
       const el = await fixture<HTMLDivElement>(html`
         <div style="display: flex; flex-direction: column; overflow: auto; max-height: 400px; gap: 8px;">
           <syn-checkbox>Checkbox</syn-checkbox>

--- a/packages/components/src/components/details/details.component.ts
+++ b/packages/components/src/components/details/details.component.ts
@@ -24,7 +24,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Details show a brief summary and expand to show additional content.
- * @documentation https://synergy.style/components/details
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-details--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/dialog/dialog.component.ts
+++ b/packages/components/src/components/dialog/dialog.component.ts
@@ -179,7 +179,7 @@ export default class SynDialog extends SynergyElement {
       // the dialogs's animation to jitter (if it starts offscreen), so we'll temporarily remove the attribute, call
       // `focus({ preventScroll: true })` ourselves, and add the attribute back afterwards.
       //
-      // Related: https://github.com/synergy-design-system/synergy/issues/693
+      // Related: https://github.com/shoelace-style/shoelace/issues/693
       //
       const autoFocusTarget = this.querySelector('[autofocus]');
       if (autoFocusTarget) {
@@ -321,7 +321,7 @@ export default class SynDialog extends SynergyElement {
               `
             : ''}
           ${
-            '' /* The tabindex="-1" is here because the body is technically scrollable if overflowing. However, if there's no focusable elements inside, you won't actually be able to scroll it via keyboard. Previously this was just a <slot>, but tabindex="-1" on the slot causes children to not be focusable. https://github.com/synergy-design-system/synergy/issues/1753#issuecomment-1836803277 */
+            '' /* The tabindex="-1" is here because the body is technically scrollable if overflowing. However, if there's no focusable elements inside, you won't actually be able to scroll it via keyboard. Previously this was just a <slot>, but tabindex="-1" on the slot causes children to not be focusable. https://github.com/shoelace-style/shoelace/issues/1753#issuecomment-1836803277 */
           }
           <div part="body" class="dialog__body" tabindex="-1"><slot></slot></div>
 

--- a/packages/components/src/components/dialog/dialog.component.ts
+++ b/packages/components/src/components/dialog/dialog.component.ts
@@ -28,7 +28,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
- * @documentation https://synergy.style/components/dialog
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dialog--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/dialog/dialog.test.ts
+++ b/packages/components/src/components/dialog/dialog.test.ts
@@ -156,7 +156,7 @@ describe('<syn-dialog>', () => {
     expect(el.open).to.be.false;
   });
 
-  // https://github.com/synergy-design-system/synergy/issues/1382
+  // https://github.com/shoelace-style/shoelace/issues/1382
   it('should properly cycle through tabbable elements when syn-dialog is used in a shadowRoot', async () => {
     class AContainer extends LitElement {
       get dialog() {

--- a/packages/components/src/components/divider/divider.component.ts
+++ b/packages/components/src/components/divider/divider.component.ts
@@ -16,7 +16,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Dividers are used to visually separate or group elements.
- * @documentation https://synergy.style/components/divider
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-divider--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/drawer/drawer.component.ts
+++ b/packages/components/src/components/drawer/drawer.component.ts
@@ -206,7 +206,7 @@ export default class SynDrawer extends SynergyElement {
       // drawer's animation to jitter, so we'll temporarily remove the attribute, call `focus({ preventScroll: true })`
       // ourselves, and add the attribute back afterwards.
       //
-      // Related: https://github.com/synergy-design-system/synergy/issues/693
+      // Related: https://github.com/shoelace-style/shoelace/issues/693
       //
       const autoFocusTarget = this.querySelector('[autofocus]');
       if (autoFocusTarget) {

--- a/packages/components/src/components/drawer/drawer.component.ts
+++ b/packages/components/src/components/drawer/drawer.component.ts
@@ -29,7 +29,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Drawers slide in from a container to expose additional options and information.
- * @documentation https://synergy.style/components/drawer
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-drawer--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/dropdown/dropdown.component.ts
+++ b/packages/components/src/components/dropdown/dropdown.component.ts
@@ -30,7 +30,7 @@ import type SynMenu from '../menu/menu.js';
 
 /**
  * @summary Dropdowns expose additional content that "drops down" in a panel.
- * @documentation https://synergy.style/components/dropdown
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dropdown--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/file/file.component.ts
+++ b/packages/components/src/components/file/file.component.ts
@@ -22,6 +22,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary File controls allow selecting an arbitrary number of files for uploading.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-file--docs
  * @status stable
  *
  * @dependency syn-button

--- a/packages/components/src/components/icon-button/icon-button.component.ts
+++ b/packages/components/src/components/icon-button/icon-button.component.ts
@@ -20,7 +20,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Icons buttons are simple, icon-only buttons that can be used for actions and in toolbars.
- * @documentation https://synergy.style/components/icon-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/icon/icon.component.ts
+++ b/packages/components/src/components/icon/icon.component.ts
@@ -31,7 +31,7 @@ interface IconSource {
 
 /**
  * @summary Icons are symbols that can be used to represent various options within an application.
- * @documentation https://synergy.style/components/icon
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/icon/icon.test.ts
+++ b/packages/components/src/components/icon/icon.test.ts
@@ -193,7 +193,7 @@ describe('<syn-icon>', () => {
       expect(rect?.width).to.be.greaterThan(0);
     });
 
-    // https://github.com/synergy-design-system/synergy/issues/2161
+    // https://github.com/shoelace-style/shoelace/issues/2161
     it('Should apply mutator to multiple identical spritesheet icons', async () => {
       registerIconLibrary('sprite', {
         resolver: name => `/public/sprite.svg#${name}`,
@@ -242,7 +242,7 @@ describe('<syn-icon>', () => {
       expect(rect?.width).to.equal(0);
 
       // Make sure the mutator is applied.
-      // https://github.com/synergy-design-system/synergy/issues/1925
+      // https://github.com/shoelace-style/shoelace/issues/1925
       expect(svg?.getAttribute('fill')).to.equal('currentColor');
     });
 

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -354,7 +354,7 @@ export default class SynInput extends SynergyElement implements SynergyFormContr
         // When using an Input Method Editor (IME), pressing enter will cause the form to submit unexpectedly. One way
         // to check for this is to look at event.isComposing, which will be true when the IME is open.
         //
-        // See https://github.com/synergy-design-system/synergy/pull/988
+        // See https://github.com/shoelace-style/shoelace/pull/988
         //
         if (!event.defaultPrevented && !event.isComposing) {
           this.formControlController.submit();

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -31,7 +31,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Inputs collect data from the user.
- * @documentation https://synergy.style/components/input
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-input--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/menu-item/menu-item.component.ts
+++ b/packages/components/src/components/menu-item/menu-item.component.ts
@@ -25,7 +25,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Menu items provide options for the user to pick from in a menu.
- * @documentation https://synergy.style/components/menu-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/menu-label/menu-label.component.ts
+++ b/packages/components/src/components/menu-label/menu-label.component.ts
@@ -16,7 +16,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Menu labels are used to describe a group of menu items.
- * @documentation https://synergy.style/components/menu-label
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-label--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/menu/menu.component.ts
+++ b/packages/components/src/components/menu/menu.component.ts
@@ -24,7 +24,7 @@ export interface MenuSelectEventDetail {
 
 /**
  * @summary Menus provide a list of options for the user to choose from.
- * @documentation https://synergy.style/components/menu
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/menu/menu.test.ts
+++ b/packages/components/src/components/menu/menu.test.ts
@@ -110,7 +110,7 @@ describe('<syn-menu>', () => {
     expect(selectHandler).to.not.have.been.called;
   });
 
-  // @see https://github.com/synergy-design-system/synergy/issues/1596
+  // @see https://github.com/shoelace-style/shoelace/issues/1596
   it('Should fire "syn-select" when clicking an element within a menu-item', async () => {
     // eslint-disable-next-line
     const selectHandler = sinon.spy(() => {});
@@ -130,7 +130,7 @@ describe('<syn-menu>', () => {
     expect(selectHandler).to.have.been.calledOnce;
   });
 
-  // @see https://github.com/synergy-design-system/synergy/issues/2115
+  // @see https://github.com/shoelace-style/shoelace/issues/2115
   it('Should be able to check a checkbox menu item in a submenu', async () => {
     const menu: SynMenu = await fixture(html`
       <syn-menu style="max-width: 200px;">

--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -12,6 +12,7 @@ import styles from './nav-item.styles.js';
 
 /**
  * @summary Flexible button / link component that can be used to quickly build navigations.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-nav-item--docs
  * Takes one of 3 forms:
  * - button (default),
  * - link (overrides button if a 'href' is provided),

--- a/packages/components/src/components/option/option.component.ts
+++ b/packages/components/src/components/option/option.component.ts
@@ -21,7 +21,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Options define the selectable items within various form controls such as [select](/components/select).
- * @documentation https://synergy.style/components/option
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-option--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/popup/popup.component.ts
+++ b/packages/components/src/components/popup/popup.component.ts
@@ -33,7 +33,7 @@ function isVirtualElement(e: unknown): e is VirtualElement {
 
 /**
  * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
- * @documentation https://synergy.style/components/popup
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-popup--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/popup/popup.component.ts
+++ b/packages/components/src/components/popup/popup.component.ts
@@ -401,7 +401,7 @@ export default class SynPopup extends SynergyElement {
     //
     // Use custom positioning logic if the strategy is absolute. Otherwise, fall back to the default logic.
     //
-    // More info: https://github.com/synergy-design-system/synergy/issues/1135
+    // More info: https://github.com/shoelace-style/shoelace/issues/1135
     //
     const getOffsetParent =
       this.strategy === 'absolute'

--- a/packages/components/src/components/prio-nav/prio-nav.component.ts
+++ b/packages/components/src/components/prio-nav/prio-nav.component.ts
@@ -24,6 +24,7 @@ import {
  * together. It will automatically group all items not visible in the viewport into a custom
  * priority menu.
  *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-prio-nav--docs
  * @example
  * <syn-prio-nav>
  *  <syn-nav-item current horizontal>Item 1</syn-nav-item>

--- a/packages/components/src/components/progress-bar/progress-bar.component.ts
+++ b/packages/components/src/components/progress-bar/progress-bar.component.ts
@@ -20,7 +20,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Progress bars are used to show the status of an ongoing operation.
- * @documentation https://synergy.style/components/progress-bar
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-bar--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/progress-ring/progress-ring.component.ts
+++ b/packages/components/src/components/progress-ring/progress-ring.component.ts
@@ -17,7 +17,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
- * @documentation https://synergy.style/components/progress-ring
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-ring--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/radio-button/radio-button.component.ts
+++ b/packages/components/src/components/radio-button/radio-button.component.ts
@@ -20,7 +20,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Radios buttons allow the user to select a single option from a group using a button-like control.
- * @documentation https://synergy.style/components/radio-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/radio-group/radio-group.component.ts
+++ b/packages/components/src/components/radio-group/radio-group.component.ts
@@ -32,7 +32,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
- * @documentation https://synergy.style/components/radio-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/radio-group/radio-group.test.ts
+++ b/packages/components/src/components/radio-group/radio-group.test.ts
@@ -472,7 +472,7 @@ describe('when the value changes', () => {
 
   it('should relatively position content to prevent visually hidden scroll bugs', async () => {
     //
-    // See https://github.com/synergy-design-system/synergy/issues/1380
+    // See https://github.com/shoelace-style/shoelace/issues/1380
     //
     const radioGroup = await fixture<SynRadioGroup>(html`
       <syn-radio-group value="1">
@@ -488,7 +488,7 @@ describe('when the value changes', () => {
   });
 
   /**
-   * @see https://github.com/synergy-design-system/synergy/issues/1361
+   * @see https://github.com/shoelace-style/shoelace/issues/1361
    * This isn't really possible to test right now due to importing "synergy.js" which
    * auto-defines all of our components up front. This should be tested if we ever split
    * to non-auto-defining components and not auto-defining for tests.

--- a/packages/components/src/components/radio/radio.component.ts
+++ b/packages/components/src/components/radio/radio.component.ts
@@ -20,7 +20,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Radios allow the user to select a single option from a group.
- * @documentation https://synergy.style/components/radio
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/range-tick/range-tick.component.ts
+++ b/packages/components/src/components/range-tick/range-tick.component.ts
@@ -8,7 +8,7 @@ import styles from './range-tick.styles.js';
 
 /**
  * @summary Ticks visually improve positioning on range sliders.
- * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range-tick--docs
  * @status stable
  *
  * @slot - The tick's label

--- a/packages/components/src/components/resize-observer/resize-observer.component.ts
+++ b/packages/components/src/components/resize-observer/resize-observer.component.ts
@@ -16,7 +16,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary The Resize Observer component offers a thin, declarative interface to the [`ResizeObserver API`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
- * @documentation https://synergy.style/components/resize-observer
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-resize-observer--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -36,7 +36,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
- * @documentation https://synergy.style/components/select
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-select--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -258,7 +258,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     //
     // Listen on the root node instead of the document in case the elements are inside a shadow root
     //
-    // https://github.com/synergy-design-system/synergy/issues/1763
+    // https://github.com/shoelace-style/shoelace/issues/1763
     //
     document.addEventListener('focusin', this.handleDocumentFocusIn);
     document.addEventListener('keydown', this.handleDocumentKeyDown);

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -216,7 +216,7 @@ describe('<syn-select>', () => {
     });
 
     // this can happen in on ms-edge autofilling an associated input element in the same form
-    // https://github.com/synergy-design-system/synergy/issues/2117
+    // https://github.com/shoelace-style/shoelace/issues/2117
     it('should not throw on incomplete events', async () => {
       const el = await fixture<SynSelect>(html`
         <syn-select required>
@@ -737,7 +737,7 @@ describe('<syn-select>', () => {
     });
 
     /**
-     * @see {https://github.com/synergy-design-system/synergy/issues/2254}
+     * @see {https://github.com/shoelace-style/shoelace/issues/2254}
      */
     it('Should account for if `value` changed before connecting', async () => {
       const select = await fixture<SynSelect>(html`
@@ -754,7 +754,7 @@ describe('<syn-select>', () => {
     });
 
     /**
-     * @see {https://github.com/synergy-design-system/synergy/issues/2254}
+     * @see {https://github.com/shoelace-style/shoelace/issues/2254}
      */
     it('Should still work if using the value attribute', async () => {
       const select = await fixture<SynSelect>(html`

--- a/packages/components/src/components/spinner/spinner.component.ts
+++ b/packages/components/src/components/spinner/spinner.component.ts
@@ -16,7 +16,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Spinners are used to show the progress of an indeterminate operation.
- * @documentation https://synergy.style/components/spinner
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-spinner--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/spinner/spinner.test.ts
+++ b/packages/components/src/components/spinner/spinner.test.ts
@@ -31,7 +31,7 @@ describe('<syn-spinner>', () => {
       // This matrix is the computed value when using `transform: rotate(x)` on the indicator. When using `rotate: x`,
       // it will be "none" instead.
       //
-      // Related: https://github.com/synergy-design-system/synergy/issues/1121
+      // Related: https://github.com/shoelace-style/shoelace/issues/1121
       //
       expect(getComputedStyle(indicator).transform).to.equal('matrix(1, 0, 0, 1, 0, 0)');
     });

--- a/packages/components/src/components/switch/switch.component.ts
+++ b/packages/components/src/components/switch/switch.component.ts
@@ -27,7 +27,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Switches allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/switch
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-switch--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/switch/switch.test.ts
+++ b/packages/components/src/components/switch/switch.test.ts
@@ -126,7 +126,7 @@ describe('<syn-switch>', () => {
 
   it('should hide the native input with the correct positioning to scroll correctly when contained in an overflow', async () => {
     //
-    // See: https://github.com/synergy-design-system/synergy/issues/1169
+    // See: https://github.com/shoelace-style/shoelace/issues/1169
     //
     const el = await fixture<SynSwitch>(html` <syn-switch></syn-switch> `);
     const label = el.shadowRoot!.querySelector('.switch')!;
@@ -273,7 +273,7 @@ describe('<syn-switch>', () => {
   });
 
   it('should not jump the page to the bottom when focusing a switch at the bottom of an element with overflow: auto;', async () => {
-    // https://github.com/synergy-design-system/synergy/issues/1169
+    // https://github.com/shoelace-style/shoelace/issues/1169
     const el = await fixture<HTMLDivElement>(html`
       <div style="display: flex; flex-direction: column; overflow: auto; max-height: 400px;">
         <syn-switch>Switch</syn-switch>

--- a/packages/components/src/components/tab-group/tab-group.component.ts
+++ b/packages/components/src/components/tab-group/tab-group.component.ts
@@ -25,7 +25,7 @@ import type SynTabPanel from '../tab-panel/tab-panel.js';
 
 /**
  * @summary Tab groups organize content into a container that shows one section at a time.
- * @documentation https://synergy.style/components/tab-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/tab-group/tab-group.component.ts
+++ b/packages/components/src/components/tab-group/tab-group.component.ts
@@ -111,7 +111,7 @@ export default class SynTabGroup extends SynergyElement {
     this.mutationObserver = new MutationObserver(mutations => {
       // Make sure to only observe the direct children of the tab group
       // instead of other sub elements that might be slotted in.
-      // @see https://github.com/synergy-design-system/synergy/issues/2320
+      // @see https://github.com/shoelace-style/shoelace/issues/2320
       const instanceMutations = mutations.filter(({ target }) => {
         if (target === this) return true; // Allow self updates
         if ((target as HTMLElement).closest('syn-tab-group') !== this) return false; // We are not direct children
@@ -440,7 +440,7 @@ export default class SynTabGroup extends SynergyElement {
       // Safari appears to calculate this incorrectly when zoomed at 110%, causing the controls to toggle indefinitely.
       // Adding a single pixel to the comparison seems to resolve it.
       //
-      // See https://github.com/synergy-design-system/synergy/issues/1839
+      // See https://github.com/shoelace-style/shoelace/issues/1839
       this.hasScrollControls =
         ['top'].includes(this.placement) && this.nav.scrollWidth > this.nav.clientWidth + 1;
     }

--- a/packages/components/src/components/tab-panel/tab-panel.component.ts
+++ b/packages/components/src/components/tab-panel/tab-panel.component.ts
@@ -20,7 +20,7 @@ let id = 0;
 
 /**
  * @summary Tab panels are used inside [tab groups](/components/tab-group) to display tabbed content.
- * @documentation https://synergy.style/components/tab-panel
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-panel--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/tab/tab.component.ts
+++ b/packages/components/src/components/tab/tab.component.ts
@@ -22,7 +22,7 @@ let id = 0;
 
 /**
  * @summary Tabs are used inside [tab groups](/components/tab-group) to represent and activate [tab panels](/components/tab-panel).
- * @documentation https://synergy.style/components/tab
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/tag/tag.component.ts
+++ b/packages/components/src/components/tag/tag.component.ts
@@ -20,7 +20,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Tags are used as labels to organize things or to indicate a selection.
- * @documentation https://synergy.style/components/tag
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tag--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/textarea/textarea.component.ts
+++ b/packages/components/src/components/textarea/textarea.component.ts
@@ -382,7 +382,7 @@ export default class SynTextarea extends SynergyElement implements SynergyFormCo
               @focus=${this.handleFocus}
               @blur=${this.handleBlur}
             ></textarea>
-            <!-- This "adjuster" exists to prevent layout shifting. https://github.com/synergy-design-system/synergy/issues/2180 -->
+            <!-- This "adjuster" exists to prevent layout shifting. https://github.com/shoelace-style/shoelace/issues/2180 -->
             <div part="textarea-adjuster" class="textarea__size-adjuster" ?hidden=${this.resize !== 'auto'}></div>
           </div>
         </div>

--- a/packages/components/src/components/textarea/textarea.component.ts
+++ b/packages/components/src/components/textarea/textarea.component.ts
@@ -27,7 +27,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
 
 /**
  * @summary Textareas collect data from the user and allow multiple lines of text.
- * @documentation https://synergy.style/components/textarea
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-textarea--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/tooltip/tooltip.component.ts
+++ b/packages/components/src/components/tooltip/tooltip.component.ts
@@ -23,7 +23,7 @@ import type { CSSResultGroup } from 'lit';
 
 /**
  * @summary Tooltips display additional information based on a specific action.
- * @documentation https://synergy.style/components/tooltip
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tooltip--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/components/src/components/validate/validate.component.ts
+++ b/packages/components/src/components/validate/validate.component.ts
@@ -18,7 +18,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @summary Validate provides form field validation messages in a unified way.
  * It does this by using [the native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
  * and showing the validation message in a consistent, user defined way.
- *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-validate--docs
  * @dependency syn-alert
  *
  * @slot - The form field that should be validated.

--- a/packages/components/src/internal/form.ts
+++ b/packages/components/src/internal/form.ts
@@ -192,7 +192,7 @@ export class FormControlController implements ReactiveController {
     // Check to make sure there's no other form controls in the collection. If we do this
     // without checking if any other controls are still in the collection, then we will wipe out the
     // validity checks for all other elements.
-    // see: https://github.com/synergy-design-system/synergy/issues/1703
+    // see: https://github.com/shoelace-style/shoelace/issues/1703
     if (formCollection.size <= 0) {
       this.form.removeEventListener('formdata', this.handleFormData);
       this.form.removeEventListener('submit', this.handleFormSubmit);
@@ -415,7 +415,7 @@ export class FormControlController implements ReactiveController {
     // We're mapping the following "states" to data attributes. In the future, we can use ElementInternals.states to
     // create a similar mapping, but instead of [data-invalid] it will look like :--invalid.
     //
-    // See this RFC for more details: https://github.com/synergy-design-system/synergy/issues/1011
+    // See this RFC for more details: https://github.com/shoelace-style/shoelace/issues/1011
     //
     host.toggleAttribute('data-required', required);
     host.toggleAttribute('data-optional', !required);

--- a/packages/react/src/components/alert.ts
+++ b/packages/react/src/components/alert.ts
@@ -18,7 +18,7 @@ Component.define('syn-alert');
 
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
- * @documentation https://synergy.style/components/alert
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-alert--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/badge.ts
+++ b/packages/react/src/components/badge.ts
@@ -12,7 +12,7 @@ Component.define('syn-badge');
 
 /**
  * @summary Badges are used to draw attention and display statuses or counts.
- * @documentation https://synergy.style/components/badge
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-badge--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/breadcrumb-item.ts
+++ b/packages/react/src/components/breadcrumb-item.ts
@@ -12,7 +12,7 @@ Component.define('syn-breadcrumb-item');
 
 /**
  * @summary Breadcrumb Items are used inside [breadcrumbs](/components/breadcrumb) to represent different links.
- * @documentation https://synergy.style/components/breadcrumb-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/breadcrumb.ts
+++ b/packages/react/src/components/breadcrumb.ts
@@ -12,7 +12,7 @@ Component.define('syn-breadcrumb');
 
 /**
  * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
- * @documentation https://synergy.style/components/breadcrumb
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/button-group.ts
+++ b/packages/react/src/components/button-group.ts
@@ -12,7 +12,7 @@ Component.define('syn-button-group');
 
 /**
  * @summary Button groups can be used to group related buttons into sections.
- * @documentation https://synergy.style/components/button-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/button.ts
+++ b/packages/react/src/components/button.ts
@@ -17,7 +17,7 @@ Component.define('syn-button');
 
 /**
  * @summary Buttons represent actions that are available to the user.
- * @documentation https://synergy.style/components/button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/card.ts
+++ b/packages/react/src/components/card.ts
@@ -12,7 +12,7 @@ Component.define('syn-card');
 
 /**
  * @summary Cards can be used to group related subjects in a container.
- * @documentation https://synergy.style/components/card
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-card--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/checkbox.ts
+++ b/packages/react/src/components/checkbox.ts
@@ -19,7 +19,7 @@ Component.define('syn-checkbox');
 
 /**
  * @summary Checkboxes allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/checkbox
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-checkbox--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/details.ts
+++ b/packages/react/src/components/details.ts
@@ -18,7 +18,7 @@ Component.define('syn-details');
 
 /**
  * @summary Details show a brief summary and expand to show additional content.
- * @documentation https://synergy.style/components/details
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-details--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/dialog.ts
+++ b/packages/react/src/components/dialog.ts
@@ -20,7 +20,7 @@ Component.define('syn-dialog');
 
 /**
  * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
- * @documentation https://synergy.style/components/dialog
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dialog--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/divider.ts
+++ b/packages/react/src/components/divider.ts
@@ -12,7 +12,7 @@ Component.define('syn-divider');
 
 /**
  * @summary Dividers are used to visually separate or group elements.
- * @documentation https://synergy.style/components/divider
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-divider--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/drawer.ts
+++ b/packages/react/src/components/drawer.ts
@@ -20,7 +20,7 @@ Component.define('syn-drawer');
 
 /**
  * @summary Drawers slide in from a container to expose additional options and information.
- * @documentation https://synergy.style/components/drawer
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-drawer--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/dropdown.ts
+++ b/packages/react/src/components/dropdown.ts
@@ -18,7 +18,7 @@ Component.define('syn-dropdown');
 
 /**
  * @summary Dropdowns expose additional content that "drops down" in a panel.
- * @documentation https://synergy.style/components/dropdown
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dropdown--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/file.ts
+++ b/packages/react/src/components/file.ts
@@ -19,6 +19,7 @@ Component.define('syn-file');
 
 /**
  * @summary File controls allow selecting an arbitrary number of files for uploading.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-file--docs
  * @status stable
  *
  * @dependency syn-button

--- a/packages/react/src/components/icon-button.ts
+++ b/packages/react/src/components/icon-button.ts
@@ -16,7 +16,7 @@ Component.define('syn-icon-button');
 
 /**
  * @summary Icons buttons are simple, icon-only buttons that can be used for actions and in toolbars.
- * @documentation https://synergy.style/components/icon-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/icon.ts
+++ b/packages/react/src/components/icon.ts
@@ -16,7 +16,7 @@ Component.define('syn-icon');
 
 /**
  * @summary Icons are symbols that can be used to represent various options within an application.
- * @documentation https://synergy.style/components/icon
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/input.ts
+++ b/packages/react/src/components/input.ts
@@ -20,7 +20,7 @@ Component.define('syn-input');
 
 /**
  * @summary Inputs collect data from the user.
- * @documentation https://synergy.style/components/input
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-input--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/menu-item.ts
+++ b/packages/react/src/components/menu-item.ts
@@ -12,7 +12,7 @@ Component.define('syn-menu-item');
 
 /**
  * @summary Menu items provide options for the user to pick from in a menu.
- * @documentation https://synergy.style/components/menu-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/menu-label.ts
+++ b/packages/react/src/components/menu-label.ts
@@ -12,7 +12,7 @@ Component.define('syn-menu-label');
 
 /**
  * @summary Menu labels are used to describe a group of menu items.
- * @documentation https://synergy.style/components/menu-label
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-label--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/menu.ts
+++ b/packages/react/src/components/menu.ts
@@ -15,7 +15,7 @@ Component.define('syn-menu');
 
 /**
  * @summary Menus provide a list of options for the user to choose from.
- * @documentation https://synergy.style/components/menu
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/nav-item.ts
+++ b/packages/react/src/components/nav-item.ts
@@ -18,6 +18,7 @@ Component.define('syn-nav-item');
 
 /**
  * @summary Flexible button / link component that can be used to quickly build navigations.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-nav-item--docs
  * Takes one of 3 forms:
  * - button (default),
  * - link (overrides button if a 'href' is provided),

--- a/packages/react/src/components/option.ts
+++ b/packages/react/src/components/option.ts
@@ -12,7 +12,7 @@ Component.define('syn-option');
 
 /**
  * @summary Options define the selectable items within various form controls such as [select](/components/select).
- * @documentation https://synergy.style/components/option
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-option--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/popup.ts
+++ b/packages/react/src/components/popup.ts
@@ -15,7 +15,7 @@ Component.define('syn-popup');
 
 /**
  * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
- * @documentation https://synergy.style/components/popup
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-popup--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/prio-nav.ts
+++ b/packages/react/src/components/prio-nav.ts
@@ -16,6 +16,7 @@ Component.define('syn-prio-nav');
  * together. It will automatically group all items not visible in the viewport into a custom
  * priority menu.
  *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-prio-nav--docs
  * @example
  * <syn-prio-nav>
  *  <syn-nav-item current horizontal>Item 1</syn-nav-item>

--- a/packages/react/src/components/progress-bar.ts
+++ b/packages/react/src/components/progress-bar.ts
@@ -12,7 +12,7 @@ Component.define('syn-progress-bar');
 
 /**
  * @summary Progress bars are used to show the status of an ongoing operation.
- * @documentation https://synergy.style/components/progress-bar
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-bar--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/progress-ring.ts
+++ b/packages/react/src/components/progress-ring.ts
@@ -12,7 +12,7 @@ Component.define('syn-progress-ring');
 
 /**
  * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
- * @documentation https://synergy.style/components/progress-ring
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-ring--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/radio-button.ts
+++ b/packages/react/src/components/radio-button.ts
@@ -16,7 +16,7 @@ Component.define('syn-radio-button');
 
 /**
  * @summary Radios buttons allow the user to select a single option from a group using a button-like control.
- * @documentation https://synergy.style/components/radio-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/radio-group.ts
+++ b/packages/react/src/components/radio-group.ts
@@ -17,7 +17,7 @@ Component.define('syn-radio-group');
 
 /**
  * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
- * @documentation https://synergy.style/components/radio-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/radio.ts
+++ b/packages/react/src/components/radio.ts
@@ -16,7 +16,7 @@ Component.define('syn-radio');
 
 /**
  * @summary Radios allow the user to select a single option from a group.
- * @documentation https://synergy.style/components/radio
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/range-tick.ts
+++ b/packages/react/src/components/range-tick.ts
@@ -12,7 +12,7 @@ Component.define('syn-range-tick');
 
 /**
  * @summary Ticks visually improve positioning on range sliders.
- * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range-tick--docs
  * @status stable
  *
  * @slot - The tick's label

--- a/packages/react/src/components/select.ts
+++ b/packages/react/src/components/select.ts
@@ -24,7 +24,7 @@ Component.define('syn-select');
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
- * @documentation https://synergy.style/components/select
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-select--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/spinner.ts
+++ b/packages/react/src/components/spinner.ts
@@ -12,7 +12,7 @@ Component.define('syn-spinner');
 
 /**
  * @summary Spinners are used to show the progress of an indeterminate operation.
- * @documentation https://synergy.style/components/spinner
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-spinner--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/switch.ts
+++ b/packages/react/src/components/switch.ts
@@ -19,7 +19,7 @@ Component.define('syn-switch');
 
 /**
  * @summary Switches allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/switch
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-switch--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/tab-group.ts
+++ b/packages/react/src/components/tab-group.ts
@@ -16,7 +16,7 @@ Component.define('syn-tab-group');
 
 /**
  * @summary Tab groups organize content into a container that shows one section at a time.
- * @documentation https://synergy.style/components/tab-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/tab-panel.ts
+++ b/packages/react/src/components/tab-panel.ts
@@ -12,7 +12,7 @@ Component.define('syn-tab-panel');
 
 /**
  * @summary Tab panels are used inside [tab groups](/components/tab-group) to display tabbed content.
- * @documentation https://synergy.style/components/tab-panel
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-panel--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/tab.ts
+++ b/packages/react/src/components/tab.ts
@@ -15,7 +15,7 @@ Component.define('syn-tab');
 
 /**
  * @summary Tabs are used inside [tab groups](/components/tab-group) to represent and activate [tab panels](/components/tab-panel).
- * @documentation https://synergy.style/components/tab
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/tag.ts
+++ b/packages/react/src/components/tag.ts
@@ -15,7 +15,7 @@ Component.define('syn-tag');
 
 /**
  * @summary Tags are used as labels to organize things or to indicate a selection.
- * @documentation https://synergy.style/components/tag
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tag--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/textarea.ts
+++ b/packages/react/src/components/textarea.ts
@@ -19,7 +19,7 @@ Component.define('syn-textarea');
 
 /**
  * @summary Textareas collect data from the user and allow multiple lines of text.
- * @documentation https://synergy.style/components/textarea
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-textarea--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/tooltip.ts
+++ b/packages/react/src/components/tooltip.ts
@@ -18,7 +18,7 @@ Component.define('syn-tooltip');
 
 /**
  * @summary Tooltips display additional information based on a specific action.
- * @documentation https://synergy.style/components/tooltip
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tooltip--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/react/src/components/validate.ts
+++ b/packages/react/src/components/validate.ts
@@ -14,7 +14,7 @@ Component.define('syn-validate');
  * @summary Validate provides form field validation messages in a unified way.
  * It does this by using [the native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
  * and showing the validation message in a consistent, user defined way.
- *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-validate--docs
  * @dependency syn-alert
  *
  * @slot - The form field that should be validated.

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -120,7 +120,7 @@ export type SynCustomElement<
  */ export type SynAccordionJSXElement = SynCustomElement<SynAccordion, []>;
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
- * @documentation https://synergy.style/components/alert
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-alert--docs
  * @status stable
  * @since 2.0
  *
@@ -153,7 +153,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Badges are used to draw attention and display statuses or counts.
- * @documentation https://synergy.style/components/badge
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-badge--docs
  * @status stable
  * @since 2.0
  *
@@ -163,7 +163,7 @@ export type SynCustomElement<
  */ export type SynBadgeJSXElement = SynCustomElement<SynBadge, []>;
 /**
  * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
- * @documentation https://synergy.style/components/breadcrumb
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb--docs
  * @status stable
  * @since 2.0
  *
@@ -176,7 +176,7 @@ export type SynCustomElement<
  */ export type SynBreadcrumbJSXElement = SynCustomElement<SynBreadcrumb, []>;
 /**
  * @summary Breadcrumb Items are used inside [breadcrumbs](/components/breadcrumb) to represent different links.
- * @documentation https://synergy.style/components/breadcrumb-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb-item--docs
  * @status stable
  * @since 2.0
  *
@@ -197,7 +197,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Buttons represent actions that are available to the user.
- * @documentation https://synergy.style/components/button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button--docs
  * @status stable
  * @since 2.0
  *
@@ -228,7 +228,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Button groups can be used to group related buttons into sections.
- * @documentation https://synergy.style/components/button-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button-group--docs
  * @status stable
  * @since 2.0
  *
@@ -238,7 +238,7 @@ export type SynCustomElement<
  */ export type SynButtonGroupJSXElement = SynCustomElement<SynButtonGroup, []>;
 /**
  * @summary Cards can be used to group related subjects in a container.
- * @documentation https://synergy.style/components/card
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-card--docs
  * @status stable
  * @since 2.0
  *
@@ -260,7 +260,7 @@ export type SynCustomElement<
  */ export type SynCardJSXElement = SynCustomElement<SynCard, []>;
 /**
  * @summary Checkboxes allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/checkbox
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-checkbox--docs
  * @status stable
  * @since 2.0
  *
@@ -360,7 +360,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Details show a brief summary and expand to show additional content.
- * @documentation https://synergy.style/components/details
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-details--docs
  * @status stable
  * @since 2.0
  *
@@ -396,7 +396,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
- * @documentation https://synergy.style/components/dialog
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dialog--docs
  * @status stable
  * @since 2.0
  *
@@ -456,7 +456,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Dividers are used to visually separate or group elements.
- * @documentation https://synergy.style/components/divider
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-divider--docs
  * @status stable
  * @since 2.0
  *
@@ -466,7 +466,7 @@ export type SynCustomElement<
  */ export type SynDividerJSXElement = SynCustomElement<SynDivider, []>;
 /**
  * @summary Drawers slide in from a container to expose additional options and information.
- * @documentation https://synergy.style/components/drawer
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-drawer--docs
  * @status stable
  * @since 2.0
  *
@@ -533,7 +533,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Dropdowns expose additional content that "drops down" in a panel.
- * @documentation https://synergy.style/components/dropdown
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dropdown--docs
  * @status stable
  * @since 2.0
  *
@@ -565,6 +565,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary File controls allow selecting an arbitrary number of files for uploading.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-file--docs
  * @status stable
  *
  * @dependency syn-button
@@ -657,7 +658,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Icons are symbols that can be used to represent various options within an application.
- * @documentation https://synergy.style/components/icon
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon--docs
  * @status stable
  * @since 2.0
  *
@@ -672,7 +673,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Icons buttons are simple, icon-only buttons that can be used for actions and in toolbars.
- * @documentation https://synergy.style/components/icon-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon-button--docs
  * @status stable
  * @since 2.0
  *
@@ -688,7 +689,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Inputs collect data from the user.
- * @documentation https://synergy.style/components/input
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-input--docs
  * @status stable
  * @since 2.0
  *
@@ -744,7 +745,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Menus provide a list of options for the user to choose from.
- * @documentation https://synergy.style/components/menu
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu--docs
  * @status stable
  * @since 2.0
  *
@@ -757,7 +758,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Menu items provide options for the user to pick from in a menu.
- * @documentation https://synergy.style/components/menu-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-item--docs
  * @status stable
  * @since 2.0
  *
@@ -783,7 +784,7 @@ export type SynCustomElement<
  */ export type SynMenuItemJSXElement = SynCustomElement<SynMenuItem, []>;
 /**
  * @summary Menu labels are used to describe a group of menu items.
- * @documentation https://synergy.style/components/menu-label
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-label--docs
  * @status stable
  * @since 2.0
  *
@@ -799,6 +800,7 @@ export type SynCustomElement<
  */ export type SynMenuLabelJSXElement = SynCustomElement<SynMenuLabel, []>;
 /**
  * @summary Flexible button / link component that can be used to quickly build navigations.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-nav-item--docs
  * Takes one of 3 forms:
  * - button (default),
  * - link (overrides button if a 'href' is provided),
@@ -874,7 +876,7 @@ export type SynCustomElement<
  */ export type SynOptgroupJSXElement = SynCustomElement<SynOptgroup, []>;
 /**
  * @summary Options define the selectable items within various form controls such as [select](/components/select).
- * @documentation https://synergy.style/components/option
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-option--docs
  * @status stable
  * @since 2.0
  *
@@ -892,7 +894,7 @@ export type SynCustomElement<
  */ export type SynOptionJSXElement = SynCustomElement<SynOption, []>;
 /**
  * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
- * @documentation https://synergy.style/components/popup
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-popup--docs
  * @status stable
  * @since 2.0
  *
@@ -928,6 +930,7 @@ export type SynCustomElement<
  * together. It will automatically group all items not visible in the viewport into a custom
  * priority menu.
  *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-prio-nav--docs
  * @example
  * <syn-prio-nav>
  *  <syn-nav-item current horizontal>Item 1</syn-nav-item>
@@ -958,7 +961,7 @@ export type SynCustomElement<
  */ export type SynPrioNavJSXElement = SynCustomElement<SynPrioNav, []>;
 /**
  * @summary Progress bars are used to show the status of an ongoing operation.
- * @documentation https://synergy.style/components/progress-bar
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-bar--docs
  * @status stable
  * @since 2.0
  *
@@ -976,7 +979,7 @@ export type SynCustomElement<
  */ export type SynProgressBarJSXElement = SynCustomElement<SynProgressBar, []>;
 /**
  * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
- * @documentation https://synergy.style/components/progress-ring
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-ring--docs
  * @status stable
  * @since 2.0
  *
@@ -997,7 +1000,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Radios allow the user to select a single option from a group.
- * @documentation https://synergy.style/components/radio
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio--docs
  * @status stable
  * @since 2.0
  *
@@ -1019,7 +1022,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Radios buttons allow the user to select a single option from a group using a button-like control.
- * @documentation https://synergy.style/components/radio-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-button--docs
  * @status stable
  * @since 2.0
  *
@@ -1042,7 +1045,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
- * @documentation https://synergy.style/components/radio-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-group--docs
  * @status stable
  * @since 2.0
  *
@@ -1134,7 +1137,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Ticks visually improve positioning on range sliders.
- * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range-tick--docs
  * @status stable
  *
  * @slot - The tick's label
@@ -1148,7 +1151,7 @@ export type SynCustomElement<
  */ export type SynRangeTickJSXElement = SynCustomElement<SynRangeTick, []>;
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
- * @documentation https://synergy.style/components/select
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-select--docs
  * @status stable
  * @since 2.0
  *
@@ -1265,7 +1268,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Spinners are used to show the progress of an indeterminate operation.
- * @documentation https://synergy.style/components/spinner
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-spinner--docs
  * @status stable
  * @since 2.0
  *
@@ -1277,7 +1280,7 @@ export type SynCustomElement<
  */ export type SynSpinnerJSXElement = SynCustomElement<SynSpinner, []>;
 /**
  * @summary Switches allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/switch
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-switch--docs
  * @status stable
  * @since 2.0
  *
@@ -1311,7 +1314,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Tabs are used inside [tab groups](/components/tab-group) to represent and activate [tab panels](/components/tab-panel).
- * @documentation https://synergy.style/components/tab
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab--docs
  * @status stable
  * @since 2.0
  *
@@ -1330,7 +1333,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Tab groups organize content into a container that shows one section at a time.
- * @documentation https://synergy.style/components/tab-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-group--docs
  * @status stable
  * @since 2.0
  *
@@ -1362,7 +1365,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Tab panels are used inside [tab groups](/components/tab-group) to display tabbed content.
- * @documentation https://synergy.style/components/tab-panel
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-panel--docs
  * @status stable
  * @since 2.0
  *
@@ -1374,7 +1377,7 @@ export type SynCustomElement<
  */ export type SynTabPanelJSXElement = SynCustomElement<SynTabPanel, []>;
 /**
  * @summary Tags are used as labels to organize things or to indicate a selection.
- * @documentation https://synergy.style/components/tag
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tag--docs
  * @status stable
  * @since 2.0
  *
@@ -1394,7 +1397,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Textareas collect data from the user and allow multiple lines of text.
- * @documentation https://synergy.style/components/textarea
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-textarea--docs
  * @status stable
  * @since 2.0
  *
@@ -1425,7 +1428,7 @@ export type SynCustomElement<
 >;
 /**
  * @summary Tooltips display additional information based on a specific action.
- * @documentation https://synergy.style/components/tooltip
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tooltip--docs
  * @status stable
  * @since 2.0
  *
@@ -1463,7 +1466,7 @@ export type SynCustomElement<
  * @summary Validate provides form field validation messages in a unified way.
  * It does this by using [the native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
  * and showing the validation message in a consistent, user defined way.
- *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-validate--docs
  * @dependency syn-alert
  *
  * @slot - The form field that should be validated.
@@ -1500,7 +1503,7 @@ declare module 'react' {
        */ 'syn-accordion': SynAccordionJSXElement;
       /**
        * @summary Alerts are used to display important messages inline or as toast notifications.
-       * @documentation https://synergy.style/components/alert
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-alert--docs
        * @status stable
        * @since 2.0
        *
@@ -1525,7 +1528,7 @@ declare module 'react' {
        */ 'syn-alert': SynAlertJSXElement;
       /**
        * @summary Badges are used to draw attention and display statuses or counts.
-       * @documentation https://synergy.style/components/badge
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-badge--docs
        * @status stable
        * @since 2.0
        *
@@ -1535,7 +1538,7 @@ declare module 'react' {
        */ 'syn-badge': SynBadgeJSXElement;
       /**
        * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
-       * @documentation https://synergy.style/components/breadcrumb
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb--docs
        * @status stable
        * @since 2.0
        *
@@ -1548,7 +1551,7 @@ declare module 'react' {
        */ 'syn-breadcrumb': SynBreadcrumbJSXElement;
       /**
        * @summary Breadcrumb Items are used inside [breadcrumbs](/components/breadcrumb) to represent different links.
-       * @documentation https://synergy.style/components/breadcrumb-item
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb-item--docs
        * @status stable
        * @since 2.0
        *
@@ -1566,7 +1569,7 @@ declare module 'react' {
        */ 'syn-breadcrumb-item': SynBreadcrumbItemJSXElement;
       /**
        * @summary Buttons represent actions that are available to the user.
-       * @documentation https://synergy.style/components/button
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button--docs
        * @status stable
        * @since 2.0
        *
@@ -1590,7 +1593,7 @@ declare module 'react' {
        */ 'syn-button': SynButtonJSXElement;
       /**
        * @summary Button groups can be used to group related buttons into sections.
-       * @documentation https://synergy.style/components/button-group
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button-group--docs
        * @status stable
        * @since 2.0
        *
@@ -1600,7 +1603,7 @@ declare module 'react' {
        */ 'syn-button-group': SynButtonGroupJSXElement;
       /**
        * @summary Cards can be used to group related subjects in a container.
-       * @documentation https://synergy.style/components/card
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-card--docs
        * @status stable
        * @since 2.0
        *
@@ -1622,7 +1625,7 @@ declare module 'react' {
        */ 'syn-card': SynCardJSXElement;
       /**
        * @summary Checkboxes allow the user to toggle an option on or off.
-       * @documentation https://synergy.style/components/checkbox
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-checkbox--docs
        * @status stable
        * @since 2.0
        *
@@ -1698,7 +1701,7 @@ declare module 'react' {
        */ 'syn-combobox': SynComboboxJSXElement;
       /**
        * @summary Details show a brief summary and expand to show additional content.
-       * @documentation https://synergy.style/components/details
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-details--docs
        * @status stable
        * @since 2.0
        *
@@ -1726,7 +1729,7 @@ declare module 'react' {
        */ 'syn-details': SynDetailsJSXElement;
       /**
        * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
-       * @documentation https://synergy.style/components/dialog
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dialog--docs
        * @status stable
        * @since 2.0
        *
@@ -1776,7 +1779,7 @@ declare module 'react' {
        */ 'syn-dialog': SynDialogJSXElement;
       /**
        * @summary Dividers are used to visually separate or group elements.
-       * @documentation https://synergy.style/components/divider
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-divider--docs
        * @status stable
        * @since 2.0
        *
@@ -1786,7 +1789,7 @@ declare module 'react' {
        */ 'syn-divider': SynDividerJSXElement;
       /**
        * @summary Drawers slide in from a container to expose additional options and information.
-       * @documentation https://synergy.style/components/drawer
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-drawer--docs
        * @status stable
        * @since 2.0
        *
@@ -1843,7 +1846,7 @@ declare module 'react' {
        */ 'syn-drawer': SynDrawerJSXElement;
       /**
        * @summary Dropdowns expose additional content that "drops down" in a panel.
-       * @documentation https://synergy.style/components/dropdown
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dropdown--docs
        * @status stable
        * @since 2.0
        *
@@ -1867,6 +1870,7 @@ declare module 'react' {
        */ 'syn-dropdown': SynDropdownJSXElement;
       /**
        * @summary File controls allow selecting an arbitrary number of files for uploading.
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-file--docs
        * @status stable
        *
        * @dependency syn-button
@@ -1943,7 +1947,7 @@ declare module 'react' {
        */ 'syn-header': SynHeaderJSXElement;
       /**
        * @summary Icons are symbols that can be used to represent various options within an application.
-       * @documentation https://synergy.style/components/icon
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon--docs
        * @status stable
        * @since 2.0
        *
@@ -1955,7 +1959,7 @@ declare module 'react' {
        */ 'syn-icon': SynIconJSXElement;
       /**
        * @summary Icons buttons are simple, icon-only buttons that can be used for actions and in toolbars.
-       * @documentation https://synergy.style/components/icon-button
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon-button--docs
        * @status stable
        * @since 2.0
        *
@@ -1968,7 +1972,7 @@ declare module 'react' {
        */ 'syn-icon-button': SynIconButtonJSXElement;
       /**
        * @summary Inputs collect data from the user.
-       * @documentation https://synergy.style/components/input
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-input--docs
        * @status stable
        * @since 2.0
        *
@@ -2014,7 +2018,7 @@ declare module 'react' {
        */ 'syn-input': SynInputJSXElement;
       /**
        * @summary Menus provide a list of options for the user to choose from.
-       * @documentation https://synergy.style/components/menu
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu--docs
        * @status stable
        * @since 2.0
        *
@@ -2024,7 +2028,7 @@ declare module 'react' {
        */ 'syn-menu': SynMenuJSXElement;
       /**
        * @summary Menu items provide options for the user to pick from in a menu.
-       * @documentation https://synergy.style/components/menu-item
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-item--docs
        * @status stable
        * @since 2.0
        *
@@ -2050,7 +2054,7 @@ declare module 'react' {
        */ 'syn-menu-item': SynMenuItemJSXElement;
       /**
        * @summary Menu labels are used to describe a group of menu items.
-       * @documentation https://synergy.style/components/menu-label
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-label--docs
        * @status stable
        * @since 2.0
        *
@@ -2066,6 +2070,7 @@ declare module 'react' {
        */ 'syn-menu-label': SynMenuLabelJSXElement;
       /**
        * @summary Flexible button / link component that can be used to quickly build navigations.
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-nav-item--docs
        * Takes one of 3 forms:
        * - button (default),
        * - link (overrides button if a 'href' is provided),
@@ -2133,7 +2138,7 @@ declare module 'react' {
        */ 'syn-optgroup': SynOptgroupJSXElement;
       /**
        * @summary Options define the selectable items within various form controls such as [select](/components/select).
-       * @documentation https://synergy.style/components/option
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-option--docs
        * @status stable
        * @since 2.0
        *
@@ -2151,7 +2156,7 @@ declare module 'react' {
        */ 'syn-option': SynOptionJSXElement;
       /**
        * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
-       * @documentation https://synergy.style/components/popup
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-popup--docs
        * @status stable
        * @since 2.0
        *
@@ -2184,6 +2189,7 @@ declare module 'react' {
        * together. It will automatically group all items not visible in the viewport into a custom
        * priority menu.
        *
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-prio-nav--docs
        * @example
        * <syn-prio-nav>
        *  <syn-nav-item current horizontal>Item 1</syn-nav-item>
@@ -2214,7 +2220,7 @@ declare module 'react' {
        */ 'syn-prio-nav': SynPrioNavJSXElement;
       /**
        * @summary Progress bars are used to show the status of an ongoing operation.
-       * @documentation https://synergy.style/components/progress-bar
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-bar--docs
        * @status stable
        * @since 2.0
        *
@@ -2232,7 +2238,7 @@ declare module 'react' {
        */ 'syn-progress-bar': SynProgressBarJSXElement;
       /**
        * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
-       * @documentation https://synergy.style/components/progress-ring
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-ring--docs
        * @status stable
        * @since 2.0
        *
@@ -2250,7 +2256,7 @@ declare module 'react' {
        */ 'syn-progress-ring': SynProgressRingJSXElement;
       /**
        * @summary Radios allow the user to select a single option from a group.
-       * @documentation https://synergy.style/components/radio
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio--docs
        * @status stable
        * @since 2.0
        *
@@ -2269,7 +2275,7 @@ declare module 'react' {
        */ 'syn-radio': SynRadioJSXElement;
       /**
        * @summary Radios buttons allow the user to select a single option from a group using a button-like control.
-       * @documentation https://synergy.style/components/radio-button
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-button--docs
        * @status stable
        * @since 2.0
        *
@@ -2289,7 +2295,7 @@ declare module 'react' {
        */ 'syn-radio-button': SynRadioButtonJSXElement;
       /**
        * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
-       * @documentation https://synergy.style/components/radio-group
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-group--docs
        * @status stable
        * @since 2.0
        *
@@ -2364,7 +2370,7 @@ declare module 'react' {
        */ 'syn-range': SynRangeJSXElement;
       /**
        * @summary Ticks visually improve positioning on range sliders.
-       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range-tick--docs
        * @status stable
        *
        * @slot - The tick's label
@@ -2378,7 +2384,7 @@ declare module 'react' {
        */ 'syn-range-tick': SynRangeTickJSXElement;
       /**
        * @summary Selects allow you to choose items from a menu of predefined options.
-       * @documentation https://synergy.style/components/select
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-select--docs
        * @status stable
        * @since 2.0
        *
@@ -2473,7 +2479,7 @@ declare module 'react' {
  */ 'syn-side-nav': SynSideNavJSXElement;
       /**
        * @summary Spinners are used to show the progress of an indeterminate operation.
-       * @documentation https://synergy.style/components/spinner
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-spinner--docs
        * @status stable
        * @since 2.0
        *
@@ -2485,7 +2491,7 @@ declare module 'react' {
        */ 'syn-spinner': SynSpinnerJSXElement;
       /**
        * @summary Switches allow the user to toggle an option on or off.
-       * @documentation https://synergy.style/components/switch
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-switch--docs
        * @status stable
        * @since 2.0
        *
@@ -2510,7 +2516,7 @@ declare module 'react' {
        */ 'syn-switch': SynSwitchJSXElement;
       /**
        * @summary Tabs are used inside [tab groups](/components/tab-group) to represent and activate [tab panels](/components/tab-panel).
-       * @documentation https://synergy.style/components/tab
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab--docs
        * @status stable
        * @since 2.0
        *
@@ -2526,7 +2532,7 @@ declare module 'react' {
        */ 'syn-tab': SynTabJSXElement;
       /**
        * @summary Tab groups organize content into a container that shows one section at a time.
-       * @documentation https://synergy.style/components/tab-group
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-group--docs
        * @status stable
        * @since 2.0
        *
@@ -2555,7 +2561,7 @@ declare module 'react' {
        */ 'syn-tab-group': SynTabGroupJSXElement;
       /**
        * @summary Tab panels are used inside [tab groups](/components/tab-group) to display tabbed content.
-       * @documentation https://synergy.style/components/tab-panel
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-panel--docs
        * @status stable
        * @since 2.0
        *
@@ -2567,7 +2573,7 @@ declare module 'react' {
        */ 'syn-tab-panel': SynTabPanelJSXElement;
       /**
        * @summary Tags are used as labels to organize things or to indicate a selection.
-       * @documentation https://synergy.style/components/tag
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tag--docs
        * @status stable
        * @since 2.0
        *
@@ -2584,7 +2590,7 @@ declare module 'react' {
        */ 'syn-tag': SynTagJSXElement;
       /**
        * @summary Textareas collect data from the user and allow multiple lines of text.
-       * @documentation https://synergy.style/components/textarea
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-textarea--docs
        * @status stable
        * @since 2.0
        *
@@ -2606,7 +2612,7 @@ declare module 'react' {
        */ 'syn-textarea': SynTextareaJSXElement;
       /**
        * @summary Tooltips display additional information based on a specific action.
-       * @documentation https://synergy.style/components/tooltip
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tooltip--docs
        * @status stable
        * @since 2.0
        *
@@ -2636,7 +2642,7 @@ declare module 'react' {
        * @summary Validate provides form field validation messages in a unified way.
        * It does this by using [the native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
        * and showing the validation message in a consistent, user defined way.
-       *
+       * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-validate--docs
        * @dependency syn-alert
        *
        * @slot - The form field that should be validated.

--- a/packages/vue/src/components/SynVueAlert.vue
+++ b/packages/vue/src/components/SynVueAlert.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Alerts are used to display important messages inline or as toast notifications.
- * @documentation https://synergy.style/components/alert
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-alert--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueBadge.vue
+++ b/packages/vue/src/components/SynVueBadge.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Badges are used to draw attention and display statuses or counts.
- * @documentation https://synergy.style/components/badge
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-badge--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueBreadcrumb.vue
+++ b/packages/vue/src/components/SynVueBreadcrumb.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
- * @documentation https://synergy.style/components/breadcrumb
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueBreadcrumbItem.vue
+++ b/packages/vue/src/components/SynVueBreadcrumbItem.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Breadcrumb Items are used inside [breadcrumbs](/components/breadcrumb) to represent different links.
- * @documentation https://synergy.style/components/breadcrumb-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-breadcrumb-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueButton.vue
+++ b/packages/vue/src/components/SynVueButton.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Buttons represent actions that are available to the user.
- * @documentation https://synergy.style/components/button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueButtonGroup.vue
+++ b/packages/vue/src/components/SynVueButtonGroup.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Button groups can be used to group related buttons into sections.
- * @documentation https://synergy.style/components/button-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-button-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueCard.vue
+++ b/packages/vue/src/components/SynVueCard.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Cards can be used to group related subjects in a container.
- * @documentation https://synergy.style/components/card
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-card--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueCheckbox.vue
+++ b/packages/vue/src/components/SynVueCheckbox.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Checkboxes allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/checkbox
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-checkbox--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueDetails.vue
+++ b/packages/vue/src/components/SynVueDetails.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Details show a brief summary and expand to show additional content.
- * @documentation https://synergy.style/components/details
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-details--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueDialog.vue
+++ b/packages/vue/src/components/SynVueDialog.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
- * @documentation https://synergy.style/components/dialog
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dialog--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueDivider.vue
+++ b/packages/vue/src/components/SynVueDivider.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Dividers are used to visually separate or group elements.
- * @documentation https://synergy.style/components/divider
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-divider--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueDrawer.vue
+++ b/packages/vue/src/components/SynVueDrawer.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Drawers slide in from a container to expose additional options and information.
- * @documentation https://synergy.style/components/drawer
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-drawer--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueDropdown.vue
+++ b/packages/vue/src/components/SynVueDropdown.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Dropdowns expose additional content that "drops down" in a panel.
- * @documentation https://synergy.style/components/dropdown
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-dropdown--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueFile.vue
+++ b/packages/vue/src/components/SynVueFile.vue
@@ -7,6 +7,7 @@
 
 /**
  * @summary File controls allow selecting an arbitrary number of files for uploading.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-file--docs
  * @status stable
  *
  * @dependency syn-button

--- a/packages/vue/src/components/SynVueIcon.vue
+++ b/packages/vue/src/components/SynVueIcon.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Icons are symbols that can be used to represent various options within an application.
- * @documentation https://synergy.style/components/icon
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueIconButton.vue
+++ b/packages/vue/src/components/SynVueIconButton.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Icons buttons are simple, icon-only buttons that can be used for actions and in toolbars.
- * @documentation https://synergy.style/components/icon-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-icon-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueInput.vue
+++ b/packages/vue/src/components/SynVueInput.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Inputs collect data from the user.
- * @documentation https://synergy.style/components/input
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-input--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueMenu.vue
+++ b/packages/vue/src/components/SynVueMenu.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Menus provide a list of options for the user to choose from.
- * @documentation https://synergy.style/components/menu
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueMenuItem.vue
+++ b/packages/vue/src/components/SynVueMenuItem.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Menu items provide options for the user to pick from in a menu.
- * @documentation https://synergy.style/components/menu-item
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-item--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueMenuLabel.vue
+++ b/packages/vue/src/components/SynVueMenuLabel.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Menu labels are used to describe a group of menu items.
- * @documentation https://synergy.style/components/menu-label
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-menu-label--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueNavItem.vue
+++ b/packages/vue/src/components/SynVueNavItem.vue
@@ -7,6 +7,7 @@
 
 /**
  * @summary Flexible button / link component that can be used to quickly build navigations.
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-nav-item--docs
  * Takes one of 3 forms:
  * - button (default),
  * - link (overrides button if a 'href' is provided),

--- a/packages/vue/src/components/SynVueOption.vue
+++ b/packages/vue/src/components/SynVueOption.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Options define the selectable items within various form controls such as [select](/components/select).
- * @documentation https://synergy.style/components/option
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-option--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVuePopup.vue
+++ b/packages/vue/src/components/SynVuePopup.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
- * @documentation https://synergy.style/components/popup
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-popup--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVuePrioNav.vue
+++ b/packages/vue/src/components/SynVuePrioNav.vue
@@ -11,6 +11,7 @@
  * together. It will automatically group all items not visible in the viewport into a custom
  * priority menu.
  *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-prio-nav--docs
  * @example
  * <syn-prio-nav>
  *  <syn-nav-item current horizontal>Item 1</syn-nav-item>

--- a/packages/vue/src/components/SynVueProgressBar.vue
+++ b/packages/vue/src/components/SynVueProgressBar.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Progress bars are used to show the status of an ongoing operation.
- * @documentation https://synergy.style/components/progress-bar
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-bar--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueProgressRing.vue
+++ b/packages/vue/src/components/SynVueProgressRing.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
- * @documentation https://synergy.style/components/progress-ring
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-progress-ring--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueRadio.vue
+++ b/packages/vue/src/components/SynVueRadio.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Radios allow the user to select a single option from a group.
- * @documentation https://synergy.style/components/radio
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueRadioButton.vue
+++ b/packages/vue/src/components/SynVueRadioButton.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Radios buttons allow the user to select a single option from a group using a button-like control.
- * @documentation https://synergy.style/components/radio-button
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-button--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueRadioGroup.vue
+++ b/packages/vue/src/components/SynVueRadioGroup.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Radio groups are used to group multiple [radios](/components/radio) or [radio buttons](/components/radio-button) so they function as a single form control.
- * @documentation https://synergy.style/components/radio-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-radio-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueRangeTick.vue
+++ b/packages/vue/src/components/SynVueRangeTick.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Ticks visually improve positioning on range sliders.
- * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-range-tick--docs
  * @status stable
  *
  * @slot - The tick's label

--- a/packages/vue/src/components/SynVueSelect.vue
+++ b/packages/vue/src/components/SynVueSelect.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
- * @documentation https://synergy.style/components/select
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-select--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueSpinner.vue
+++ b/packages/vue/src/components/SynVueSpinner.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Spinners are used to show the progress of an indeterminate operation.
- * @documentation https://synergy.style/components/spinner
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-spinner--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueSwitch.vue
+++ b/packages/vue/src/components/SynVueSwitch.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Switches allow the user to toggle an option on or off.
- * @documentation https://synergy.style/components/switch
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-switch--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueTab.vue
+++ b/packages/vue/src/components/SynVueTab.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Tabs are used inside [tab groups](/components/tab-group) to represent and activate [tab panels](/components/tab-panel).
- * @documentation https://synergy.style/components/tab
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueTabGroup.vue
+++ b/packages/vue/src/components/SynVueTabGroup.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Tab groups organize content into a container that shows one section at a time.
- * @documentation https://synergy.style/components/tab-group
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-group--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueTabPanel.vue
+++ b/packages/vue/src/components/SynVueTabPanel.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Tab panels are used inside [tab groups](/components/tab-group) to display tabbed content.
- * @documentation https://synergy.style/components/tab-panel
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tab-panel--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueTag.vue
+++ b/packages/vue/src/components/SynVueTag.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Tags are used as labels to organize things or to indicate a selection.
- * @documentation https://synergy.style/components/tag
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tag--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueTextarea.vue
+++ b/packages/vue/src/components/SynVueTextarea.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Textareas collect data from the user and allow multiple lines of text.
- * @documentation https://synergy.style/components/textarea
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-textarea--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueTooltip.vue
+++ b/packages/vue/src/components/SynVueTooltip.vue
@@ -7,7 +7,7 @@
 
 /**
  * @summary Tooltips display additional information based on a specific action.
- * @documentation https://synergy.style/components/tooltip
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-tooltip--docs
  * @status stable
  * @since 2.0
  *

--- a/packages/vue/src/components/SynVueValidate.vue
+++ b/packages/vue/src/components/SynVueValidate.vue
@@ -9,7 +9,7 @@
  * @summary Validate provides form field validation messages in a unified way.
  * It does this by using [the native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
  * and showing the validation message in a consistent, user defined way.
- *
+ * @documentation https://synergy-design-system.github.io/?path=/docs/components-syn-validate--docs
  * @dependency syn-alert
  *
  * @slot - The form field that should be validated.


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes some issues with comments in our vendoring process:

- Ticket URLs are no longer changed from Shoelace to Synergy. This helps when trying to read documentation about issues that shoelace has linked to.
- The `@documentation` tags are now dynamically created and match our Storybook URLs. This means you are able to click on autocomplete suggestions for a given tag and land on Storybook instead of a Error 404 page as described in #857.

### 🎫 Issues

Closes #471
Closes #857

<!--
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

I have checked all of the urls that where changed manually. There are multiple ones that do NOT work for the `documentation`:

- syn-button-group
- syn-popup
- syn-radio-button
- syn-resize-observer

Each of those stories does not exist as we don´t have any stories. I am not sure how to treat this problem. I could also remove those, but we should built them later on anyways (e.g. for syn-button-group and syn-radio-group, tickets already exist). If wanted, I could blacklist them.

I also made sure to add the Documentation key to the `vscode-settings` so the correct URLs are used there too.

## 📑 Test Plan

Just have a look at the changes. See if you can open the documentation URL and it points on the right file.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
