### PR TITLE
fix: 🐛  Angular problem with multiple select and async options

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Select.ts
@@ -65,6 +65,18 @@ import { type SelectItem, mockAsyncData, mockData } from '@synergy-design-system
         <syn-option [value]="level.value">{{level.label}}</syn-option>
       }
     </syn-select>
+
+    <syn-select
+      data-testid="select-851-multiple"
+      help-text="Normal value binding and async options"
+      label="Multiple with async options"
+      multiple
+      value="1 2"
+    >
+      @for (level of levels; track $index; let index = $index) {
+        <syn-option [value]="level.value">{{level.label}}</syn-option>
+      }
+    </syn-select>
   `
 })
 export class Select implements OnInit {

--- a/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents.spec.ts
@@ -275,8 +275,6 @@ test.describe('<SynSelect />', () => {
     test.describe(`Feature#540: ${name}`, () => {
       test('should select the given elements when the delimiter is set', async ({ page }) => {
         // Angular currently has problems with selection.
-        // @todo: Remove this after #847 is fixed!
-        test.skip(name === 'angular', 'Angular currently has problems with selection. Please see #847');
 
         const AllComponents = new AllComponentsPage(page, port);
         await AllComponents.loadInitialPage();
@@ -381,6 +379,24 @@ test.describe('<SynSelect />', () => {
         expect(resetDisplayedValue).toEqual('Option 1');
       });
     }); // regression#813
+
+    test.describe(`Regression#851: ${name}`, () => {
+      test('should show the text content of the options, when value was set initially via normal binding and options added dynamically with multiple', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('selectLink');
+
+        await expect(AllComponents.getLocator('selectContent')).toBeVisible();
+
+        const select = await AllComponents.getLocator('select851Multiple');
+        // Check that the displayed value is the text content of the option
+        const displayedValue = await select.evaluate((ele: SynSelect) => ele.displayLabel);
+        const value = await select.evaluate((ele: SynSelect) => ele.value);
+
+        expect(value).toEqual(['1', '2']);
+        expect(displayedValue).toEqual('2 options selected');
+      });
+    }); // regression#851
   }); // End frameworks
 }); // </syn-select>
 

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -28,6 +28,7 @@ const AllComponentSelectors = {
   optgroupThirdItem: '#tab-content-OptGroup syn-select syn-optgroup:nth-of-type(3)',
 
   // Select
+  select851Multiple: '#tab-content-Select syn-select[data-testid="select-851-multiple"]',
   selectContent: '#tab-content-Select',
   selectForm: '#tab-content-Select syn-select[data-testid="select-form-813"]',
   selectFormOptions: '#tab-content-Select syn-select[data-testid="select-form-813"] syn-option',

--- a/packages/_private/react-demo/src/AllComponentParts/Select.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Select.tsx
@@ -75,6 +75,20 @@ export const Select = () => {
           </syn-option>
         ))}
       </syn-select>
+
+      <syn-select
+        data-testid="select-851-multiple"
+        help-text="Normal value binding and async options"
+        label="Multiple with async options"
+        multiple
+        value="1 2"
+      >
+        {levels.map(level => (
+          <syn-option key={level.value} value={level.value}>
+            {level.label}
+          </syn-option>
+        ))}
+      </syn-select>
     </>
   );
 };

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
@@ -47,5 +47,13 @@ export const Select = (regressions: Array<() => void> = []) => {
       multiple
       value="1|2"
     ></syn-select>
+
+    <syn-select
+      data-testid="select-851-multiple"
+      help-text="Normal value binding and async options"
+      label="Multiple with async options"
+      multiple
+      value="1 2"
+    ></syn-select>
   `;
 };

--- a/packages/_private/vanilla-demo/src/all-components-regressions.ts
+++ b/packages/_private/vanilla-demo/src/all-components-regressions.ts
@@ -65,6 +65,8 @@ export const allComponentsRegressions = new Map(Object.entries({
     () => appendOptions805('syn-select[data-testid="select-805-multi-select"]'),
     // #813
     () => appendOptions813('syn-select[data-testid="select-level-813"]'),
+    // #851
+    () => appendOptions813('syn-select[data-testid="select-851-multiple"]'),
   ],
   TabGroup: [
     // #814

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
@@ -58,4 +58,14 @@ onMounted(async () => {
     <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
   </SynVueSelect>
 
+  <SynVueSelect
+    data-testid="select-851-multiple"
+    help-text="Normal value binding and async options"
+    label="Multiple with async options"
+    multiple
+    value="1 2"
+  >
+    <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
+  </SynVueSelect>
+
 </template>

--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -251,6 +251,34 @@ const transformComponent = (path, originalContent) => {
     ],
   ], content);
 
+  // #851: Fix angular problem with multiple and initial attribute
+  // value ( `<syn-select multiple value="1 2">` )
+  content = addSectionsBefore([
+    [
+      "isAllowedValue } from './utility.js';",
+      'compareValues, ',
+      { newlinesAfterInsertion: 0 },
+    ],
+  ], content);
+
+  content = replaceSections([
+    [
+      `if (this._value === val) {
+      return;
+    }`,
+      `if (compareValues(this._value, val)) {
+      return;
+    }`,
+    ],
+    [
+      `this.handleDelimiterChange();
+    const value = Array.isArray(val) ? val : [val];`,
+      `this.handleDelimiterChange();
+    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(Boolean);`,
+    ],
+  ], content);
+  // End#851
+
   return {
     content,
     path,

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -31,7 +31,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import type { SynergyFormControl } from '../../internal/synergy-element.js';
 import type { SynRemoveEvent } from '../../events/syn-remove.js';
 import type SynOption from '../option/option.component.js';
-import { isAllowedValue } from './utility.js';
+import { compareValues, isAllowedValue } from './utility.js';
 import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator.js';
 
 /**
@@ -146,7 +146,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
       val = Array.isArray(val) ? val.join(this.delimiter) : val;
     }
 
-    if (this._value === val) {
+    if (compareValues(this._value, val)) {
       return;
     }
 
@@ -562,7 +562,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     const val = this.valueHasChanged ? this.value : this.defaultValue;
 
     this.handleDelimiterChange();
-    const value = Array.isArray(val) ? val : [val];
+    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(Boolean);;
     const values: Array<string | number> = [];
 
     // Check for duplicate values in menu items

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -562,7 +562,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     const val = this.valueHasChanged ? this.value : this.defaultValue;
 
     this.handleDelimiterChange();
-    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(Boolean);;
+    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(Boolean);
     const values: Array<string | number> = [];
 
     // Check for duplicate values in menu items

--- a/packages/components/src/components/select/select.custom.test.ts
+++ b/packages/components/src/components/select/select.custom.test.ts
@@ -3,6 +3,7 @@ import {
   aTimeout, expect, fixture, html, oneEvent,
 } from '@open-wc/testing';
 import type SynSelect from './select.js';
+import { compareValues } from './utility.js';
 
 describe('<syn-select>', () => {
   describe('#540: should allow to use a custom delimiter for multiple values', () => {
@@ -200,4 +201,38 @@ describe('<syn-select>', () => {
       });
     }); // #850
   }); // regression tests
+
+  describe('utility functions', () => {
+    describe('compareValues', () => {
+      it('should return true for equal values', () => {
+        expect(compareValues('123', '123')).to.be.true;
+        expect(compareValues(123, 123)).to.be.true;
+        expect(compareValues(['1', '2'], ['1', '2'])).to.be.true;
+      });
+
+      it('should return false for different values', () => {
+        expect(compareValues('123', '321')).to.be.false;
+        expect(compareValues(123, 321)).to.be.false;
+      });
+
+      // TODO: do we want to support ordered or unordered arrays?
+      it('should return false for arrays with different order', () => {
+        expect(compareValues([1, 2], [2, 1])).to.be.false;
+      });
+
+      it('should return false for arrays with different length', () => {
+        expect(compareValues([1, 2], [1, 2, 3])).to.be.false;
+      });
+
+      it('should return false for array and non-array', () => {
+        expect(compareValues([1], 1)).to.be.false;
+        expect(compareValues(1, [1])).to.be.false;
+      });
+
+      // TODO: or should we do a string conversion of numbers in the function?
+      it('should return false for different types', () => {
+        expect(compareValues(1, '1')).to.be.false;
+      });
+    });
+  });
 });

--- a/packages/components/src/components/select/utility.ts
+++ b/packages/components/src/components/select/utility.ts
@@ -23,3 +23,19 @@ export const isAllowedValue = (value: AllowedValueTypes) => {
 
   return !!value;
 };
+
+/**
+ * Compare two values if they are equal
+ * @param a The first value to compare
+ * @param b The second value to compare
+ * @returns True if the values are equal, false otherwise
+ */
+export const compareValues = (a: AllowedValueTypes, b: AllowedValueTypes) => {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+    return a.every((v, i) => v === b[i]);
+  }
+  return a === b;
+};


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes an issue, which only appears with angular with specific circumstances. 
If using a syn-select:
- with multiple
- async options
- normal `value` binding

```html
    <syn-select multiple value="1 2" >
      @for (option of asyncOptions; track $index; let index = $index) {
        <syn-option [value]="option.value">{{option.label}}</syn-option>
      }
    </syn-select>
```

### 🎫 Issues
Closes #851 

## 👩‍💻 Reviewer Notes
We had two failures parts in the syn-select. But these parts seems to only occur with angular and are "fixed" (overwritten) if used with any other framework.

At one point two arrays where compared but it was false every time because `['1'] === ['1']` is always false. Therefore I added a compareValues utility function, which checks if the arrays are the same.

At another part we checked if an value is an array and if not we will just put the value in an array, which resulted in this string `'option-1 option-2'` was converted to this array `['option-1 option-2']` instead of this array `['option-1',  'option-2']`

## 📑 Test Plan
Have a look at the new angular demo test


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
