### PR TITLE
feat: ✨ Add restricted options to syn-combobox

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Combobox.ts
@@ -46,6 +46,15 @@ import { SynButtonComponent } from '@synergy-design-system/angular/components/bu
       <syn-option value="option-3">dolor</syn-option>
     </syn-combobox>
 
+    <syn-combobox
+      data-testid="combobox-626"
+      label="'Restricted' feature #626"
+      restricted
+    >
+      <syn-option value="option-1">Lorem</syn-option>
+      <syn-option value="option-2">ipsum</syn-option>
+      <syn-option value="option-3">dolor</syn-option>
+    </syn-combobox>
   `,
 })
 export class Combobox implements OnInit {

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -10,6 +10,7 @@ const AllComponentSelectors = {
   alertLink: '#tab-Alert',
 
   // Combobox
+  combobox626: '#tab-content-Combobox syn-combobox[data-testid="combobox-626"]',
   combobox632: '#tab-content-Combobox syn-combobox[data-testid="combobox-632"]',
   combobox797: '#tab-content-Combobox syn-combobox[data-testid="combobox-797"]',
   combobox813Form: '#tab-content-Combobox syn-combobox[data-testid="combobox-form-813"]',

--- a/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Combobox.tsx
@@ -48,6 +48,16 @@ export const Combobox = () => {
         <syn-option value="option-2">ipsum</syn-option>
         <syn-option value="option-3">dolor</syn-option>
       </syn-combobox>
+
+      <syn-combobox
+        data-testid="combobox-626"
+        label="'Restricted' feature #626"
+        restricted
+      >
+        <syn-option value="option-1">Lorem</syn-option>
+        <syn-option value="option-2">ipsum</syn-option>
+        <syn-option value="option-3">dolor</syn-option>
+      </syn-combobox>
     </>
   );
 };

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Combobox.ts
@@ -34,5 +34,15 @@ export const Combobox = (regressions: RegressionFns = []) => {
       <syn-option value="option-2">ipsum</syn-option>
       <syn-option value="option-3">dolor</syn-option>
     </syn-combobox>
+
+    <syn-combobox
+      data-testid="combobox-626"
+      label="'Restricted' feature #626"
+      restricted
+    >
+      <syn-option value="option-1">Lorem</syn-option>
+      <syn-option value="option-2">ipsum</syn-option>
+      <syn-option value="option-3">dolor</syn-option>
+    </syn-combobox>
   `;
 };

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoCombobox.vue
@@ -47,4 +47,13 @@ setTimeout(() => {
     <SynVueOption value="option-3">dolor</SynVueOption>
   </SynVueCombobox>
 
+  <SynVueCombobox
+    data-testid="combobox-626"
+    label="'Restricted' feature #626"
+    restricted
+  >
+    <SynVueOption value="option-1">Lorem</SynVueOption>
+    <SynVueOption value="option-2">ipsum</SynVueOption>
+    <SynVueOption value="option-3">dolor</SynVueOption>
+  </SynVueCombobox>
 </template>

--- a/packages/angular/components/combobox/combobox.component.ts
+++ b/packages/angular/components/combobox/combobox.component.ts
@@ -321,8 +321,9 @@ The form must be in the same document or shadow root for this to work.
   }
 
   /**
-   * Defines if the combobox is restricted to the options list
-   */
+* When set to `true`, restricts the combobox to only allow selection from the available options.
+Users will not be able to enter custom values that are not present in the list.
+ */
   @Input()
   set restricted(v: '' | SynCombobox['restricted']) {
     this._ngZone.runOutsideAngular(

--- a/packages/angular/components/combobox/combobox.component.ts
+++ b/packages/angular/components/combobox/combobox.component.ts
@@ -74,6 +74,7 @@ import '@synergy-design-system/components/components/combobox/combobox.js';
  * @csspart expand-icon - The container that wraps the expand icon.
  * @csspart popup - The popup's exported `popup` part.
  * Use this to target the tooltip's popup container.
+ * @csspart no-results - The container that wraps the "no results" message.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -317,6 +318,19 @@ The form must be in the same document or shadow root for this to work.
   }
   get required(): SynCombobox['required'] {
     return this.nativeElement.required;
+  }
+
+  /**
+   * Defines if the combobox is restricted to the options list
+   */
+  @Input()
+  set restricted(v: '' | SynCombobox['restricted']) {
+    this._ngZone.runOutsideAngular(
+      () => (this.nativeElement.restricted = v === '' || v),
+    );
+  }
+  get restricted(): SynCombobox['restricted'] {
+    return this.nativeElement.restricted;
   }
 
   /**

--- a/packages/components/scripts/vendorism/custom/translations.vendorism.js
+++ b/packages/components/scripts/vendorism/custom/translations.vendorism.js
@@ -18,13 +18,13 @@ const translations = {
     de: 'Dateien auswählen',
     en: 'Choose files',
   },
-  folderButtonText: {
-    de: 'Ordner auswählen',
-    en: 'Choose folder',
-  },
   fileDragDrop: {
     de: 'Datei ablegen oder auswählen',
     en: 'Drop or choose file',
+  },
+  folderButtonText: {
+    de: 'Ordner auswählen',
+    en: 'Choose folder',
   },
   folderDragDrop: {
     de: 'Ordner ablegen oder auswählen',
@@ -33,6 +33,10 @@ const translations = {
   menu: {
     de: 'Menü',
     en: 'Menu',
+  },
+  noResults: {
+    de: 'Keine Ergebnisse gefunden',
+    en: 'No results found',
   },
   notification: {
     de: 'Benachrichtigung',

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -22,8 +22,8 @@ import type SynOptGroup from '../optgroup/optgroup.js';
 import styles from './combobox.styles.js';
 import customStyles from './combobox.custom.styles.js';
 import {
-  createOptionFromDifferentTypes,
-  filterOnlyOptgroups, getAllOptions, getAssignedElementsForSlot, normalizeString,
+  createOptionFromDifferentTypes, filterOnlyOptgroups, getAllOptions, getAssignedElementsForSlot,
+  getValueFromOption, normalizeString,
 } from './utils.js';
 import { scrollIntoView } from '../../internal/scroll.js';
 import { type OptionRenderer, defaultOptionRenderer } from './option-renderer.js';
@@ -106,8 +106,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   private closeWatcher: CloseWatcher | null;
 
-  /** The last value of a syn-option, that was selected by click or via keyboard navigation */
-  private lastOptionValue = '';
+  /** The last syn-option, that was selected by click or via keyboard navigation */
+  private lastOption: SynOption | undefined;
 
   private isOptionRendererTriggered = false;
 
@@ -126,6 +126,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   @query('slot:not([name])') private defaultSlot: HTMLSlotElement;
 
   @state() private hasFocus = false;
+
+  @state() private isUserInput = false;
 
   @state() displayLabel = '';
 
@@ -194,6 +196,9 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   /** The combobox's required attribute. */
   @property({ reflect: true, type: Boolean }) required = false;
+
+  /** Defines if the combobox is restricted to the options list */
+  @property({ reflect: true, type: Boolean }) restricted = false;
 
   /**
    * A function that customizes the rendered option. The first argument is the option, the second
@@ -365,7 +370,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
       // Update the value based on the current selection and close it
       if (currentOption) {
-        const oldValue = this.lastOptionValue;
+        const oldValue = this.lastOption ? getValueFromOption(this.lastOption) : undefined;
         this.setSelectedOption(currentOption);
 
         if (this.value !== oldValue) {
@@ -457,7 +462,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     if (this.value !== '') {
       this.value = '';
       this.displayInput.value = '';
-      this.lastOptionValue = '';
+      this.lastOption = undefined;
       this.setSelectedOption(undefined);
       this.displayInput.focus({ preventScroll: true });
 
@@ -482,7 +487,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   private handleOptionClick(event: MouseEvent) {
     const target = event.target as HTMLElement;
     const option = target.closest('syn-option');
-    const oldValue = this.lastOptionValue;
+    const oldValue = this.lastOption ? getValueFromOption(this.lastOption) : undefined;
     if (option && !option.disabled) {
       this.setSelectedOption(option);
 
@@ -565,20 +570,20 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   /**
    * Updates the selected options cache, the current value, and the display value
    */
+  // eslint-disable-next-line complexity
   private setSelectedOption(option: SynOption | undefined) {
     this.selectedOption = option;
 
-    // Check if the selected option has a value,
-    // if not take the text content of the option otherwise the input text
     let optionValue;
-    if (this.selectedOption?.value) {
-      optionValue = String(this.selectedOption.value);
-    } else {
-      optionValue = this.selectedOption?.getTextLabel();
-    }
 
     if (option) {
-      this.lastOptionValue = optionValue || '';
+      this.lastOption = option;
+      optionValue = String(getValueFromOption(option));
+    } else if (this.restricted && !this.isValidValue() && this.value !== '' && !this.isUserInput) {
+      // if an invalid value was set via property binding for `restricted`comboboxes,
+      // reset to last valid value
+      this.resetToLastValidValue();
+      return;
     }
 
     // Update the value
@@ -774,27 +779,79 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
   private async handleInput() {
     const inputValue = this.displayInput.value;
+    const cachedLastOption = this.lastOption;
+    this.isUserInput = true;
+
     this.value = inputValue;
     await this.updateComplete;
+    this.isUserInput = false;
+    this.lastOption = cachedLastOption;
     this.open = this.numberFilteredOptions > 0;
-    this.setSelectedOption(undefined);
 
     this.formControlController.updateValidity();
     this.emit('syn-input');
   }
 
+  /**
+   * Checks if the current value is available in the options list.
+   * This is used to determine if the value is valid when the combobox is restricted.
+   *
+   * @returns `true` if the current value is available in the options list,
+   * otherwise `false`.
+   */
+  private isValidValue(): boolean {
+    const isValid = this.cachedOptions.some(
+      option => getValueFromOption(option) === this.value,
+    );
+    return isValid;
+  }
+
+  private getOptionFromValue(): SynOption | undefined {
+    return this.cachedOptions.find(option => getValueFromOption(option) === this.value);
+  }
+
+  /**
+   * Resets the value to the last valid value or to an empty string.
+   */
+  private resetToLastValidValue() {
+    let label = '';
+    let value = '';
+
+    if (this.lastOption) {
+      value = String(getValueFromOption(this.lastOption));
+      label = this.lastOption.getTextLabel();
+    }
+
+    this.value = value;
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateComplete.then(() => {
+      this.displayInput.value = label;
+      this.formControlController.updateValidity();
+    });
+  }
+
   private handleChange() {
     // Only update the value and emit the event, if the change event occurred by
     // the user typing something in and removing focus of the combobox
-    if (!this.selectedOption) {
-      this.value = this.displayInput.value;
-      // Update validity
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.updateComplete.then(() => {
-        this.formControlController.updateValidity();
-      });
-      this.emit('syn-change');
+    if (this.selectedOption) {
+      return;
     }
+
+    // If the value is not valid, we need to reset the value to the last valid value
+    if (this.restricted && !this.isValidValue() && this.value !== '') {
+      this.resetToLastValidValue();
+      return;
+    }
+
+    // Otherwise, update value from input and emit change
+    this.value = this.displayInput.value;
+    this.lastOption = this.getOptionFromValue();
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.updateComplete.then(() => {
+      this.formControlController.updateValidity();
+    });
+    this.emit('syn-change');
   }
 
   private getSlottedOptions() {
@@ -826,8 +883,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   private updateSelectedOptionFromValue(): void {
     // check if the value has a corresponding option via value or text content
     // for empty values use the text content, as then the values of the option are not set
-    const option = this.cachedOptions
-      .find(o => (o.value !== '' && o.value === this.value) || (o.getTextLabel() === this.value));
+    const option = this.getOptionFromValue();
 
     if (!option) {
       this.displayInput.value = this.value;

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -77,6 +77,7 @@ import { enableDefaultSettings } from '../../utilities/defaultSettings/decorator
  * @csspart expand-icon - The container that wraps the expand icon.
  * @csspart popup - The popup's exported `popup` part.
  * Use this to target the tooltip's popup container.
+ * @csspart no-results - The container that wraps the "no results" message.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -629,8 +630,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   @watch('open', { waitUntilFirstUpdate: true })
   async handleOpenChange() {
     if (this.open && !this.disabled) {
-      if (this.numberFilteredOptions === 0) {
-        // Don't open the listbox if there are no options
+      if (this.numberFilteredOptions === 0 && !this.restricted) {
+        // Don't open the listbox if there are no options and it is not restricted
         this.open = false;
         this.emit('syn-error');
         return;
@@ -786,7 +787,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     await this.updateComplete;
     this.isUserInput = false;
     this.lastOption = cachedLastOption;
-    this.open = this.numberFilteredOptions > 0;
+    this.open = this.restricted || this.numberFilteredOptions > 0;
 
     this.formControlController.updateValidity();
     this.emit('syn-input');
@@ -1061,6 +1062,14 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
               @mouseup=${this.handleOptionClick}
             >
               <div class="listbox__options" part="filtered-listbox">
+                ${this.numberFilteredOptions === 0
+                  ? html`<span
+                      class="listbox__no-results"
+                      aria-hidden="true"
+                      part="no-results"
+                      >${this.localize.term('noResults')}</span
+                    >`
+                  : ''}
                 <slot @slotchange=${this.handleDefaultSlotChange}></slot>      
               </div>
             </div>

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -198,7 +198,10 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   /** The combobox's required attribute. */
   @property({ reflect: true, type: Boolean }) required = false;
 
-  /** Defines if the combobox is restricted to the options list */
+  /**
+   * When set to `true`, restricts the combobox to only allow selection from the available options.
+   * Users will not be able to enter custom values that are not present in the list.
+   */
   @property({ reflect: true, type: Boolean }) restricted = false;
 
   /**

--- a/packages/components/src/components/combobox/combobox.custom.styles.ts
+++ b/packages/components/src/components/combobox/combobox.custom.styles.ts
@@ -11,5 +11,25 @@ export default css`
     display: none;
   }
 
+  .listbox__no-results {
+    align-items: center;
+    color: var(--syn-color-neutral-950);
+    display: flex;
+    font: var(--syn-body-medium-regular);
+    padding: var(--syn-spacing-small) var(--syn-spacing-medium) var(--syn-spacing-small) 52px;
+  }
+
+  .combobox--small .listbox__no-results {
+    font-size: var(--syn-input-font-size-small);
+    min-height: var(--syn-input-height-small);
+    padding: 0 var(--syn-spacing-small) 0 40px;
+  }
+
+  .combobox--large .listbox__no-results {
+    font-size: var(--syn-input-font-size-large);
+    min-height: var(--syn-input-height-large);
+    padding: 0 var(--syn-spacing-large) 0 68px;
+  }
+
   ${sharedOptionSize}
 `;

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -1346,5 +1346,73 @@ describe('<syn-combobox>', () => {
     await expect(el.displayLabel).to.equal('Option 1');
   });
 
+  describe('#626: when using `restricted` feature ', () => {
+    it('should reset the input to empty string for invalid user input', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox restricted>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      el.focus();
+      await sendKeys({ type: 'abc' });
+      el.blur();
+      await el.updateComplete;
+
+      expect(el.value).to.equal('');
+    });
+
+    it('should reset the input to last selected option for invalid user input', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox value="option-2" restricted>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      el.focus();
+      await sendKeys({ type: 'abc' });
+      el.blur();
+      await el.updateComplete;
+
+      expect(el.value).to.equal('option-2');
+    });
+
+    it('should reset to last selected option when setting invalid value programmatically', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox value="option-2" restricted>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+      el.value = 'invalid';
+      await aTimeout(0);
+
+      expect(el.displayInput.value).to.equal('Option 2');
+      expect(el.valueInput.value).to.equal('option-2');
+      expect(el.value).to.equal('option-2');
+    });
+
+    it('should reset to empty value when setting invalid value programmatically', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox restricted>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+      el.value = 'invalid';
+      await aTimeout(0);
+
+      expect(el.displayInput.value).to.equal('');
+      expect(el.valueInput.value).to.equal('');
+      expect(el.value).to.equal('');
+    });
+  });
+
   runFormControlBaseTests('syn-combobox');
 });

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -1412,6 +1412,26 @@ describe('<syn-combobox>', () => {
       expect(el.valueInput.value).to.equal('');
       expect(el.value).to.equal('');
     });
+
+    it('should open the listbox and show a message when a letter key is pressed with syn-combobox is on focus with no appropriate options', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox restricted>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+      const displayInput = el.shadowRoot!.querySelector<HTMLInputElement>('[part="display-input"]')!;
+      el.focus();
+      await el.updateComplete;
+      await sendKeys({ press: 'f' });
+      await el.updateComplete;
+      const filteredListbox = el.shadowRoot!.querySelector('[part="filtered-listbox"]')!;
+      const noResults = filteredListbox.querySelector('[part="no-results"]');
+      expect(displayInput.getAttribute('aria-expanded')).to.equal('true');
+      expect(noResults).to.exist;
+      expect(noResults!.textContent).to.equal('No results found');
+    });
   });
 
   runFormControlBaseTests('syn-combobox');

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -297,6 +297,80 @@ describe('<syn-combobox>', () => {
 
       expect(handler).to.be.calledTwice;
     });
+
+    it('should set the selected option to selected when the user types option value in the combobox', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
+
+      el.focus();
+      await sendKeys({ type: 'option-2' });
+      el.blur();
+      await el.updateComplete;
+      expect(secondOption.selected).to.be.true;
+    });
+
+    it('should set the selected option to selected when the user types option text content in the combobox', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
+
+      el.focus();
+      await sendKeys({ type: 'Option 2' });
+      el.blur();
+      await el.updateComplete;
+      expect(secondOption.selected).to.be.true;
+    });
+
+    it('should set the selected option to selected when the value is changed with the mouse', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+
+      await el.show();
+
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
+      await clickOnElement(secondOption);
+      await el.updateComplete;
+
+      expect(secondOption.selected).to.be.true;
+    });
+
+    it('should set the selected option to selected when the value is changed with the keyboard', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-combobox>
+      `);
+      const secondOption = el.querySelectorAll<SynOption>('syn-option')[1];
+
+      el.focus();
+      await el.updateComplete;
+      await sendKeys({ press: 'ArrowDown' }); // open the dropdown and move to first option
+      await el.updateComplete;
+      await sendKeys({ press: 'ArrowDown' }); // move selection to the second option
+      await el.updateComplete;
+      await sendKeys({ press: 'Enter' }); // commit the selection
+      await el.updateComplete;
+
+      expect(secondOption.selected).to.be.true;
+    });
   });
 
   describe('keyboard handling', () => {
@@ -1361,6 +1435,15 @@ describe('<syn-combobox>', () => {
       el.blur();
       await el.updateComplete;
 
+      // Unfortunately we need to wait for the popup animation to be finished,
+      // before the value is reset, as this was needed to not have a flickering listbox
+      const { popup } = el.popup;
+      await new Promise<void>((resolve) => {
+        popup.getAnimations()[0].onfinish = () => {
+          resolve();
+        };
+      });
+
       expect(el.value).to.equal('');
     });
 
@@ -1377,6 +1460,15 @@ describe('<syn-combobox>', () => {
       await sendKeys({ type: 'abc' });
       el.blur();
       await el.updateComplete;
+
+      // Unfortunately we need to wait for the popup animation to be finished,
+      // before the value is reset, as this was needed to not have a flickering listbox
+      const { popup } = el.popup;
+      await new Promise<void>((resolve) => {
+        popup.getAnimations()[0].onfinish = () => {
+          resolve();
+        };
+      });
 
       expect(el.value).to.equal('option-2');
     });

--- a/packages/components/src/components/combobox/utils.ts
+++ b/packages/components/src/components/combobox/utils.ts
@@ -94,3 +94,17 @@ export const createOptionFromDifferentTypes = (option: TemplateResult | string |
 
   return undefined;
 };
+
+/**
+ * Gets the value from an option. If an option has no value, it will use the text label.
+ * @param option The syn-option to get the value from
+ * @returns The value of the option
+ */
+export const getValueFromOption = (option: SynOption) => {
+  const { value } = option;
+  if (value === undefined || value === null || value === '') {
+    // If the option has no value, use the text label
+    return option.getTextLabel();
+  }
+  return value;
+};

--- a/packages/components/src/components/combobox/utils.ts
+++ b/packages/components/src/components/combobox/utils.ts
@@ -108,3 +108,19 @@ export const getValueFromOption = (option: SynOption) => {
   }
   return value;
 };
+
+/**
+ * Check if a value belongs to the value or text label of an option.
+ * @param value The value to check
+ * @param option The option to check against
+ * @returns True if the value belongs to the option, false otherwise
+ */
+export const checkValueBelongsToOption = (value: string, option: SynOption | undefined) => {
+  if (!option || !value) {
+    return false;
+  }
+
+  const optionValue = option.value;
+  const optionText = option.getTextLabel();
+  return value === optionValue || value === optionText;
+};

--- a/packages/components/src/translations/de.ts
+++ b/packages/components/src/translations/de.ts
@@ -47,10 +47,11 @@ const translation: Translation = {
   danger: 'Gefahr',
   fileButtonText: 'Datei auswählen',
   fileButtonTextMultiple: 'Dateien auswählen',
-  folderButtonText: 'Ordner auswählen',
   fileDragDrop: 'Datei ablegen oder auswählen',
+  folderButtonText: 'Ordner auswählen',
   folderDragDrop: 'Ordner ablegen oder auswählen',
   menu: 'Menü',
+  noResults: 'Keine Ergebnisse gefunden',
   notification: 'Benachrichtigung',
   numFilesSelected: (num, dir) => {
       if (num === 0) return `Keine ${dir ? 'Ordner' : 'Dateien'} ausgewählt`;

--- a/packages/components/src/translations/en.ts
+++ b/packages/components/src/translations/en.ts
@@ -47,10 +47,11 @@ const translation: Translation = {
   danger: 'Danger',
   fileButtonText: 'Choose file',
   fileButtonTextMultiple: 'Choose files',
-  folderButtonText: 'Choose folder',
   fileDragDrop: 'Drop or choose file',
+  folderButtonText: 'Choose folder',
   folderDragDrop: 'Drop or choose folder',
   menu: 'Menu',
+  noResults: 'No results found',
   notification: 'Notification',
   numFilesSelected: (num, dir) => {
       if (num === 0) return `No ${dir ? 'folder' : 'files'} chosen`;

--- a/packages/components/src/utilities/localize.ts
+++ b/packages/components/src/utilities/localize.ts
@@ -33,6 +33,7 @@ export interface Translation extends DefaultTranslation {
   folderButtonText: string;
   folderDragDrop: string;
   menu: string;
+  noResults: string;
   notification: string;
   numFilesSelected: (num: number, dir: boolean) => string;
   openMenu: string;

--- a/packages/docs/stories/components/combobox.stories.ts
+++ b/packages/docs/stories/components/combobox.stories.ts
@@ -535,6 +535,24 @@ export const CustomFilter: Story = {
   `,
 };
 
+export const Restricted: Story = {
+  parameters: {
+    docs: {
+      description: {
+        // TODO: add correct docs description asap
+        story: generateStoryDescription('combobox', 'label'),
+      },
+    },
+  },
+  render: () => html`
+    <syn-combobox label="State" restricted>
+      <syn-option>Option 1</syn-option>
+      <syn-option>Option 2</syn-option>
+      <syn-option>Option 3</syn-option>
+    </syn-combobox>
+  `,
+};
+
 // Bundled screenshot story
 /* eslint-disable sort-keys */
 export const Screenshot: Story = generateScreenshotStory({
@@ -548,5 +566,6 @@ export const Screenshot: Story = generateScreenshotStory({
   PrefixSuffixTextAndIcons,
   AsyncOptions,
   CustomFilter,
+  Restricted,
 }, 500);
 /* eslint-enable sort-keys */

--- a/packages/docs/stories/components/combobox.stories.ts
+++ b/packages/docs/stories/components/combobox.stories.ts
@@ -200,6 +200,55 @@ export const Disabled: Story = {
   `,
 };
 
+export const Restricted: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: generateStoryDescription('combobox', 'restrict-options'),
+      },
+    },
+  },
+  render: () => html`
+    <syn-combobox value="Option 1" restricted>
+      <syn-option>Option 1</syn-option>
+      <syn-option>Option 2</syn-option>
+      <syn-option>Option 3</syn-option>
+    </syn-combobox>
+  `,
+};
+
+export const NoResultsFound: Story = {
+  parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
+    docs: {
+      description: {
+        story: generateStoryDescription('combobox', 'no-results'),
+      },
+      story: {
+        inline: false,
+      },
+    },
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const combobox = canvasElement.querySelector<SynCombobox>('syn-combobox')!;
+    await combobox.updateComplete;
+    combobox.focus();
+    const input = combobox.shadowRoot?.querySelector('input');
+    if (input) {
+      await userEvent.type(input, 'Search term');
+    }
+  },
+  render: () => html`
+    <syn-combobox id="no-results" value="Search term" open restricted>
+      <syn-option>Option 1</syn-option>
+      <syn-option>Option 2</syn-option>
+      <syn-option>Option 3</syn-option>
+    </syn-combobox>
+  `,
+};
+
 export const Sizes: Story = {
   parameters: {
     docs: {
@@ -535,24 +584,6 @@ export const CustomFilter: Story = {
   `,
 };
 
-export const Restricted: Story = {
-  parameters: {
-    docs: {
-      description: {
-        // TODO: add correct docs description asap
-        story: generateStoryDescription('combobox', 'label'),
-      },
-    },
-  },
-  render: () => html`
-    <syn-combobox label="State" restricted>
-      <syn-option>Option 1</syn-option>
-      <syn-option>Option 2</syn-option>
-      <syn-option>Option 3</syn-option>
-    </syn-combobox>
-  `,
-};
-
 // Bundled screenshot story
 /* eslint-disable sort-keys */
 export const Screenshot: Story = generateScreenshotStory({
@@ -562,10 +593,10 @@ export const Screenshot: Story = generateScreenshotStory({
   Placeholder,
   Clearable,
   Disabled,
+  Restricted,
   Sizes,
   PrefixSuffixTextAndIcons,
   AsyncOptions,
   CustomFilter,
-  Restricted,
 }, 500);
 /* eslint-enable sort-keys */

--- a/packages/docs/stories/components/combobox.stories.ts
+++ b/packages/docs/stories/components/combobox.stories.ts
@@ -210,9 +210,9 @@ export const Restricted: Story = {
   },
   render: () => html`
     <syn-combobox value="Option 1" restricted>
-      <syn-option>Option 1</syn-option>
-      <syn-option>Option 2</syn-option>
-      <syn-option>Option 3</syn-option>
+      <syn-option value="option-1">Option 1</syn-option>
+      <syn-option value="option-2">Option 2</syn-option>
+      <syn-option value="option-3">Option 3</syn-option>
     </syn-combobox>
   `,
 };

--- a/packages/react/src/components/combobox.ts
+++ b/packages/react/src/components/combobox.ts
@@ -71,6 +71,7 @@ Component.define('syn-combobox');
  * @csspart expand-icon - The container that wraps the expand icon.
  * @csspart popup - The popup's exported `popup` part.
  * Use this to target the tooltip's popup container.
+ * @csspart no-results - The container that wraps the "no results" message.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.

--- a/packages/react/src/types/syn-jsx-elements.ts
+++ b/packages/react/src/types/syn-jsx-elements.ts
@@ -342,6 +342,7 @@ export type SynCustomElement<
  * @csspart expand-icon - The container that wraps the expand icon.
  * @csspart popup - The popup's exported `popup` part.
  * Use this to target the tooltip's popup container.
+ * @csspart no-results - The container that wraps the "no results" message.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -1716,6 +1717,7 @@ declare module 'react' {
        * @csspart expand-icon - The container that wraps the expand icon.
        * @csspart popup - The popup's exported `popup` part.
        * Use this to target the tooltip's popup container.
+       * @csspart no-results - The container that wraps the "no results" message.
        *
        * @animation combobox.show - The animation to use when showing the combobox.
        * @animation combobox.hide - The animation to use when hiding the combobox.

--- a/packages/tokens/src/figma-tokens/_docs.json
+++ b/packages/tokens/src/figma-tokens/_docs.json
@@ -3333,6 +3333,36 @@
           "type": "text"
         }
       },
+      "multiple": {
+        "title": {
+          "value": "Multiple",
+          "type": "text"
+        },
+        "description": {
+          "value": "To allow multiple options to be selected, use the multiple attribute. It’s a good practice to use clearable when this option is enabled. To set multiple values at once, set value to a space-delimited list of values. \n\nUse the max-options-visible attribute to define the maximum number of selected options that will be visible. After the maximum, \"+n\" will be shown to indicate the number of additional items that are selected.",
+          "type": "text"
+        }
+      },
+      "initial-values": {
+        "title": {
+          "value": "Setting Initial Values",
+          "type": "text"
+        },
+        "description": {
+          "value": "Use the value attribute to set the initial selection.\n\nWhen using multiple, the value attribute uses space-delimited values to select more than one option. Because of this, <syn-option> values cannot contain spaces. If you’re accessing the value property through Javascript, it will be an array.",
+          "type": "text"
+        }
+      },
+      "no-results": {
+        "title": {
+          "value": "No results found",
+          "type": "text"
+        },
+        "description": {
+          "value": "A “No results found” message is displayed, when the search term doesn’t match the options.",
+          "type": "text"
+        }
+      },
       "size": {
         "title": {
           "value": "Sizes",

--- a/packages/tokens/src/figma-tokens/_docs.json
+++ b/packages/tokens/src/figma-tokens/_docs.json
@@ -3345,11 +3345,21 @@
       },
       "initial-values": {
         "title": {
-          "value": "Setting Initial Values",
+          "value": "Setting initial values",
           "type": "text"
         },
         "description": {
           "value": "Use the value attribute to set the initial selection.\n\nWhen using multiple, the value attribute uses space-delimited values to select more than one option. Because of this, <syn-option> values cannot contain spaces. If you’re accessing the value property through Javascript, it will be an array.",
+          "type": "text"
+        }
+      },
+      "restrict-options": {
+        "title": {
+          "value": "Restrict options",
+          "type": "text"
+        },
+        "description": {
+          "value": "This restricts the combobox to only allow selections from the available options. Users cannot enter custom values that are not in the list.",
           "type": "text"
         }
       },

--- a/packages/vue/src/components/SynVueCombobox.vue
+++ b/packages/vue/src/components/SynVueCombobox.vue
@@ -159,8 +159,9 @@ The form must be in the same document or shadow root for this to work.
   required?: SynCombobox['required'];
 
   /**
-   * Defines if the combobox is restricted to the options list
-   */
+* When set to `true`, restricts the combobox to only allow selection from the available options.
+Users will not be able to enter custom values that are not present in the list.
+ */
   restricted?: SynCombobox['restricted'];
 
   /**

--- a/packages/vue/src/components/SynVueCombobox.vue
+++ b/packages/vue/src/components/SynVueCombobox.vue
@@ -53,6 +53,7 @@
  * @csspart expand-icon - The container that wraps the expand icon.
  * @csspart popup - The popup's exported `popup` part.
  * Use this to target the tooltip's popup container.
+ * @csspart no-results - The container that wraps the "no results" message.
  *
  * @animation combobox.show - The animation to use when showing the combobox.
  * @animation combobox.hide - The animation to use when hiding the combobox.
@@ -156,6 +157,11 @@ The form must be in the same document or shadow root for this to work.
    * The combobox's required attribute.
    */
   required?: SynCombobox['required'];
+
+  /**
+   * Defines if the combobox is restricted to the options list
+   */
+  restricted?: SynCombobox['restricted'];
 
   /**
 * A function that customizes the rendered option.


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds the `restricted` property to the syn-combobox. Additionally the selected state is added to the syn-combobox, not only for `restricted`, but for all.

### 🎫 Issues
Closes #626 

## 👩‍💻 Reviewer Notes
- is the property naming  (`restricted`) okay?
- feels the behavior correct?

## 📑 Test Plan

Have a look at the changes and how the new behavior feels like as well as the new stories.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [ ] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have used design tokens instead of fix css values
