### PR TITLE
fix: 🐛 CD updated button component colors do not work as expected

### DIFF
--- a/.changeset/1145-adjust-syn-button-tokens.md
+++ b/.changeset/1145-adjust-syn-button-tokens.md
@@ -1,0 +1,9 @@
+---
+"@synergy-design-system/tokens": patch
+"@synergy-design-system/mcp": patch
+---
+
+fix: 🐛 adjust syn button tokens (#1145)
+
+The original tokens used `inherit` as a fallback value, which did not have any effect but to fall back to the original value.
+This is now made explicit to allow the use of button variables in code directly.

--- a/packages/mcp/metadata/checksum.txt
+++ b/packages/mcp/metadata/checksum.txt
@@ -1,1 +1,1 @@
-a63ba6a328e910f16e0cd08c9f83e9af
+7a03e0ff66aff6be03fe0dff81bd7186

--- a/packages/tokens/scripts/config.js
+++ b/packages/tokens/scripts/config.js
@@ -44,56 +44,37 @@ export const DARK_2018_THEME = 'sick2018-dark.json';
 
 /**
  * List of static changed to variables for specific themes and modes.
- * @type {Record<string, OutputVariableChangeList>}
+ * @type {{ global: OutputVariableChangeList } & Record<string, OutputVariableChangeList>}
  */
 export const OUTPUT_VARIABLE_CHANGES = {
-  sick2018_dark: {
+  global: {
     // filled button
-    'syn-button-filled-color-text': 'inherit',
-    'syn-button-filled-color-text-active': 'inherit',
-    'syn-button-filled-color-text-hover': 'inherit',
+    'syn-button-filled-color-text': 'var(--syn-color-neutral-0)',
+    'syn-button-filled-color-text-active': 'var(--syn-color-neutral-0)',
+    'syn-button-filled-color-text-hover': 'var(--syn-color-neutral-0)',
 
     // outlined button
-    'syn-button-outline-color-active': 'none',
-    'syn-button-outline-color-hover': 'none',
-    'syn-button-outline-color-text': 'inherit',
+    'syn-button-outline-color-text': 'var(--syn-color-primary-600)',
     'syn-button-outline-color-text-active': 'var(--syn-color-primary-950)',
     'syn-button-outline-color-text-hover': 'var(--syn-color-primary-900)',
 
-    // Text button
+    // text button
     'syn-button-text-color-text': 'var(--syn-button-color)',
     'syn-button-text-color-text-active': 'var(--syn-button-color-active)',
     'syn-button-text-color-text-hover': 'var(--syn-button-color-hover)',
   },
-  sick2018_light: {
-    // filled button
-    'syn-button-filled-color-text': 'inherit',
-    'syn-button-filled-color-text-active': 'inherit',
-    'syn-button-filled-color-text-hover': 'inherit',
-
+  sick2018_dark: {
     // outlined button
     'syn-button-outline-color-active': 'none',
     'syn-button-outline-color-hover': 'none',
-    'syn-button-outline-color-text': 'inherit',
-    'syn-button-outline-color-text-active': 'var(--syn-color-primary-950)',
-    'syn-button-outline-color-text-hover': 'var(--syn-color-primary-900)',
-
-    // Text button
-    'syn-button-text-color-text': 'var(--syn-button-color)',
-    'syn-button-text-color-text-active': 'var(--syn-button-color-active)',
-    'syn-button-text-color-text-hover': 'var(--syn-button-color-hover)',
+  },
+  sick2018_light: {
+    // outlined button
+    'syn-button-outline-color-active': 'none',
+    'syn-button-outline-color-hover': 'none',
   },
   sick2025_dark: {
   },
   sick2025_light: {
-    // filled button
-    'syn-button-filled-color-text': 'inherit',
-    'syn-button-filled-color-text-active': 'inherit',
-    'syn-button-filled-color-text-hover': 'inherit',
-
-    // Text button
-    'syn-button-text-color-text': 'var(--syn-button-color)',
-    'syn-button-text-color-text-active': 'var(--syn-button-color-active)',
-    'syn-button-text-color-text-hover': 'var(--syn-button-color-hover)',
   },
 };

--- a/packages/tokens/scripts/helpers.js
+++ b/packages/tokens/scripts/helpers.js
@@ -140,7 +140,11 @@ export const getInformationForTheme = (theme, mode) => {
 
   // Create the list of selectors that should be changed
   // depending on the theme and mode.
-  const changeOutputValues = OUTPUT_VARIABLE_CHANGES[`${usedTheme}`] || {};
+  // Make sure to merge the global changes with the specific ones.
+  const changeOutputValues = {
+    ...OUTPUT_VARIABLE_CHANGES.global,
+    ...(OUTPUT_VARIABLE_CHANGES[`${usedTheme}`] || {}),
+  };
 
   return {
     changeOutputValues,

--- a/packages/tokens/test/sick2018_dark.css
+++ b/packages/tokens/test/sick2018_dark.css
@@ -1,5 +1,5 @@
 /**
- * @synergy-design-system/tokens version 2.47.0
+ * @synergy-design-system/tokens version 2.48.0
  * SICK Global UX Foundation
  * Do not edit directly, this file was auto-generated.
  */
@@ -56,15 +56,15 @@
   --syn-button-color: var(--syn-interactive-emphasis-color);
   --syn-button-color-active: var(--syn-interactive-emphasis-color-active);
   --syn-button-color-hover: var(--syn-interactive-emphasis-color-hover);
-  --syn-button-filled-color-text: inherit;
-  --syn-button-filled-color-text-active: inherit;
-  --syn-button-filled-color-text-hover: inherit;
+  --syn-button-filled-color-text: var(--syn-color-neutral-0);
+  --syn-button-filled-color-text-active: var(--syn-color-neutral-0);
+  --syn-button-filled-color-text-hover: var(--syn-color-neutral-0);
   --syn-button-font-size-large: var(--syn-font-size-large);
   --syn-button-font-size-medium: var(--syn-font-size-medium);
   --syn-button-font-size-small: var(--syn-font-size-small);
   --syn-button-outline-color-active: none;
   --syn-button-outline-color-hover: none;
-  --syn-button-outline-color-text: inherit;
+  --syn-button-outline-color-text: var(--syn-color-primary-600);
   --syn-button-outline-color-text-active: var(--syn-color-primary-950);
   --syn-button-outline-color-text-hover: var(--syn-color-primary-900);
   --syn-button-text-color-text: var(--syn-button-color);

--- a/packages/tokens/test/sick2018_light.css
+++ b/packages/tokens/test/sick2018_light.css
@@ -1,5 +1,5 @@
 /**
- * @synergy-design-system/tokens version 2.47.0
+ * @synergy-design-system/tokens version 2.48.0
  * SICK Global UX Foundation
  * Do not edit directly, this file was auto-generated.
  */
@@ -56,15 +56,15 @@
   --syn-button-color: var(--syn-interactive-emphasis-color);
   --syn-button-color-active: var(--syn-interactive-emphasis-color-active);
   --syn-button-color-hover: var(--syn-interactive-emphasis-color-hover);
-  --syn-button-filled-color-text: inherit;
-  --syn-button-filled-color-text-active: inherit;
-  --syn-button-filled-color-text-hover: inherit;
+  --syn-button-filled-color-text: var(--syn-color-neutral-0);
+  --syn-button-filled-color-text-active: var(--syn-color-neutral-0);
+  --syn-button-filled-color-text-hover: var(--syn-color-neutral-0);
   --syn-button-font-size-large: var(--syn-font-size-large);
   --syn-button-font-size-medium: var(--syn-font-size-medium);
   --syn-button-font-size-small: var(--syn-font-size-small);
   --syn-button-outline-color-active: none;
   --syn-button-outline-color-hover: none;
-  --syn-button-outline-color-text: inherit;
+  --syn-button-outline-color-text: var(--syn-color-primary-600);
   --syn-button-outline-color-text-active: var(--syn-color-primary-950);
   --syn-button-outline-color-text-hover: var(--syn-color-primary-900);
   --syn-button-text-color-text: var(--syn-button-color);

--- a/packages/tokens/test/sick2025_dark.css
+++ b/packages/tokens/test/sick2025_dark.css
@@ -1,5 +1,5 @@
 /**
- * @synergy-design-system/tokens version 2.47.0
+ * @synergy-design-system/tokens version 2.48.0
  * SICK Global UX Foundation
  * Do not edit directly, this file was auto-generated.
  */

--- a/packages/tokens/test/sick2025_light.css
+++ b/packages/tokens/test/sick2025_light.css
@@ -1,5 +1,5 @@
 /**
- * @synergy-design-system/tokens version 2.47.0
+ * @synergy-design-system/tokens version 2.48.0
  * SICK Global UX Foundation
  * Do not edit directly, this file was auto-generated.
  */
@@ -56,9 +56,9 @@
   --syn-button-color: var(--syn-interactive-emphasis-color);
   --syn-button-color-active: var(--syn-interactive-emphasis-color-active);
   --syn-button-color-hover: var(--syn-interactive-emphasis-color-hover);
-  --syn-button-filled-color-text: inherit;
-  --syn-button-filled-color-text-active: inherit;
-  --syn-button-filled-color-text-hover: inherit;
+  --syn-button-filled-color-text: var(--syn-color-neutral-0);
+  --syn-button-filled-color-text-active: var(--syn-color-neutral-0);
+  --syn-button-filled-color-text-hover: var(--syn-color-neutral-0);
   --syn-button-font-size-large: var(--syn-font-size-large);
   --syn-button-font-size-medium: var(--syn-font-size-medium);
   --syn-button-font-size-small: var(--syn-font-size-small);


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes an issue that arises because we are using `inherit` for the custom overrides in `<syn-button>`. I have restructured this to:

1. Use the variables with a real meaning in external applications.
2. Make the usage more explicit

### 🎫 Issues

Closes #1145 

## 👩‍💻 Reviewer Notes

I had to tweak the global config in the tokens package to make sure we still allow theme based overrides, but global ones, too. We now use the globals as a base. Those may be overridden with the corresponding theme key.

## 📑 Test Plan

Just make sure everything is still looking fine in Storybook. This includes hover and active state tests.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [ ] ~~I have added documentation to the DaVinci migration guide (if need be)~~
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
