### PR TITLE
chore: 🔧 Fix timing issues in e2e tests

### DIFF
--- a/packages/_private/e2e-demo-test/src/AllComponents/SynCombobox.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynCombobox.spec.ts
@@ -1,11 +1,10 @@
 import { expect, test } from '@playwright/test';
 import {
-  type SynChangeEvent,
   type SynCombobox,
   type SynSelect,
 } from '@synergy-design-system/components';
 import { AllComponentsPage } from '../PageObjects/index.js';
-import { createTestCases, fillField, hasEvent } from '../helpers.js';
+import { createTestCases, fillField, runActionAndValidateEvents } from '../helpers.js';
 
 test.describe('<SynCombobox />', () => {
   createTestCases(({ name, port }) => {
@@ -184,10 +183,14 @@ test.describe('<SynCombobox />', () => {
         await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
 
         const combobox = await AllComponents.getLocator('combobox626');
-        const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
 
-        await fillField(combobox, 'lo', '.combobox__display-input', true);
-        await waitForChange;
+        await runActionAndValidateEvents(
+          page,
+          () => fillField(combobox, 'lo', '.combobox__display-input', true),
+          [
+            { event: 'syn-change', shouldFire: true },
+          ],
+        );
 
         // Check that the displayed value is the text content of the option
         const displayedValue = await combobox.evaluate((ele: SynCombobox) => ele.displayLabel);
@@ -208,10 +211,14 @@ test.describe('<SynCombobox />', () => {
         combobox.evaluate((ele: SynCombobox) => {
           ele.value = 'ipsum';
         });
-        const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
 
-        await fillField(combobox, 'lo', '.combobox__display-input', true);
-        await waitForChange;
+        await runActionAndValidateEvents(
+          page,
+          () => fillField(combobox, 'lo', '.combobox__display-input', true),
+          [
+            { event: 'syn-change', shouldFire: true },
+          ],
+        );
 
         // Check that the displayed value is the text content of the option
         const displayedValue = await combobox.evaluate((ele: SynCombobox) => ele.displayLabel);
@@ -227,7 +234,6 @@ test.describe('<SynCombobox />', () => {
         await expect(AllComponents.getLocator('comboboxContent')).toBeVisible();
 
         const combobox = await AllComponents.getLocator('combobox626Async');
-        const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
 
         const displayedValue = await combobox.evaluate((ele: SynCombobox) => ele.displayLabel);
         const value = await combobox.evaluate((ele: SynCombobox) => ele.value);
@@ -235,8 +241,13 @@ test.describe('<SynCombobox />', () => {
         expect(value).toEqual('3');
         expect(displayedValue).toEqual('Advanced');
 
-        await fillField(combobox, 'lo', '.combobox__display-input', true);
-        await waitForChange;
+        await runActionAndValidateEvents(
+          page,
+          () => fillField(combobox, 'lo', '.combobox__display-input', true),
+          [
+            { event: 'syn-change', shouldFire: true },
+          ],
+        );
 
         const displayedValueReset = await combobox.evaluate((ele: SynCombobox) => ele.displayLabel);
         const valueReset = await combobox.evaluate((ele: SynCombobox) => ele.value);

--- a/packages/_private/e2e-demo-test/src/AllComponents/SynInput.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynInput.spec.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@playwright/test';
 import {
-  type SynChangeEvent,
-  type SynClampEvent,
   type SynInput,
 } from '@synergy-design-system/components';
 import {
@@ -13,8 +11,7 @@ import {
   type SetterType,
   createTestCases,
   fillInput,
-  hasEvent,
-  hasNoEvent,
+  runActionAndValidateEvents,
   setPropertyForLocator,
 } from '../helpers.js';
 
@@ -43,13 +40,17 @@ test.describe('<SynInput />', () => {
 
           const input = await AllComponents.getLocator('input417NumericNative');
 
-          const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
-          const waitForClamp = hasNoEvent<SynClampEvent>(page, 'syn-clamp');
+          const eventResults = await runActionAndValidateEvents(
+            page,
+            () => fillInput(input, '-5'),
+            [
+              { event: 'syn-change', shouldFire: true },
+              { event: 'syn-clamp', shouldFire: false },
+            ],
+          );
 
-          await fillInput(input, '-5');
-
-          const hasChangeEvent = await waitForChange;
-          const hasClampEvent = await waitForClamp;
+          const changeResult = eventResults.find(r => r.event === 'syn-change');
+          const clampResult = eventResults.find(r => r.event === 'syn-clamp');
 
           const data = await input.evaluate((el: SynInput) => {
             const { validity, value, valueAsNumber } = el;
@@ -61,8 +62,8 @@ test.describe('<SynInput />', () => {
             };
           });
 
-          expect(hasChangeEvent, 'The syn-change event should be fired').toBeTruthy();
-          expect(hasClampEvent, 'The syn-clamp event should not be fired').toBeTruthy();
+          expect(changeResult?.hasFired, 'The syn-change event should be fired').toBeTruthy();
+          expect(clampResult?.hasFired, 'The syn-clamp event should not be fired').toBeFalsy();
 
           expect(data.value, 'Value should be set to a string of "-5"').toEqual('-5');
           expect(data.valueAsNumber, 'valueAsNumber should be set to float -5').toEqual(-5);
@@ -76,13 +77,17 @@ test.describe('<SynInput />', () => {
 
           const input = await AllComponents.getLocator('input417NumericNative');
 
-          const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
-          const waitForClamp = hasNoEvent<SynClampEvent>(page, 'syn-clamp');
+          const eventResults = await runActionAndValidateEvents(
+            page,
+            () => fillInput(input, '105'),
+            [
+              { event: 'syn-change', shouldFire: true },
+              { event: 'syn-clamp', shouldFire: false },
+            ],
+          );
 
-          await fillInput(input, '105');
-
-          const hasChangeEvent = await waitForChange;
-          const hasClampEvent = await waitForClamp;
+          const changeResult = eventResults.find(r => r.event === 'syn-change');
+          const clampResult = eventResults.find(r => r.event === 'syn-clamp');
 
           const data = await input.evaluate((el: SynInput) => {
             const { validity, value, valueAsNumber } = el;
@@ -94,8 +99,8 @@ test.describe('<SynInput />', () => {
             };
           });
 
-          expect(hasChangeEvent, 'The syn-change event should be fired').toBeTruthy();
-          expect(hasClampEvent, 'The syn-clamp event should not be fired').toBeTruthy();
+          expect(changeResult?.hasFired, 'The syn-change event should be fired').toBeTruthy();
+          expect(clampResult?.hasFired, 'The syn-clamp event should not be fired').toBeFalsy();
 
           expect(data.value, 'Value should be set to a string of "105"').toEqual('105');
           expect(data.valueAsNumber, 'valueAsNumber should be set to float 105').toEqual(105);
@@ -111,13 +116,17 @@ test.describe('<SynInput />', () => {
 
           const input = await AllComponents.getLocator('input417NumericModern');
 
-          const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
-          const waitForClamp = hasEvent<SynClampEvent>(page, 'syn-clamp');
+          const eventResults = await runActionAndValidateEvents(
+            page,
+            () => fillInput(input, '-5'),
+            [
+              { event: 'syn-change', shouldFire: true },
+              { event: 'syn-clamp', shouldFire: true },
+            ],
+          );
 
-          await fillInput(input, '-5');
-
-          const hasChangeEvent = await waitForChange;
-          const hasClampEvent = await waitForClamp;
+          const changeResult = eventResults.find(r => r.event === 'syn-change');
+          const clampResult = eventResults.find(r => r.event === 'syn-clamp');
 
           const data = await input.evaluate((el: SynInput) => {
             const { validity, value, valueAsNumber } = el;
@@ -129,8 +138,8 @@ test.describe('<SynInput />', () => {
             };
           });
 
-          expect(hasChangeEvent, 'The syn-change event should be fired').toBeTruthy();
-          expect(hasClampEvent, 'The syn-clamp event should be fired').toBeTruthy();
+          expect(changeResult?.hasFired, 'The syn-change event should be fired').toBeTruthy();
+          expect(clampResult?.hasFired, 'The syn-clamp event should be fired').toBeTruthy();
 
           expect(data.value, 'Value should be set to a string of "0"').toEqual('0');
           expect(data.valueAsNumber, 'valueAsNumber should be set to float 0').toEqual(0);
@@ -144,13 +153,17 @@ test.describe('<SynInput />', () => {
 
           const input = await AllComponents.getLocator('input417NumericModern');
 
-          const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
-          const waitForClamp = hasEvent<SynClampEvent>(page, 'syn-clamp');
+          const eventResults = await runActionAndValidateEvents(
+            page,
+            () => fillInput(input, '105'),
+            [
+              { event: 'syn-change', shouldFire: true },
+              { event: 'syn-clamp', shouldFire: true },
+            ],
+          );
 
-          await fillInput(input, '105');
-
-          const hasChangeEvent = await waitForChange;
-          const hasClampEvent = await waitForClamp;
+          const changeResult = eventResults.find(r => r.event === 'syn-change');
+          const clampResult = eventResults.find(r => r.event === 'syn-clamp');
 
           const data = await input.evaluate((el: SynInput) => {
             const { validity, value, valueAsNumber } = el;
@@ -162,8 +175,8 @@ test.describe('<SynInput />', () => {
             };
           });
 
-          expect(hasChangeEvent, 'The syn-change event should be fired').toBeTruthy();
-          expect(hasClampEvent, 'The syn-clamp event should be fired').toBeTruthy();
+          expect(changeResult?.hasFired, 'The syn-change event should be fired').toBeTruthy();
+          expect(clampResult?.hasFired, 'The syn-clamp event should be fired').toBeTruthy();
 
           expect(data.value, 'Value should be set to a string of "100"').toEqual('100');
           expect(data.valueAsNumber, 'valueAsNumber should be set to float 100').toEqual(100);
@@ -183,11 +196,15 @@ test.describe('<SynInput />', () => {
 
           const input = await AllComponents.getLocator('input417NumericMinFractionDigitsNative');
 
-          const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
+          const eventResults = await runActionAndValidateEvents(
+            page,
+            () => fillInput(input, '1'),
+            [
+              { event: 'syn-change', shouldFire: true },
+            ],
+          );
 
-          await fillInput(input, '1');
-
-          const hasChangeEvent = await waitForChange;
+          const changeResult = eventResults.find(r => r.event === 'syn-change');
 
           const data = await input.evaluate((el: SynInput) => {
             const { value, valueAsNumber } = el;
@@ -197,7 +214,7 @@ test.describe('<SynInput />', () => {
             };
           });
 
-          expect(hasChangeEvent, 'The syn-change event should be fired').toBeTruthy();
+          expect(changeResult?.hasFired, 'The syn-change event should be fired').toBeTruthy();
 
           expect(data.value, 'Value should be set to a string of "1.0000"').toEqual('1.0000');
           expect(data.valueAsNumber, 'valueAsNumber should be set to float 1.0000').toEqual(1.0000);
@@ -212,11 +229,15 @@ test.describe('<SynInput />', () => {
 
           const input = await AllComponents.getLocator('input417NumericMinFractionDigitsModern');
 
-          const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
+          const eventResults = await runActionAndValidateEvents(
+            page,
+            () => fillInput(input, '1'),
+            [
+              { event: 'syn-change', shouldFire: true },
+            ],
+          );
 
-          await fillInput(input, '1');
-
-          const hasChangeEvent = await waitForChange;
+          const changeResult = eventResults.find(r => r.event === 'syn-change');
 
           const data = await input.evaluate((el: SynInput) => {
             const { value, valueAsNumber } = el;
@@ -226,7 +247,7 @@ test.describe('<SynInput />', () => {
             };
           });
 
-          expect(hasChangeEvent, 'The syn-change event should be fired').toBeTruthy();
+          expect(changeResult?.hasFired, 'The syn-change event should be fired').toBeTruthy();
 
           expect(data.value, 'Value should be set to a string of "1.0000"').toEqual('1.0000');
           expect(data.valueAsNumber, 'valueAsNumber should be set to float 1.0000').toEqual(1.0000);

--- a/packages/_private/e2e-demo-test/src/AllComponents/SynValidate.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynValidate.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { SynChangeEvent } from '@synergy-design-system/components';
 import { AllComponentsPage } from '../PageObjects/index.js';
-import { createTestCases, fillInput, hasEvent } from '../helpers.js';
+import { createTestCases, fillInput, runActionAndValidateEvents } from '../helpers.js';
 
 test.describe('<SynValidate />', () => {
   createTestCases(({ name, port }) => {
@@ -16,10 +15,14 @@ test.describe('<SynValidate />', () => {
 
         const validate = AllComponents.getLocator('validate915');
         const input = validate.locator('syn-input');
-        const waitForChange = hasEvent<SynChangeEvent>(page, 'syn-change');
 
-        await fillInput(input, 'invalid');
-        await waitForChange;
+        await runActionAndValidateEvents(
+          page,
+          () => fillInput(input, 'invalid'),
+          [
+            { event: 'syn-change', shouldFire: true },
+          ],
+        );
 
         await expect(input, 'data-invalid attribute should be available').toHaveAttribute('data-invalid', '');
         await expect(input, 'data-user-invalid attribute should be available').toHaveAttribute('data-user-invalid', '');


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes timing / performance issues of the e2e tests in the pipeline. They occurred because of the usage / handling of the "hasEvent" method. The event was registered and a timeout for the event to occur was started, afterwards the action was executed, which should result in the event. If the execution time of the machine is bad, this resulted into the timeout being triggered before the action was executed.

Therefore a new function was added, which executes the timeout after the action execution.

### 🎫 Issues

Closes #1003 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan


## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] ~I have added automatic tests for my changes (unit- and visual regression tests).~
- [ ] ~I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).~
- [ ] ~I have added documentation to the DaVinci migration guide (if need be)~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [ ] ~I have validated that there are no accessibility errors.~
- [ ] ~I have used design tokens instead of fix css values~
