### PR TITLE
docs: 📚 TOC does not work for Token description files in Storybook

### DIFF
--- a/packages/docs/stories/tokens/Colors.mdx
+++ b/packages/docs/stories/tokens/Colors.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/blocks";
+import { Markdown, Meta } from "@storybook/blocks";
 import { CopyToClipBoard } from '../../src/shared-components/Clipboard.tsx';
 import { CopyRawHexValue } from '../../src/shared-components/RawColorValue.tsx';
 import { ColorSwatch, MultiLineDescription } from '../../src/shared-components/TokenHelpers.tsx';
@@ -21,7 +21,7 @@ import {
 
 {['light', 'dark'].map(theme => (
   <div key={theme}>
-    <h2>Colors / {theme}</h2>
+    <Markdown>{`## Colors - ${theme}`}</Markdown>
     <table className={`syn-theme-${theme}`}>
       <tbody>
         {[

--- a/packages/docs/stories/tokens/Typography.mdx
+++ b/packages/docs/stories/tokens/Typography.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/blocks";
+import { Markdown, Meta } from "@storybook/blocks";
 import { camelCase } from 'change-case';
 import { CopyToClipBoard } from '../../src/shared-components/Clipboard.tsx';
 import { CopyRawCssPropValue , CopyRawValue} from '../../src/shared-components/RawColorValue.tsx';
@@ -28,7 +28,7 @@ import {
     ['line-height', 'Line Height', getLineHeight(true)],
   ].map(([prop, title, category]) => (
     <>
-      <h2>{title}</h2>
+      <Markdown>{`## ${title}`}</Markdown>
       <p>
         {docsTokens?.tokens?.typography?.[prop]?.description?.value ?? ''}
         {prop === 'font-family' && (


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes the TOC links on the Colors and Typography stories.

### 🎫 Issues

Closes #480 

## 👩‍💻 Reviewer Notes

The reason for this problem was that the TOC creation only works with provided Markdown and not React-Components. Therefore, the headlines used (regular `<h2>` elements) where replaced with the React markdown parser and `##` for the same effect. This is a limitation of the TOC plugin that will only parse Markdown for `mdx` files.

## 📑 Test Plan

Just have a look at the created chromatic build of storybook to validate the stories are working now.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
