### PR TITLE
fix: 🐛 syn-validate - Incorrect state of form element if setting customValidationMessage via custom event

### DIFF
--- a/packages/_private/angular-demo/src/AllComponentParts/Validate.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Validate.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { SynInputComponent } from '@synergy-design-system/angular/components/input';
 import { SynValidateComponent } from '@synergy-design-system/angular/components/validate';
 
@@ -18,6 +18,18 @@ import { SynValidateComponent } from '@synergy-design-system/angular/components/
         required
       />
     </syn-validate>
+
+    <syn-validate #validate915 data-testid="validate-915" on="revalidate" variant="inline">
+      <syn-input #input915 label="Incorrect state with custom event #915" (synChangeEvent)="setError('Invalid value')"/>
+    </syn-validate>
   `,
 })
-export class Validate {}
+export class Validate {
+  @ViewChild('input915') input!: SynInputComponent;
+  @ViewChild('validate915') validate!: SynValidateComponent;
+
+  setError(message: string) {
+    this.validate.customValidationMessage = message;
+    this.input.nativeElement.dispatchEvent(new CustomEvent('revalidate', { bubbles: true}));
+  }
+}

--- a/packages/_private/e2e-demo-test/src/AllComponents/SynValidate.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynValidate.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
+import { SynChangeEvent } from '@synergy-design-system/components';
 import { AllComponentsPage } from '../PageObjects/index.js';
 import { createTestCases, fillInput, hasEvent } from '../helpers.js';
-import { SynChangeEvent } from '@synergy-design-system/components';
 
 test.describe('<SynValidate />', () => {
   createTestCases(({ name, port }) => {
@@ -17,11 +17,10 @@ test.describe('<SynValidate />', () => {
         const validate = AllComponents.getLocator('validate915');
         const input = validate.locator('syn-input');
         const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
-              //     const waitForClamp = hasNoEvent<SynClampEvent>(page, 'syn-clamp');
-        
+
         await fillInput(input, 'invalid');
         await waitForChange;
-      
+
         await expect(input, 'data-invalid attribute should be available').toHaveAttribute('data-invalid', '');
         await expect(input, 'data-user-invalid attribute should be available').toHaveAttribute('data-user-invalid', '');
       });

--- a/packages/_private/e2e-demo-test/src/AllComponents/SynValidate.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynValidate.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { AllComponentsPage } from '../PageObjects/index.js';
+import { createTestCases, fillInput, hasEvent } from '../helpers.js';
+import { SynChangeEvent } from '@synergy-design-system/components';
+
+test.describe('<SynValidate />', () => {
+  createTestCases(({ name, port }) => {
+    test.describe(`Regression#915: ${name}`, () => {
+      test('should have data-user-invalid attribute after revalidation was triggered via custom event', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+
+        // Initial state should be the first item is open
+        await AllComponents.activateItem('validateLink');
+        await expect(AllComponents.getLocator('validateContent')).toBeVisible();
+
+        const validate = AllComponents.getLocator('validate915');
+        const input = validate.locator('syn-input');
+        const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
+              //     const waitForClamp = hasNoEvent<SynClampEvent>(page, 'syn-clamp');
+        
+        await fillInput(input, 'invalid');
+        await waitForChange;
+      
+        await expect(input, 'data-invalid attribute should be available').toHaveAttribute('data-invalid', '');
+        await expect(input, 'data-user-invalid attribute should be available').toHaveAttribute('data-user-invalid', '');
+      });
+    }); // regression#915
+  }); // End frameworks
+}); // </syn-accordion>

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -74,6 +74,11 @@ const AllComponentSelectors = {
   tabGroupCustom: '#tab-content-TabGroup syn-tab:nth-of-type(3)',
   tabGroupGeneral: '#tab-content-TabGroup syn-tab:nth-of-type(1)',
   tabGroupLink: '#tab-TabGroup',
+
+  // Validate
+  validateContent: '#tab-content-Validate',
+  validateLink: '#tab-Validate',
+  validate915: '#tab-content-Validate syn-validate[data-testid="validate-915"]',
 };
 
 export default {

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -78,9 +78,9 @@ const AllComponentSelectors = {
   tabGroupLink: '#tab-TabGroup',
 
   // Validate
+  validate915: '#tab-content-Validate syn-validate[data-testid="validate-915"]',
   validateContent: '#tab-content-Validate',
   validateLink: '#tab-Validate',
-  validate915: '#tab-content-Validate syn-validate[data-testid="validate-915"]',
 };
 
 export default {

--- a/packages/_private/react-demo/src/AllComponentParts/Validate.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Validate.tsx
@@ -1,10 +1,27 @@
-export const Validate = () => (
-  <syn-validate eager variant="inline" on="live">
-    <syn-input
-      label="Invalid input"
-      type="email"
-      value=""
-      required
-    />
-  </syn-validate>
-);
+import type { SynInput } from '@synergy-design-system/components';
+import { useLayoutEffect, useRef, useState } from 'react';
+
+export const Validate = () => {
+  const [errorMsg, setError] = useState<string>('');
+  const inputRef = useRef<SynInput>(null);
+  useLayoutEffect(() => {
+    inputRef.current?.dispatchEvent(new CustomEvent('revalidate'));
+  }, [errorMsg]);
+
+  return (
+    <>
+      <syn-validate eager variant="inline" on="live">
+        <syn-input
+          label="Invalid input"
+          type="email"
+          value=""
+          required
+        />
+      </syn-validate>
+
+      <syn-validate data-testid="validate-915" on="revalidate" customValidationMessage={errorMsg} variant="inline">
+        <syn-input label="Incorrect state with custom event #915" ref={inputRef} onsyn-change={() => setError('Invalid value')} />
+      </syn-validate>
+    </>
+  );
+};

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Validate.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Validate.ts
@@ -1,12 +1,24 @@
 import { html } from 'lit';
+import { RegressionFns } from '../all-components-regressions';
 
-export const Validate = () => html`
-  <syn-validate eager variant="inline" on="live">
-    <syn-input
-      label="Invalid input"
-      type="email"
-      value=""
-      required
-    ></syn-input>
-  </syn-validate>
-`;
+export const Validate = (regressions: RegressionFns = []) => {
+  regressions.forEach((regression) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    regression();
+  });
+
+  return html`
+    <syn-validate eager variant="inline" on="live">
+      <syn-input
+        label="Invalid input"
+        type="email"
+        value=""
+        required
+      ></syn-input>
+    </syn-validate>
+
+    <syn-validate data-testid="validate-915" on="revalidate" variant="inline">
+      <syn-input label="Incorrect state with custom event #915"></syn-input>
+    </syn-validate>
+  `;
+};

--- a/packages/_private/vanilla-demo/src/all-components-regressions.ts
+++ b/packages/_private/vanilla-demo/src/all-components-regressions.ts
@@ -50,7 +50,7 @@ const revalidateValidate = async () => {
     validate.customValidationMessage = 'Invalid value';
     input.dispatchEvent(new CustomEvent('revalidate'));
   });
-}
+};
 
 export type RegressionFn = () => Promise<void> | void;
 export type RegressionFns = RegressionFn[];

--- a/packages/_private/vanilla-demo/src/all-components-regressions.ts
+++ b/packages/_private/vanilla-demo/src/all-components-regressions.ts
@@ -2,8 +2,10 @@ import type { LitElement } from 'lit';
 import type {
   SynButton,
   SynDialog,
+  SynInput,
   SynTabGroup,
   SynTabShowEvent,
+  SynValidate,
 } from '@synergy-design-system/components';
 import { mockAsyncData, mockData } from '@synergy-design-system/demo-utilities';
 
@@ -39,6 +41,16 @@ const appendOptions813 = async (querySelector: string) => {
     element.appendChild(option);
   });
 };
+
+const revalidateValidate = async () => {
+  const allComponents = await getAllComponentsElement();
+  const validate = allComponents?.shadowRoot?.querySelector('syn-validate[data-testid="validate-915"]') as SynValidate;
+  const input = validate.querySelector('syn-input') as SynInput;
+  input.addEventListener('syn-change', () => {
+    validate.customValidationMessage = 'Invalid value';
+    input.dispatchEvent(new CustomEvent('revalidate'));
+  });
+}
 
 export type RegressionFn = () => Promise<void> | void;
 export type RegressionFns = RegressionFn[];
@@ -95,5 +107,9 @@ export const allComponentsRegressions: Regressions = new Map(Object.entries({
         tabGroup.appendChild(newTabPanel);
       });
     },
+  ],
+  Validate: [
+    // #915
+    () => revalidateValidate(),
   ],
 }));

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoValidate.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoValidate.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
 import { SynVueValidate, SynVueInput } from '@synergy-design-system/vue';
+import { ref } from 'vue';
+
+const errorMessage = ref<string>('');
+const inputRef = ref<InstanceType<typeof SynVueInput>>();
+
+const setError = (message: string) => {
+  errorMessage.value = message;
+  Promise.resolve().then(() => {
+    inputRef.value?.nativeElement?.dispatchEvent(new CustomEvent('revalidate', { bubbles: true}));
+  });
+};
+
 </script>
 
 <template>
@@ -9,6 +21,14 @@ import { SynVueValidate, SynVueInput } from '@synergy-design-system/vue';
       type="email"
       value=""
       required
+    />
+  </SynVueValidate>
+
+  <SynVueValidate data-testid="validate-915" on="revalidate" variant="inline" :custom-validation-message="errorMessage">
+    <SynVueInput
+      label="Incorrect state with custom event #915" 
+      @syn-change="setError('Invalid value')"
+      ref="inputRef"
     />
   </SynVueValidate>
 </template>

--- a/packages/components/src/components/validate/validate.component.ts
+++ b/packages/components/src/components/validate/validate.component.ts
@@ -270,24 +270,14 @@ export default class SynValidate extends SynergyElement {
     input.focus();
   }
 
-  /**
-   * Triggers a validation run, showing the validation message if needed.
-   */
   // eslint-disable-next-line complexity
-  private validate = (e: Event) => {
-    // Make sure to stop the validate component from going into an endless cycle of triggering
-    if (isInvalidEvent(e.type) && this.variant === 'native' && this.isInternalTriggeredInvalid === true) {
-      this.isInternalTriggeredInvalid = false;
-      return;
-    }
-
-    // Make sure to always prevent the invalid event when not using native validation
-    if (isInvalidEvent(e.type) && this.variant !== 'native') {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
+  private handleValidate = async (e: Event) => {
     const input = e.currentTarget as HTMLInputElement;
+    if (input instanceof SynergyElement) {
+      // When using a synergy element, we need to wait for it to be ready!
+      // This is needed as the validity state of the element may not be set yet.
+      await input.updateComplete;
+    }
     this.isValid = input.validity?.valid;
 
     // When we are using eager, make sure to skip focus on the first mount
@@ -314,6 +304,27 @@ export default class SynValidate extends SynergyElement {
         input.reportValidity();
       });
     }
+  };
+
+  /**
+   * Triggers a validation run, showing the validation message if needed.
+   */
+  // eslint-disable-next-line complexity
+  private validate = (e: Event) => {
+    // Make sure to stop the validate component from going into an endless cycle of triggering
+    if (isInvalidEvent(e.type) && this.variant === 'native' && this.isInternalTriggeredInvalid === true) {
+      this.isInternalTriggeredInvalid = false;
+      return;
+    }
+
+    // Make sure to always prevent the invalid event when not using native validation
+    if (isInvalidEvent(e.type) && this.variant !== 'native') {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.handleValidate(e);
   };
 
   async firstUpdated(changedProperties: PropertyValues) {

--- a/packages/components/src/components/validate/validate.component.ts
+++ b/packages/components/src/components/validate/validate.component.ts
@@ -271,7 +271,6 @@ export default class SynValidate extends SynergyElement {
     input.focus();
   }
 
-
   /**
    * Triggers a validation run, showing the validation message if needed.
    */

--- a/packages/components/src/components/validate/validate.test.ts
+++ b/packages/components/src/components/validate/validate.test.ts
@@ -130,9 +130,9 @@ describe('<syn-validate>', () => {
 
       // Trigger another validation run to make sure it works
       input.value = 'test';
-      await input.updateComplete;
       input.focus();
       input.blur();
+      await input.updateComplete;
 
       const isValid = el.getValidity();
       await expect(isValid).to.equal(false);
@@ -308,9 +308,9 @@ describe('<syn-validate>', () => {
 
       const input = el.querySelector('syn-input')!;
       input.value = 'test';
-      await input.updateComplete;
       input.focus();
       input.blur();
+      await input.updateComplete;
 
       // email address is the only part that all three browsers have in common.
       // Could also check for non empty values, but it makes it more brittle.
@@ -330,8 +330,8 @@ describe('<syn-validate>', () => {
       await expect(el.validationMessage).to.equal('');
 
       input.value = 'test';
-      await input.updateComplete;
       input.dispatchEvent(new Event('syn-change', { bubbles: true }));
+      await input.updateComplete;
 
       expect(el.validationMessage).to.include('email address');
 
@@ -351,14 +351,14 @@ describe('<syn-validate>', () => {
 
       input.focus();
       input.value = 'test';
-      await input.updateComplete;
       input.blur();
+      await input.updateComplete;
       expect(el.validationMessage).to.include('email address');
 
       input.focus();
       input.value = 'test@example';
-      await input.updateComplete;
       input.blur();
+      await input.updateComplete;
       await expect(el.validationMessage).to.equal('');
     });
 
@@ -398,8 +398,8 @@ describe('<syn-validate>', () => {
 
       input.value = 'test';
       input.dispatchEvent(new Event('syn-input'));
+      await input.updateComplete;
       await el.updateComplete;
-
       expect(reportValiditySpy).to.have.been.calledOnce;
     });
 
@@ -453,6 +453,7 @@ describe('<syn-validate>', () => {
 
       input.value = 'test';
       input.dispatchEvent(new Event('syn-input'));
+      await input.updateComplete;
       await el.updateComplete;
 
       expect(input.hasAttribute('data-user-invalid')).to.be.true;

--- a/packages/components/src/components/validate/validate.test.ts
+++ b/packages/components/src/components/validate/validate.test.ts
@@ -556,5 +556,31 @@ describe('<syn-validate>', () => {
         }); // property (disabled or readonly)
       }); // Element type (SynInput or HTMLInputElement)
     }); // End test #717
+
+    describe('#915: should set correct invalid state for custom "on" event', () => {
+      it('Should set the data-user-invalid attribute correctly for syn-input', async () => {
+        const event = 'syn-change';
+
+        const validate = await fixture<SynValidate>(html`
+          <syn-validate on="revalidate">
+            <syn-input></syn-input>
+          </syn-validate>
+        `);
+
+        const input = validate.querySelector('syn-input')!;
+        input.addEventListener(event, () => {
+          validate.customValidationMessage = 'invalid';
+          input.dispatchEvent(new CustomEvent('revalidate', { bubbles: true }));
+        });
+
+        input.value = 'test';
+        input.dispatchEvent(new Event(event));
+        await validate.updateComplete;
+
+        expect(input.validationMessage).to.include('invalid');
+        expect(input.hasAttribute('data-user-invalid'), 'data-user-invalid attribute should be available').to.be.true;
+        expect(validate.getValidity(), 'syn-validate should be invalid').to.be.false;
+      });
+    }); // End test #915
   }); // End regression tests
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "packages/*"
   - "packages/_private/*"
+# Needed because of following issue: https://github.com/microsoft/vscode-eslint/issues/1986#issuecomment-2799868163
+publicHoistPattern:
+  - "*eslint*" # this seems to be needed as long as we are using eslint v8


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the problem, that potentially the form element is not shown with red border, if a custom event for the `on` property is used.

### 🎫 Issues

Closes #915 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

Have a look at the demo pages and tests.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have used design tokens instead of fix css values
