### PR TITLE
fix: 🐛 syn-side-nav does not correctly reappear after double-click on burger menu

### DIFF
--- a/packages/components/src/components/header/header.component.ts
+++ b/packages/components/src/components/header/header.component.ts
@@ -61,6 +61,11 @@ export default class SynHeader extends SynergyElement {
    */
   private mutationObserver: MutationObserver;
 
+  /*
+   * #587: If the side nav is animating, we should not allow to trigger the burger menu
+   */
+  private isSideNavAnimating = false;
+
   /**
    * The headers label. If you need to display HTML, use the `label` slot instead.
    */
@@ -91,10 +96,12 @@ export default class SynHeader extends SynergyElement {
 
   private handleBurgerMenuToggle() {
     // If there is a side-nav in non-rail mode, toggle the open state!
-    if (this.sideNav && !this.sideNav.rail) {
+    if (this.sideNav && !this.sideNav.rail && !this.isSideNavAnimating) {
       this.sideNav.open = !this.sideNav.open;
     }
-    this.toggleBurgerMenu();
+    if (!this.isSideNavAnimating) {
+      this.toggleBurgerMenu();
+    }
   }
 
   /**
@@ -159,6 +166,21 @@ export default class SynHeader extends SynergyElement {
       // Otherwise the mutation observer won`t trigger the method.
       this.updateBurgerMenuBasedOnSideNav();
       this.mutationObserver.observe(this.sideNav, { attributeFilter: ['open', 'rail'], attributes: true });
+
+      // #587: Make sure to not trigger the burger menu if the side nav is currently
+      // animating and the user clicks on the burger menu button.
+      const isAnimating = () => {
+        this.isSideNavAnimating = true;
+      };
+
+      const isNotAnimating = () => {
+        this.isSideNavAnimating = false;
+      };
+
+      this.sideNav.addEventListener('syn-show', isAnimating);
+      this.sideNav.addEventListener('syn-hide', isAnimating);
+      this.sideNav.addEventListener('syn-after-show', isNotAnimating);
+      this.sideNav.addEventListener('syn-after-hide', isNotAnimating);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue with `<syn-header>` that lead to animation issues when clicking the burger menu icon too fast.

### 🎫 Issues

Closes #587

## 👩‍💻 Reviewer Notes

I just added a small status variable to check if the animation of the linked `<syn-side-nav>` is already finished. If it is not, the click on the item will do nothing.

I was also thinking about adding something like a `cursor: wait;` to the item in this case, but did not want to make the private property reactive, which would have caused rerenders on finish. Would be possible by using `@state isSideNavAnimating` instead of a private variable.


## 📑 Test Plan

Just click the burger menu icon as fast as you can :). It should break in our current implementation, but ignore the subsequent clicks and not toggle the icon when the animation takes place.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
