### PR TITLE
fix: 🐛 Releases do not trigger Chromatic Deployments anymore

### DIFF
--- a/.changeset/1070-fix-chromatic-deploy.md
+++ b/.changeset/1070-fix-chromatic-deploy.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: 🐛 Fix docs deployment for chromatic main (#1070)

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,11 +23,16 @@ jobs:
           ref: "main"
           path: "synergy-design-system"
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-node-pnpm
+      # We cannot use our own action as it interferes with the checkout paths
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          skip-install: 'true'
-          with-build: 'false'
+          node-version: 22
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Install dependencies
         working-directory: ./synergy-design-system

--- a/packages/_private/release-utils/src/create-changeset-from-git.js
+++ b/packages/_private/release-utils/src/create-changeset-from-git.js
@@ -85,7 +85,7 @@ const createChangesetContent = (
   bumpType,
   changeset,
 ) => {
-  const packages = changeset.changedPackages?.map(pkg => `"${pkg}": ${bumpType}`).join('\n');
+  const packages = changeset.changedPackages?.map(pkg => `"${pkg}": ${bumpType}`).join('\n') || '';
   const message = createHumanReadableMessageFromBranchName(branchName);
   return `
 ---


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that made our chromatic deployment process crash because of reuse of our new custom action.

### 🎫 Issues

Closes #1069 

## 👩‍💻 Reviewer Notes

I tried it out locally, we cannot use our own action as it sets up the system in the wrong way (e.g. paths do not match anymore). This cannot be fixed easily and I opted to just revert the use of our action, which ran nice afterwards.

## 📑 Test Plan

Have a look at the workflow, merge and see it work (hopefully :)).

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [ ] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] I have added documentation to the DaVinci migration guide (if need be)
- [ ] I have made sure to follow the projects coding and contribution guides.
- [ ] I have made sure that the bundle size has changed appropriately.
- [ ] I have validated that there are no accessibility errors.
- [ ] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [ ] I have used design tokens instead of fix css values
