### PR TITLE
chore: 🔧 Create regression test for issue 632

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import type { SynChangeEvent, SynCombobox } from '@synergy-design-system/components';
 import { SynComboboxComponent } from '@synergy-design-system/angular/components/combobox';
 import { SynOptionComponent } from '@synergy-design-system/angular/components/option';
 import { SynButtonComponent } from '@synergy-design-system/angular/components/button';
@@ -33,18 +34,36 @@ import { SynButtonComponent } from '@synergy-design-system/angular/components/bu
       </syn-combobox>
       <syn-button type="reset">Reset</syn-button>
     </form>
+
+    <syn-combobox
+      data-testid="combobox-632"
+      label="Keyboard Interaction test #632"
+      [value]="cb632Value"
+      (synChangeEvent)="setcb632Value($event)"
+    >
+      <syn-option value="option-1">Lorem</syn-option>
+      <syn-option value="option-2">ipsum</syn-option>
+      <syn-option value="option-3">dolor</syn-option>
+    </syn-combobox>
+
   `,
 })
 export class Combobox implements OnInit {
   levels!: Array<{value: string, label: string }>
 
+  cb632Value: string = '';
+
+  setcb632Value(e: SynChangeEvent) {
+    this.cb632Value = (e.target as SynCombobox).value;
+  };
+
   ngOnInit(): void {
     setTimeout(() => {
       this.levels = [
-          { value: '1', label: 'Novice' },
-          { value: '2', label: 'Intermediate' },
-          { value: '3', label: 'Advanced' },
-        ];
+        { value: '1', label: 'Novice' },
+        { value: '2', label: 'Intermediate' },
+        { value: '3', label: 'Advanced' },
+      ];
     }, 0);
   }
 }

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -10,6 +10,7 @@ const AllComponentSelectors = {
   alertLink: '#tab-Alert',
 
   // Combobox
+  combobox632: '#tab-content-Combobox syn-combobox[data-testid="combobox-632"]',
   combobox797: '#tab-content-Combobox syn-combobox[data-testid="combobox-797"]',
   combobox813Form: '#tab-content-Combobox syn-combobox[data-testid="combobox-form-813"]',
   combobox813FormOptions: '#tab-content-Combobox syn-combobox[data-testid="combobox-form-813"] syn-option',

--- a/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
+import type { SynCombobox } from '@synergy-design-system/components';
 
 export const Combobox = () => {
   const [levels, setLevels] = useState<Array<{ value: string, label: string }>>([]);
+  const [cb632Value, setcb632Value] = useState<string>('');
   useEffect(() => {
     setTimeout(() => {
       setLevels([
@@ -35,6 +37,17 @@ export const Combobox = () => {
         </syn-combobox>
         <syn-button type="reset">Reset</syn-button>
       </form>
+
+      <syn-combobox
+        data-testid="combobox-632"
+        label="Keyboard Interaction test #632"
+        value={cb632Value}
+        onsyn-change={(e) => setcb632Value((e.target as SynCombobox).value)}
+      >
+        <syn-option value="option-1">Lorem</syn-option>
+        <syn-option value="option-2">ipsum</syn-option>
+        <syn-option value="option-3">dolor</syn-option>
+      </syn-combobox>
     </>
   );
 };

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
@@ -25,5 +25,14 @@ export const Combobox = (regressions: RegressionFns = []) => {
       </syn-combobox>
       <syn-button type="reset">Reset</syn-button>
     </form>
+
+    <syn-combobox
+      data-testid="combobox-632"
+      label="Keyboard Interaction test #632"
+    >
+      <syn-option value="option-1">Lorem</syn-option>
+      <syn-option value="option-2">ipsum</syn-option>
+      <syn-option value="option-3">dolor</syn-option>
+    </syn-combobox>
   `;
 };

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { SynVueButton, SynVueCombobox, SynVueOption } from '@synergy-design-system/vue';
+import type { SynCombobox } from '@synergy-design-system/components';
 import { ref } from 'vue';
+
 const levels = ref<Array<{ value: string, label: string }>>([]);
+
+const cb632Value = ref<string>('');
 
 setTimeout(() => {
   levels.value = [
@@ -22,6 +26,7 @@ setTimeout(() => {
   <SynVueCombobox :value="'2'" data-testid="combobox-level-813">
     <SynVueOption v-for="level in levels" :value="level.value" :key="level.value"> {{ level.label }}</SynVueOption>
   </SynVueCombobox>
+  
   <form>
     <SynVueCombobox value="option-1" data-testid="combobox-form-813">
       <SynVueOption value="option-1">Option 1</SynVueOption>
@@ -30,4 +35,16 @@ setTimeout(() => {
     </SynVueCombobox>
     <SynVueButton type="reset">reset</SynVueButton>
   </form>
+
+  <SynVueCombobox
+    data-testid="combobox-632"
+    label="Keyboard Interaction test #632"
+    :value="cb632Value"
+    @syn-change="(e) => cb632Value = ((e.target as SynCombobox).value)"
+  >
+    <SynVueOption value="option-1">Lorem</SynVueOption>
+    <SynVueOption value="option-2">ipsum</SynVueOption>
+    <SynVueOption value="option-3">dolor</SynVueOption>
+  </SynVueCombobox>
+
 </template>


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a long outstanding regression test for an issue originally handled in #632. The test will make sure to use a combination of state management (`useState` in React, `ref` in Vue and class binding in Angular) and keyboard interaction to trigger the faulty behavior.

The original issue was that the DOM nodes of `<syn-combobox>` where cached, but some frameworks recreated the nodes when rerendering a component (e.g. react does this on every render), making the list stale.

### 🎫 Issues

Closes #635 

## 👩‍💻 Reviewer Notes

Just let the tests run on the respective frameworks. I did not add state management tests for vanilla as vanilla applications tend to use whatever a developer sees fit and it would not meet any field demands. The tests still run and are valid, however.

## 📑 Test Plan

-

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] ~~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~~
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [ ] ~~I have made sure that the bundle size has changed appropriately.~~
- [ ] ~~I have validated that there are no accessibility errors.~~
- [ ] ~~I have used design tokens instead of fix css values~~
