### PR TITLE
feat: ✨ Update syn-details with semibold title/summary

### DIFF
--- a/.changeset/1114-syn-details-update-summary-font.md
+++ b/.changeset/1114-syn-details-update-summary-font.md
@@ -1,0 +1,6 @@
+---
+"@synergy-design-system/components": minor
+"@synergy-design-system/mcp": minor
+---
+
+feat: ✨ `<syn-details>` summary is now always shown in bold. (#1114)

--- a/packages/components/src/components/details/details.custom.styles.ts
+++ b/packages/components/src/components/details/details.custom.styles.ts
@@ -56,7 +56,7 @@ export default css`
   }
 
   .details--size-medium .details__summary {
-    font: var(--syn-body-medium-regular);
+    font: var(--syn-body-medium-bold);
   }
 
   .details--size-medium .details__summary::slotted(syn-icon) {
@@ -80,7 +80,7 @@ export default css`
   }
 
   .details--size-large .details__summary {
-    font: var(--syn-body-large-regular);
+    font: var(--syn-body-large-bold);
   }
 
   .details--size-large .details__summary-icon {
@@ -92,13 +92,6 @@ export default css`
     flex-shrink: 0;
     font-size: var(--syn-spacing-x-large);
     margin-right: var(--syn-spacing-small);
-  }
-
-  /**
-   * Mark the details as open by adjusting its label
-   */
-  .details--open .details__summary {
-    font-weight: var(--syn-font-weight-bold);
   }
 
   /**

--- a/packages/mcp/metadata/checksum.txt
+++ b/packages/mcp/metadata/checksum.txt
@@ -1,1 +1,1 @@
-47a303a1eaa206c74ddf7d8823c0bac2
+39f9c3bde8cc1e9ee0b1b0b3bd2c8d29


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds a small change to `<syn-details>` that makes sure that we are aligned with Figma and the website team. It changes the `summary` part of the component to always use a **bold** font representation, regardless of open status.

### 🎫 Issues

Closes #1114 

## 👩‍💻 Reviewer Notes

Just have a look at Chromatic.

## 📑 Test Plan

Just have a look at Chromatic.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
