### PR TITLE
fix: 🐛 syn-input: Numeric inputs having wrong min/max state when setting the value prop externally

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Input.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Input.ts
@@ -78,6 +78,17 @@ import { SynInputComponent } from '@synergy-design-system/angular/components/inp
       value="50"
     />
     <!-- /#838 -->
+
+    <!-- #872: Spin buttons out of sync with value -->
+    <syn-input
+      data-testid="input-872-spin-buttons"
+      label="Issue #872 - Spin Buttons out of sync with value"
+      [max]=100
+      [min]=0
+      type="number"
+      value="50"
+    />
+    <!-- /#872 -->
   `,
 })
 export class Input {}

--- a/packages/_private/e2e-demo-test/src/helpers.ts
+++ b/packages/_private/e2e-demo-test/src/helpers.ts
@@ -10,6 +10,45 @@ import { type AvailableFrameworks, frameworks } from '../frameworks.config.js';
 
 type FrameworkCallback = (framework: { name: AvailableFrameworks, port: number }) => void;
 
+export type SetterType = 'property' | 'attribute';
+
+/**
+ * Set a value for a given component via property or attribute.
+ * @param locator The locator to set the property for
+ * @param attribute The property to set
+ * @param value The value to set the property to
+ * @param via The type of setter to use. Can be either property or attribute.
+ */
+export const setPropertyForLocator = async <T extends HTMLElement>(
+  locator: Locator,
+  attribute: keyof T,
+  value: unknown,
+  via: SetterType = 'property',
+) => locator.evaluate(
+  (el: T, options) => {
+    const {
+      attribute: attr,
+      value: val,
+      via: setterVia,
+    } = options;
+
+    // Set the property directly on the element
+    if (setterVia === 'property') {
+      (el as Record<string, unknown>)[attr as string] = val;
+      return el;
+    }
+
+    // Set the attribute on the element
+    el.setAttribute(attr as string, String(val));
+    return el;
+  },
+  {
+    attribute,
+    value,
+    via,
+  },
+);
+
 export const getInputValue = async (locator: Locator) => locator
   .evaluate((el: SynInput | SynTextarea | SynSelect) => el.value);
 

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -24,6 +24,7 @@ const AllComponentSelectors = {
   input417NumericMinFractionDigitsNative: '#tab-content-Input syn-input[data-testid="input-838-numeric-native-min-fraction-digits"]',
   input417NumericModern: '#tab-content-Input syn-input[data-testid="input-417-numeric-modern"]',
   input417NumericNative: '#tab-content-Input syn-input[data-testid="input-417-numeric-native"]',
+  input872SpinButtons: '#tab-content-Input syn-input[data-testid="input-872-spin-buttons"]',
   inputContent: '#tab-content-Input',
   inputLink: '#tab-Input',
 

--- a/packages/_private/react-demo/src/AllComponentParts/Input.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Input.tsx
@@ -67,5 +67,14 @@ export const Input = () => (
         valueAsNumber={50}
       />
     </>
+
+    <syn-input
+      data-testid="input-872-spin-buttons"
+      label="Issue #872 - Spin Buttons out of sync with value"
+      max={100}
+      min={0}
+      type="number"
+      value="50"
+    />
   </>
 );

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Input.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Input.ts
@@ -69,4 +69,15 @@ export const Input = () => html`
     value="50"
   ></syn-input>
   <!-- /#838 -->
+
+  <!-- #872: Spin buttons out of sync with value -->
+  <syn-input
+    data-testid="input-872-spin-buttons"
+    label="Issue #872 - Spin Buttons out of sync with value"
+    max="100"
+    min="0"
+    type="number"
+    value="50"
+  ></syn-input>
+  <!-- /#872 -->
 `;

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoInput.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoInput.vue
@@ -70,4 +70,15 @@ import { SynVueInput, SynVueIcon } from '@synergy-design-system/vue';
     value="50"
   />
   <!-- /#838 -->
+
+  <!-- #872: Spin buttons out of sync with value -->
+  <syn-input
+    data-testid="input-872-spin-buttons"
+    label="Issue #872 - Spin Buttons out of sync with value"
+    :max=100
+    :min=0
+    type="number"
+    value="50"
+  />
+  <!-- /#872 -->
 </template>

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -358,7 +358,7 @@ export class Home {
 }
 ```
 
-The default update of the ngModel values is done on the `syn-input` event. If you want to change the event, which triggers the update, you can use the `ngModelUpdateOn` property. 
+The default update of the ngModel values is done on the `syn-input` event. If you want to change the event, which triggers the update, you can use the `ngModelUpdateOn` property.
 
 ```typescript
 // Changed ngModel update event. NgModel value change is triggered on the `syn-change` event, instead of the `syn-input` event

--- a/packages/components/scripts/vendorism/custom/input.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/input.vendorism.js
@@ -113,7 +113,10 @@ export`,
     }
 
     const min = typeof this.min === 'string' ? parseFloat(this.min) : this.min;
-    return this.valueAsNumber <= min;
+
+    // #872: Use value instead of valueAsNumber as valueAsNumber is drawn from the hidden input
+    // that is not yet updated in the current render cycle.
+    return parseFloat(this.value) <= min;
   }
 
   private isIncrementDisabled() {
@@ -126,7 +129,10 @@ export`,
     }
 
     const max = typeof this.max === 'string' ? parseFloat(this.max) : this.max;
-    return this.valueAsNumber >= max;
+
+    // #872: Use value instead of valueAsNumber as valueAsNumber is drawn from the hidden input
+    // that is not yet updated in the current render cycle.
+    return parseFloat(this.value) >= max;
   }`,
   );
 

--- a/packages/components/src/components/input/input.component.ts
+++ b/packages/components/src/components/input/input.component.ts
@@ -379,7 +379,10 @@ export default class SynInput extends SynergyElement implements SynergyFormContr
     }
 
     const min = typeof this.min === 'string' ? parseFloat(this.min) : this.min;
-    return this.valueAsNumber <= min;
+
+    // #872: Use value instead of valueAsNumber as valueAsNumber is drawn from the hidden input
+    // that is not yet updated in the current render cycle.
+    return parseFloat(this.value) <= min;
   }
 
   private isIncrementDisabled() {
@@ -392,7 +395,10 @@ export default class SynInput extends SynergyElement implements SynergyFormContr
     }
 
     const max = typeof this.max === 'string' ? parseFloat(this.max) : this.max;
-    return this.valueAsNumber >= max;
+
+    // #872: Use value instead of valueAsNumber as valueAsNumber is drawn from the hidden input
+    // that is not yet updated in the current render cycle.
+    return parseFloat(this.value) >= max;
   }
 
   


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that arises when dynamically changing the `value` prop of a `<syn-input type="number">`. The bug resulted in the stepper buttons to be out of sync when either the min- or max was reached. Reason for this was that we have drawn the min and max values from `this.valueAsNumber`, which would always be one render cycle behind. Reason for this is that this value is drawn from the rendered hidden `<input />` element, which did not finish rendering yet. Because of this, the value was always of one render cycle.

I fixed this by using `parseFloat(this.value)` instead.

### 🎫 Issues

Closes #872 

## 👩‍💻 Reviewer Notes

Just remove `no-spin-buttons` from our [syn-range with prefix-suffix](https://synergy-design-system.github.io/?path=/docs/components-syn-range--docs&globals=viewport:defaultViewPort#prefix-suffix-text) and observe that it no longer lacks behind on this branch.

I also added some e2e tests, as well as a new e2e utility that might prove to be valuable in the future. Just have a look at the tests what it does and how it works.

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
