### PR TITLE
fix: 🐛 syn-select with numeric value does not work with 0

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Select.ts
@@ -77,6 +77,22 @@ import { type SelectItem, mockAsyncData, mockData } from '@synergy-design-system
         <syn-option [value]="level.value">{{level.label}}</syn-option>
       }
     </syn-select>
+
+    <syn-select
+      data-testid="select-885-value-zero-string"
+      label="Select should allow to select value of string(zero)"
+      value="0"
+    >
+      <syn-option value="0">Zero (string)</syn-option>
+    </syn-select>
+
+    <syn-select
+      data-testid="select-885-value-zero-number"
+      label="Select should allow to select value of number(zero)"
+      [value]=0
+    >
+      <syn-option [value]=0>Zero (numeric)</syn-option>
+    </syn-select>
   `
 })
 export class Select implements OnInit {

--- a/packages/_private/e2e-demo-test/src/AllComponents/SynSelect.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynSelect.spec.ts
@@ -130,5 +130,39 @@ test.describe('<SynSelect />', () => {
         expect(displayedValue).toEqual('2 options selected');
       });
     }); // regression#847
+
+    test.describe(`Regression#885: ${name}`, () => {
+      test('should allow to select zero as string', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('selectLink');
+
+        await expect(AllComponents.getLocator('selectContent')).toBeVisible();
+
+        const select = await AllComponents.getLocator('select885ValueZeroString');
+        // Check that the displayed value is the text content of the option
+        const displayedValue = await select.evaluate((ele: SynSelect) => ele.displayLabel);
+        const value = await select.evaluate((ele: SynSelect) => ele.value);
+
+        expect(value).toEqual('0');
+        expect(displayedValue).toEqual('Zero (string)');
+      });
+
+      test('should allow to select zero as number', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('selectLink');
+
+        await expect(AllComponents.getLocator('selectContent')).toBeVisible();
+
+        const select = await AllComponents.getLocator('select885ValueZeroNumber');
+        // Check that the displayed value is the text content of the option
+        const displayedValue = await select.evaluate((ele: SynSelect) => ele.displayLabel);
+        const value = await select.evaluate((ele: SynSelect) => ele.value);
+
+        expect(value).toEqual(0);
+        expect(displayedValue).toEqual('Zero (numeric)');
+      });
+    }); // regression#885
   }); // End frameworks
 }); // </syn-select>

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -52,6 +52,8 @@ const AllComponentSelectors = {
 
   // Select
   select847Multiple: '#tab-content-Select syn-select[data-testid="select-847-multiple"]',
+  select885ValueZeroNumber: '#tab-content-Select syn-select[data-testid="select-885-value-zero-number"]',
+  select885ValueZeroString: '#tab-content-Select syn-select[data-testid="select-885-value-zero-string"]',
   selectContent: '#tab-content-Select',
   selectForm: '#tab-content-Select syn-select[data-testid="select-form-813"]',
   selectFormOptions: '#tab-content-Select syn-select[data-testid="select-form-813"] syn-option',

--- a/packages/_private/react-demo/src/AllComponentParts/Select.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Select.tsx
@@ -89,6 +89,22 @@ export const Select = () => {
           </syn-option>
         ))}
       </syn-select>
+
+      <syn-select
+        data-testid="select-885-value-zero-string"
+        label="Select should allow to select value of string(zero)"
+        value="0"
+      >
+        <syn-option value="0">Zero (string)</syn-option>
+      </syn-select>
+
+      <syn-select
+        data-testid="select-885-value-zero-number"
+        label="Select should allow to select value of number(zero)"
+        value={0}
+      >
+        <syn-option value={0}>Zero (numeric)</syn-option>
+      </syn-select>
     </>
   );
 };

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Select.ts
@@ -57,5 +57,21 @@ export const Select = (regressions: RegressionFns = []) => {
       multiple
       value="1 2"
     ></syn-select>
+
+    <syn-select
+      data-testid="select-885-value-zero-string"
+      label="Select should allow to select value of string(zero)"
+      value="0"
+    >
+      <syn-option value="0">Zero (string)</syn-option>
+    </syn-select>
+
+    <syn-select
+      data-testid="select-885-value-zero-number"
+      label="Select should allow to select value of number(zero)"
+      .value=${0}
+    >
+      <syn-option .value=${0}>Zero (numeric)</syn-option>
+    </syn-select>
   `;
 };

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoSelect.vue
@@ -68,4 +68,20 @@ onMounted(async () => {
     <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
   </SynVueSelect>
 
+  <SynVueSelect
+    data-testid="select-885-value-zero-string"
+    label="Select should allow to select value of string(zero)"
+    value="0"
+  >
+    <SynVueOption value="0">Zero (string)</SynVueOption>
+  </SynVueSelect>
+
+  <SynVueSelect
+    data-testid="select-885-value-zero-number"
+    label="Select should allow to select value of number(zero)"
+    :value="0"
+  >
+    <SynVueOption :value="0">Zero (numeric)</SynVueOption>
+  </SynVueSelect>
+
 </template>

--- a/packages/components/scripts/vendorism/custom/select.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/select.vendorism.js
@@ -279,6 +279,15 @@ const transformComponent = (path, originalContent) => {
   ], content);
   // End#847
 
+  // #885: Add support for custom option values
+  content = replaceSections([
+    [
+      '[val].filter(Boolean);',
+      '[val].filter(isAllowedValue);',
+    ],
+  ], content);
+  // End#885
+
   return {
     content,
     path,

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -31,7 +31,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import type { SynergyFormControl } from '../../internal/synergy-element.js';
 import type { SynRemoveEvent } from '../../events/syn-remove.js';
 import type SynOption from '../option/option.component.js';
-import { compareValues, isAllowedValue, isTruthy } from './utility.js';
+import { compareValues, isAllowedValue } from './utility.js';
 import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator.js';
 
 /**
@@ -140,7 +140,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   set value(val: string | number | Array<string | number>) {
     if (this.multiple) {
       if (!Array.isArray(val)) {
-        val = typeof val === 'string' ? val.split(this.delimiter) : [val].filter(isTruthy);
+        val = typeof val === 'string' ? val.split(this.delimiter) : [val].filter(isAllowedValue);
       }
     } else {
       val = Array.isArray(val) ? val.join(this.delimiter) : val;
@@ -562,7 +562,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     const val = this.valueHasChanged ? this.value : this.defaultValue;
 
     this.handleDelimiterChange();
-    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(isTruthy);
+    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(isAllowedValue);
     const values: Array<string | number> = [];
 
     // Check for duplicate values in menu items

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -31,7 +31,7 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import type { SynergyFormControl } from '../../internal/synergy-element.js';
 import type { SynRemoveEvent } from '../../events/syn-remove.js';
 import type SynOption from '../option/option.component.js';
-import { compareValues, isAllowedValue } from './utility.js';
+import { compareValues, isAllowedValue, isTruthy } from './utility.js';
 import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator.js';
 
 /**
@@ -140,7 +140,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   set value(val: string | number | Array<string | number>) {
     if (this.multiple) {
       if (!Array.isArray(val)) {
-        val = typeof val === 'string' ? val.split(this.delimiter) : [val].filter(Boolean);
+        val = typeof val === 'string' ? val.split(this.delimiter) : [val].filter(isTruthy);
       }
     } else {
       val = Array.isArray(val) ? val.join(this.delimiter) : val;
@@ -562,7 +562,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     const val = this.valueHasChanged ? this.value : this.defaultValue;
 
     this.handleDelimiterChange();
-    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(Boolean);
+    const value = Array.isArray(val) ? val :  typeof val === 'string' ? val.split(this.delimiter) : [val].filter(isTruthy);
     const values: Array<string | number> = [];
 
     // Check for duplicate values in menu items

--- a/packages/components/src/components/select/utility.ts
+++ b/packages/components/src/components/select/utility.ts
@@ -39,3 +39,10 @@ export const compareValues = (a: AllowedValueTypes, b: AllowedValueTypes) => {
   }
   return a === b;
 };
+
+/**
+ * Check if a value is truthy
+ * @param value The value to check
+ * @returns True if the value is truthy, false otherwise
+ */
+export const isTruthy = (value: unknown) => typeof value !== 'undefined' && value !== null && value !== false && value !== '';

--- a/packages/components/src/components/select/utility.ts
+++ b/packages/components/src/components/select/utility.ts
@@ -39,10 +39,3 @@ export const compareValues = (a: AllowedValueTypes, b: AllowedValueTypes) => {
   }
   return a === b;
 };
-
-/**
- * Check if a value is truthy
- * @param value The value to check
- * @returns True if the value is truthy, false otherwise
- */
-export const isTruthy = (value: unknown) => typeof value !== 'undefined' && value !== null && value !== false && value !== '';


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue when using `<syn-select>` with numeric zero values. This was caused by using a `Boolean` filter on arrays that mistreats `0` as `false` when cast via `Boolean(0)`.

### 🎫 Issues

Closes #885

## 👩‍💻 Reviewer Notes

Just have a look at the code changes, they are quite minimal. I opted to reuse the already existing `isAllowedValue` function.

## 📑 Test Plan

Create `<syn-select>` with various values in the demo applications or storybook. The following code (taken from react) shows the example:

```tsx
const MyTest = () => (
  <syn-select
    data-testid="select-885-value-zero-number"
    label="Select should allow to select value of number(zero)"
    value={0}
  >
    <syn-option value={0}>Zero (numeric)</syn-option>
  </syn-select>
);
```

This will not select the given option. With the fix applied, the option will be selected.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
