### PR TITLE
feat: ✨ syn-combobox, syn-select: Allow listbox of syn-select to exceed the input width

### DIFF
--- a/packages/angular/components/combobox/combobox.component.ts
+++ b/packages/angular/components/combobox/combobox.component.ts
@@ -72,6 +72,8 @@ import '@synergy-design-system/components/components/combobox/combobox.js';
  * @csspart filtered-listbox - The container that wraps the filtered options.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part.
+ * Use this to target the tooltip's popup container.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.

--- a/packages/angular/components/select/select.component.ts
+++ b/packages/angular/components/select/select.component.ts
@@ -71,6 +71,7 @@ import '@synergy-design-system/components/components/select/select.js';
  * @csspart tag__remove-button__base - The tag's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  */
 @Component({
   selector: 'syn-select',

--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -180,6 +180,23 @@ const transformComponent = (path, originalContent) => {
     },
   );
 
+  // #781: Export the popup so users can choose their own listbox size
+  content = addSectionsAfter([
+    [
+      '@csspart expand-icon - The container that wraps the expand icon.',
+      " * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.",
+    ],
+    [
+      'auto-size-padding="10"',
+      '            exportparts="popup"',
+    ],
+  ], content);
+
+  content = replaceSection([
+    '{this.placement}',
+    "{this.placement + '-start'}",
+  ], content);
+
   return {
     content,
     path,

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -75,6 +75,8 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart filtered-listbox - The container that wraps the filtered options.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part.
+ * Use this to target the tooltip's popup container.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -909,13 +911,14 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
               'combobox--standard': true,
               'combobox--top': this.placement === 'top',
             })}
-            placement=${this.placement}
+            placement=${`${this.placement}-start`}
             strategy=${this.hoist ? 'fixed' : 'absolute'}
             flip
             shift
             sync="width"
             auto-size="vertical"
             auto-size-padding="10"
+            exportparts="popup"
           >
             <div
               part="combobox"

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -80,6 +80,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart tag__remove-button__base - The tag's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  */
 @enableDefaultSettings('SynSelect')
 export default class SynSelect extends SynergyElement implements SynergyFormControl {
@@ -894,7 +895,8 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
               'select--medium': this.size === 'medium',
               'select--large': this.size === 'large'
             })}
-            placement=${this.placement}
+            exportparts="popup"
+            placement=${this.placement + '-start'}
             strategy=${this.hoist ? 'fixed' : 'absolute'}
             flip
             shift

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -895,7 +895,6 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
               'select--medium': this.size === 'medium',
               'select--large': this.size === 'large'
             })}
-            exportparts="popup"
             placement=${this.placement + '-start'}
             strategy=${this.hoist ? 'fixed' : 'absolute'}
             flip
@@ -903,6 +902,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
             sync="width"
             auto-size="vertical"
             auto-size-padding="10"
+            exportparts="popup"
           >
             <div
               part="combobox"

--- a/packages/react/src/components/combobox.ts
+++ b/packages/react/src/components/combobox.ts
@@ -69,6 +69,8 @@ Component.define('syn-combobox');
  * @csspart filtered-listbox - The container that wraps the filtered options.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part.
+ * Use this to target the tooltip's popup container.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.

--- a/packages/react/src/components/select.ts
+++ b/packages/react/src/components/select.ts
@@ -68,6 +68,7 @@ Component.define('syn-select');
  * @csspart tag__remove-button__base - The tag's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  */
 export const SynSelect = createComponent({
   displayName: 'SynSelect',

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -339,6 +339,8 @@ export type SynCustomElement<
  * @csspart filtered-listbox - The container that wraps the filtered options.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part.
+ * Use this to target the tooltip's popup container.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -1195,6 +1197,7 @@ export type SynCustomElement<
  * @csspart tag__remove-button__base - The tag's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  */ export type SynSelectJSXElement = SynCustomElement<
   SynSelect,
   [
@@ -1695,6 +1698,8 @@ declare module 'react' {
        * @csspart filtered-listbox - The container that wraps the filtered options.
        * @csspart clear-button - The clear button.
        * @csspart expand-icon - The container that wraps the expand icon.
+       * @csspart popup - The popup's exported `popup` part.
+       * Use this to target the tooltip's popup container.
        *
        * @animation combobox.show - The animation to use when showing the combobox.
        * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -2428,6 +2433,7 @@ declare module 'react' {
        * @csspart tag__remove-button__base - The tag's remove button base part.
        * @csspart clear-button - The clear button.
        * @csspart expand-icon - The container that wraps the expand icon.
+       * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
        */ 'syn-select': SynSelectJSXElement;
       /**
  * @summary The <syn-side-nav /> element contains secondary navigation and fits below the header.

--- a/packages/vue/src/components/SynVueCombobox.vue
+++ b/packages/vue/src/components/SynVueCombobox.vue
@@ -51,6 +51,8 @@
  * @csspart filtered-listbox - The container that wraps the filtered options.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part.
+ * Use this to target the tooltip's popup container.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.

--- a/packages/vue/src/components/SynVueSelect.vue
+++ b/packages/vue/src/components/SynVueSelect.vue
@@ -51,6 +51,7 @@
  * @csspart tag__remove-button__base - The tag's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
+ * @csspart popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  */
 import { computed, ref } from 'vue';
 import '@synergy-design-system/components/components/select/select.js';


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR provides changes that make it possible to override the width of the `syn-popup` used in `<syn-select>` and `<syn-combobox>`

### 🎫 Issues

Closes #781 

## 👩‍💻 Reviewer Notes

I went with the approach of defining a default behavior. After testing in Storybook and the demo projects, there seems nothing breaking in there.

## 📑 Test Plan

Use @kirchsuSICKAG example from the ticket in Storybook to test:

```html
<div class="container">
    <syn-select label="Option more lines">
    <syn-option value="option-1">This is a long text exceeding the input width</syn-option>
    <syn-option value="option-2">This is a long text exceeding the input width</syn-option>
      <syn-option value="option-3">This is a long text exceeding the input width</syn-option>
    </syn-select>
    <syn-select class="one-line"  label="Option one line">
      <syn-option value="option-1">This is a long text exceeding the input width</syn-option>
      <syn-option value="option-2">This is a long text exceeding the input width</syn-option>
      <syn-option value="option-3">This is a long text exceeding the input width</syn-option>
    </syn-select>
  </div>
    <style>
     .container {
        width: 15%;
     }

     .one-line::part(popup) {
      min-width: 400px;
     }
    </style>
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
