### PR TITLE
fix: 🐛 syn-header with syn-side-nav burger menu stops working

### DIFF
--- a/packages/_private/angular-demo/src/app.component.html
+++ b/packages/_private/angular-demo/src/app.component.html
@@ -41,6 +41,21 @@
       Framework specific issues
       <syn-icon name="bug_report" slot="prefix"></syn-icon>
     </syn-nav-item>
+
+    <!-- e2e tests for issue #921 -->
+    <syn-nav-item open id="header921" slot="footer">
+      <syn-icon name="wallpaper" slot="prefix"></syn-icon>
+      Fix#921 (first level)
+
+      <syn-nav-item open slot="children">
+        <syn-icon name="wallpaper" slot="prefix"></syn-icon>
+        Fix#921 (second level)
+        <syn-nav-item slot="children">
+          <syn-icon name="wallpaper" slot="prefix"></syn-icon>
+          Fix#921 (third level)
+        </syn-nav-item>
+      </syn-nav-item>
+    </syn-nav-item>
   </syn-side-nav>
   <main class="content">
     <router-outlet></router-outlet>

--- a/packages/_private/e2e-demo-test/src/AppShell.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AppShell.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import {
+  type SynSideNav,
+} from '@synergy-design-system/components';
+import { AppShellPage } from './PageObjects/index.js';
+import {
+  createTestCases,
+  setPropertyForLocator,
+} from './helpers.js';
+
+// Default application shell tests
+test.describe('AppShell', () => {
+  test.describe('<SynHeader>', () => {
+    createTestCases(({ name, port }) => {
+      test.describe(`Regression#921: ${name}`, () => {
+        test('should allow to close connected <SynSideNav> when using variant="default" and sub menus are opened or closed', async ({ page }) => {
+          const appShell = new AppShellPage(page, port);
+          await appShell.loadInitialPage();
+
+          const header = await appShell.getLocator('appHeader');
+          const sideNav = await appShell.getLocator('appSideNav');
+          const header921 = await appShell.getLocator('header921NavItem');
+
+          // Assert that everything works as expected
+          await expect(header).toBeVisible();
+          await expect(sideNav).toBeVisible();
+
+          // Toggle the side nav to use the burger menu
+          await setPropertyForLocator<SynSideNav>(sideNav, 'variant', 'default');
+
+          // Check that the initial state is correct
+          await expect(sideNav).toBeHidden();
+          await expect(sideNav).toHaveAttribute('variant', 'default');
+          await expect(header).toHaveAttribute('burger-menu', 'closed');
+
+          // Open the side nav
+          await setPropertyForLocator<SynSideNav>(sideNav, 'open', true);
+
+          await expect(sideNav).toBeVisible();
+          await expect(header).toHaveAttribute('burger-menu', 'open');
+          await expect(header921).toBeVisible();
+
+          // Click the defect nested syn-nav-item.
+          // With the bug present, the side nav will not close
+          // when the header burger menu toggle is used
+          await expect(header).toHaveAttribute('burger-menu', 'open');
+
+          // I would have liked to click the <summary> itself, but webkit does not let me :(
+          await header921.locator('.nav-item__content').first().click();
+
+          await expect(header921).not.toHaveAttribute('open');
+
+          // Now, we try to toggle the side nav via the burger menu button
+          await header.locator('.header__burger-menu-toggle').click();
+
+          await expect(header).toHaveAttribute('burger-menu', 'closed');
+          await expect(sideNav).toBeHidden();
+        });
+      });
+    });
+  });
+});

--- a/packages/_private/e2e-demo-test/src/AppShell.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AppShell.spec.ts
@@ -13,7 +13,12 @@ test.describe('AppShell', () => {
   test.describe('<SynHeader>', () => {
     createTestCases(({ name, port }) => {
       test.describe(`Regression#921: ${name}`, () => {
-        test('should allow to close connected <SynSideNav> when using variant="default" and sub menus are opened or closed', async ({ page }) => {
+        test('should allow to close connected <SynSideNav> when using variant="default" and sub menus are opened or closed', async ({ browserName, page }) => {
+          // Webkit is having issues with the burger menu toggle
+          // It reports false positives half the time for the burger menu state
+          // Therefore, we skip this test in webkit
+          test.skip(browserName === 'webkit', 'Not supported in Safari/WebKit');
+
           const appShell = new AppShellPage(page, port);
           await appShell.loadInitialPage();
 

--- a/packages/_private/e2e-demo-test/src/PageObjects/AllComponents.ts
+++ b/packages/_private/e2e-demo-test/src/PageObjects/AllComponents.ts
@@ -11,13 +11,4 @@ export class AllComponentsPage extends PageObject {
     const foundLocator = this.getLocator(locator);
     await foundLocator.click();
   }
-
-  getLocator(locator: keyof typeof selectors) {
-    const locatorFound = selectors[locator];
-
-    if (typeof locatorFound === 'undefined') {
-      throw new Error(`Locator not found: ${locator}`);
-    }
-    return this.page.locator(selectors[locator]);
-  }
 }

--- a/packages/_private/e2e-demo-test/src/PageObjects/AppShell.ts
+++ b/packages/_private/e2e-demo-test/src/PageObjects/AppShell.ts
@@ -1,0 +1,10 @@
+import { PageObject } from './PageObject.js';
+import { BaseFormObject } from './BaseForm.js';
+
+/**
+ * Page object for the app shell
+ * This tests the app shell layout and functionality such as header and side-nav
+ */
+export class AppShellPage extends BaseFormObject {
+  protected initialPage: string = PageObject.availablePages.index;
+}

--- a/packages/_private/e2e-demo-test/src/PageObjects/PageObject.ts
+++ b/packages/_private/e2e-demo-test/src/PageObjects/PageObject.ts
@@ -48,6 +48,28 @@ export class PageObject {
     return this.page.locator(selectors.themeSwitch);
   }
 
+  /**
+   * Returns a locator for the given selector key.
+   * This is useful for accessing elements in the page using the predefined selectors.
+   *
+   * @param locator - The locator to find
+   * @throws Will throw an error if the locator is not found
+   *
+   * @example
+   * const myLocator = pageObject.getLocator('mySelectorKey');
+   * await myLocator.click();
+   *
+   * @returns Locator - The Playwright Locator for the given selector key.
+   */
+  getLocator(locator: keyof typeof selectors) {
+    const locatorFound = selectors[locator];
+
+    if (typeof locatorFound === 'undefined') {
+      throw new Error(`Locator not found: ${locator}`);
+    }
+    return this.page.locator(selectors[locator]);
+  }
+
   public getSizeToggle(size: 'small' | 'medium' | 'large'): Locator {
     switch (size) {
     case 'small':

--- a/packages/_private/e2e-demo-test/src/PageObjects/index.ts
+++ b/packages/_private/e2e-demo-test/src/PageObjects/index.ts
@@ -1,4 +1,5 @@
 export * from './AllComponents.js';
+export * from './AppShell.js'
 export * from './DemoForm.js';
 export * from './DemoFormValidate.js';
 export * from './PageObject.js';

--- a/packages/_private/e2e-demo-test/src/PageObjects/index.ts
+++ b/packages/_private/e2e-demo-test/src/PageObjects/index.ts
@@ -1,5 +1,5 @@
 export * from './AllComponents.js';
-export * from './AppShell.js'
+export * from './AppShell.js';
 export * from './DemoForm.js';
 export * from './DemoFormValidate.js';
 export * from './PageObject.js';

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -1,3 +1,11 @@
+const AppShellSelectors = {
+  appHeader: 'syn-header',
+  appSideNav: 'syn-side-nav',
+
+  // Regressions for #921
+  header921NavItem: '#header921',
+};
+
 const AllComponentSelectors = {
   // Accordion
   accordionContent: '#tab-content-Accordion',
@@ -85,6 +93,7 @@ const AllComponentSelectors = {
 
 export default {
   ...AllComponentSelectors,
+  ...AppShellSelectors,
   addInfoLoc: '#additional-info',
   angular: 'syn-option[value=angular]',
   birth: '#input-date',

--- a/packages/_private/react-demo/src/Layout.tsx
+++ b/packages/_private/react-demo/src/Layout.tsx
@@ -67,6 +67,21 @@ export const Layout: FC = () => {
             Framework specific issues
             <SynIcon name="bug_report" slot="prefix" />
           </RouterLink>
+
+          { /* e2e tests for issue #921 */}
+          <syn-nav-item open id="header921" slot="footer">
+            <syn-icon name="wallpaper" slot="prefix" />
+            Fix#921 (first level)
+
+            <syn-nav-item open slot="children">
+              <syn-icon name="wallpaper" slot="prefix" />
+              Fix#921 (second level)
+              <syn-nav-item slot="children">
+                <syn-icon name="wallpaper" slot="prefix" />
+                Fix#921 (third level)
+              </syn-nav-item>
+            </syn-nav-item>
+          </syn-nav-item>
         </SynSideNav>
         <main className="content">
           <Outlet />

--- a/packages/_private/vanilla-demo/src/layout.ts
+++ b/packages/_private/vanilla-demo/src/layout.ts
@@ -110,6 +110,21 @@ export const createLayout = () => `
         Framework specific issues
         <syn-icon name="bug_report" slot="prefix"></syn-icon>
       </syn-nav-item>
+
+      <!-- e2e tests for issue #921 -->
+      <syn-nav-item open id="header921" slot="footer">
+        <syn-icon name="wallpaper" slot="prefix"></syn-icon>
+        Fix#921 (first level)
+
+        <syn-nav-item open slot="children">
+          <syn-icon name="wallpaper" slot="prefix"></syn-icon>
+          Fix#921 (second level)
+          <syn-nav-item slot="children">
+            <syn-icon name="wallpaper" slot="prefix"></syn-icon>
+            Fix#921 (third level)
+          </syn-nav-item>
+        </syn-nav-item>
+      </syn-nav-item>
     </syn-side-nav>
     <!-- /side-nav -->
 

--- a/packages/_private/vue-demo/src/App.vue
+++ b/packages/_private/vue-demo/src/App.vue
@@ -51,6 +51,21 @@ const routeTo = (route: string) => {
         Framework specific issues
         <SynVueIcon name="bug_report" slot="prefix"/>
       </SynVueNavItem>
+
+      <!-- e2e tests for issue #921 -->
+      <SynVueNavItem open id="header921" slot="footer">
+        <SynVueIcon name="wallpaper" slot="prefix" />
+        Fix#921 (first level)
+
+        <SynVueNavItem open slot="children">
+          <SynVueIcon name="wallpaper" slot="prefix" />
+          Fix#921 (second level)
+          <SynVueNavItem slot="children">
+            <SynVueIcon name="wallpaper" slot="prefix" />
+            Fix#921 (third level)
+          </SynVueNavItem>
+        </SynVueNavItem>
+      </SynVueNavItem>
     </SynVueSideNav>
     <main class="content">
       <RouterView />

--- a/packages/components/src/components/header/header.component.ts
+++ b/packages/components/src/components/header/header.component.ts
@@ -170,11 +170,20 @@ export default class SynHeader extends SynergyElement {
 
       // #587: Make sure to not trigger the burger menu if the side nav is currently
       // animating and the user clicks on the burger menu button.
-      const isAnimating = () => {
+
+      // #921: Make sure to only trigger this if the source of the element is the side nav.
+      // This is because syn-nav-item also triggers show and hide events when opened or closed.
+      const isAnimating = (e: Event) => {
+        if (e.target !== this.sideNav) {
+          return;
+        }
         this.isSideNavAnimating = true;
       };
 
-      const isNotAnimating = () => {
+      const isNotAnimating = (e: Event) => {
+        if (e.target !== this.sideNav) {
+          return;
+        }
         this.isSideNavAnimating = false;
       };
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue with a specific combination of `<syn-header>` and `<syn-side-nav>` when using the `default` value for `<syn-side-nav>`'s `variant`.

The issue is caused by a side effect of #587. We opted to check for the `<syn-side-nav>`'s `syn-hide` and `syn-show` events to check if it is still animating. However, nested `<syn-nav-item>` elements **also emit** the same events when opened or closed. As this [was not scoped in our code](https://github.com/synergy-design-system/synergy-design-system/blob/main/packages/components/src/components/header/header.component.ts#L173), the header set its `isAnimating` property to true when the `<syn-nav-item>` was toggeled to open state.

This is now fixed by checking the root element of the event that is emitted. We now only toggle the `isAnimating` private property if the source of the event is the connected `<syn-side-nav>` element.

### 🎫 Issues

Closes #921

## 👩‍💻 Reviewer Notes

I also added regression tests in our demo projects. For this, a new section was added to the rendered side bar, containing a nested navigation example.

## 📑 Test Plan

Have a look at the main branch and add the side nav code samples. Notice that after toggling the nested navigation, you are no longer able to close the side nav via the menu button. Do the same with this new branch and see it working.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [ ] ~~I have used design tokens instead of fix css values~~
