### PR TITLE
fix: 🐛 syn-tooltip - box-shadow bleeds into tooltip arrow

### DIFF
--- a/packages/components/src/components/tooltip/tooltip.custom.styles.ts
+++ b/packages/components/src/components/tooltip/tooltip.custom.styles.ts
@@ -5,4 +5,9 @@ export default css`
   .tooltip__body {
     box-shadow: var(--syn-shadow-large);
   }
+
+  /** #640: Adjust the zIndex of the arrow to make sure the box-shadow above does not bleed out */
+  :host::part(arrow) {
+    z-index: 0;
+  }
 `;


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a fix for `<syn-tooltip>` that made coloring harder. The root cause was that the provided `box-shadow` on the body of the `<syn-tooltip>` was positioned **above** the `arrow`, which made it look wrong in all but very dark backgrounds (like Synergies default).

### 🎫 Issues

Closes #640 

## 👩‍💻 Reviewer Notes

I also tried experimenting with replacing the `box-shadow` with a `filter: drop-shadow` on the underlying `<syn-popup>`. This works fine for the most part, however our variables are not able to be used with this, so I left it. Maybe this is something we can adjust in a future major version.

## 📑 Test Plan

Just set the color of a given tooltip via `--syn-tooltip-background-color` to `red` in current Storybook. You will notice the color is bleeding over the arrow. Do the same in the created storybook. You will notice that the color does not bleed anymore.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~~I have added automatic tests for my changes (unit- and visual regression tests).~~
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
