### PR TITLE
fix: 🐛 syn-option - Slotted <syn-icon> elements not visible on hover

### DIFF
--- a/.changeset/1277-syn-option-slotted-icons-not-visible.md
+++ b/.changeset/1277-syn-option-slotted-icons-not-visible.md
@@ -1,0 +1,8 @@
+---
+"@synergy-design-system/components": patch
+"@synergy-design-system/metadata": patch
+---
+
+fix: 🐛 `<syn-option>` slotted icons not visible on hover (#1277)
+
+This release fixes a bug that accidentally set the color of slotted elements in `<syn-option>` to white which lead to the icons appear to be invisible.

--- a/packages/components/src/components/option/option.styles.ts
+++ b/packages/components/src/components/option/option.styles.ts
@@ -139,14 +139,14 @@ export default css`
     font-size: var(--option-icon-size, var(--syn-spacing-large));
   }
 
-  .option--hover .option__prefix::slotted(syn-icon),
-  .option--hover .option__suffix::slotted(syn-icon) {
-    color: var(--syn-option-icon-color-hover);
-  }
-
   .option--current .option__prefix::slotted(syn-icon),
   .option--current .option__suffix::slotted(syn-icon) {
     color: var(--syn-option-icon-color-active);
+  }
+
+  .option--hover:not(.option--disabled) .option__prefix::slotted(syn-icon),
+  .option--hover:not(.option--disabled) .option__suffix::slotted(syn-icon) {
+    color: var(--syn-option-icon-color-hover);
   }
 
   /* This is needed for the highlight styling of the options in syn-combobox */

--- a/packages/docs/stories/components/option.stories.ts
+++ b/packages/docs/stories/components/option.stories.ts
@@ -76,6 +76,13 @@ export const Disabled: Story = {
       <syn-option value="option-1">Email</syn-option>
       <syn-option value="option-2" disabled>Phone</syn-option>
       <syn-option value="option-3">Chat</syn-option>
+
+      <syn-option value="option-4" disabled>
+        <syn-icon name="chat_bubble_outline" slot="prefix"></syn-icon>
+        <syn-icon name="check_circle_outline" slot="suffix"></syn-icon>  
+        Other
+      </syn-option>
+      <!-- /Regression#1277 -->
     </syn-select>
   `,
 };
@@ -89,7 +96,7 @@ export const PrefixAndSuffix: Story = {
     },
   },
   render: () => html`
-    <syn-select label="Select one">
+    <syn-select label="Select one" open>
       <syn-option value="option-1">
         <syn-icon slot="prefix" name="email"></syn-icon>
         Email

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-04-29T13:20:40.658Z",
+  "builtAt": "2026-05-04T13:07:33.485Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset:sick2018-icons.json",

--- a/packages/metadata/data/layers/examples/component/component:syn-option.md
+++ b/packages/metadata/data/layers/examples/component/component:syn-option.md
@@ -22,6 +22,13 @@ Use the disabled attribute to disable an option and prevent it from being select
   <syn-option value="option-1">Email</syn-option>
   <syn-option value="option-2" disabled="">Phone</syn-option>
   <syn-option value="option-3">Chat</syn-option>
+
+  <syn-option value="option-4" disabled="">
+    <syn-icon name="chat_bubble_outline" slot="prefix"></syn-icon>
+    <syn-icon name="check_circle_outline" slot="suffix"></syn-icon>
+    Other
+  </syn-option>
+  <!-- /Regression#1277 -->
 </syn-select>
 ```
 
@@ -32,7 +39,7 @@ Use the disabled attribute to disable an option and prevent it from being select
 Add icons to the start and end of menu items using the prefix and suffix slots.
 
 ```html
-<syn-select label="Select one">
+<syn-select label="Select one" open="">
   <syn-option value="option-1">
     <syn-icon slot="prefix" name="email"></syn-icon>
     Email

--- a/packages/metadata/data/layers/full/component/component:syn-option/components/option.styles.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-option/components/option.styles.ts
@@ -139,14 +139,14 @@ export default css`
     font-size: var(--option-icon-size, var(--syn-spacing-large));
   }
 
-  .option--hover .option__prefix::slotted(syn-icon),
-  .option--hover .option__suffix::slotted(syn-icon) {
-    color: var(--syn-option-icon-color-hover);
-  }
-
   .option--current .option__prefix::slotted(syn-icon),
   .option--current .option__suffix::slotted(syn-icon) {
     color: var(--syn-option-icon-color-active);
+  }
+
+  .option--hover:not(.option--disabled) .option__prefix::slotted(syn-icon),
+  .option--hover:not(.option--disabled) .option__suffix::slotted(syn-icon) {
+    color: var(--syn-option-icon-color-hover);
   }
 
   /* This is needed for the highlight styling of the options in syn-combobox */

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-04-29T13:20:40.659Z",
+  "builtAt": "2026-05-04T13:07:33.486Z",
   "sources": [
     {
       "entityCount": 4,


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes a bug that accidentally set the color of slotted elements in `<syn-option>` to white which lead to the icons appear to be invisible.

### 🎫 Issues

Closes #1277

## 👩‍💻 Reviewer Notes

Same issue than #1194: Hover was not guarded for disabled, so it always hovered, even on disabled entries. Fixed by adding a disabled guard to the code.

## 📑 Test Plan

Check the adjusted Storybook story. I added a new entry with both prefix and suffix item and disabled.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
