### PR TITLE
fix: 🐛 syn-menu - Multiple Issues

### DIFF
--- a/.changeset/1295-syn-menu-multiple-issues.md
+++ b/.changeset/1295-syn-menu-multiple-issues.md
@@ -1,0 +1,12 @@
+---
+"@synergy-design-system/components": patch
+"@synergy-design-system/metadata": patch
+---
+
+fix: 🐛 `<syn-menu>` multiple issues (#1295)
+
+This release fixes multiple issues when using `<syn-menu>`:
+
+- submenus no longer stay open when leaving the browser window (#882)
+- `<syn-menu-item>` wrapped in tooltip can now be used reliably (including navigation and selection) (#1162)
+- `<syn-menu-item>` no longer steals focus on hover (#1286)

--- a/packages/_private/angular-demo/src/AllComponentParts/Menu.ts
+++ b/packages/_private/angular-demo/src/AllComponentParts/Menu.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { SynInputComponent } from '@synergy-design-system/angular/components/input';
 import { SynMenuComponent } from '@synergy-design-system/angular/components/menu';
 import { SynMenuItemComponent } from '@synergy-design-system/angular/components/menu-item';
 import { SynDividerComponent } from '@synergy-design-system/angular/components/divider';
@@ -7,6 +8,7 @@ import { SynDividerComponent } from '@synergy-design-system/angular/components/d
   selector: 'demo-menu',
   standalone: true,
   imports: [
+    SynInputComponent,
     SynMenuComponent,
     SynMenuItemComponent,
     SynDividerComponent,
@@ -21,6 +23,31 @@ import { SynDividerComponent } from '@synergy-design-system/angular/components/d
         <syn-menu-item value="copy">Copy</syn-menu-item>
         <syn-menu-item value="paste">Paste</syn-menu-item>
         <syn-menu-item value="delete">Delete</syn-menu-item>
+      </syn-menu>
+    </div>
+
+    <syn-divider />
+
+    <div
+      data-testid="menu-1295-steals-focus"
+      style="
+        display: flex;
+        flex-direction: column;
+        gap: var(--syn-spacing-small);
+        margin: var(--syn-spacing-large) 0;
+      "
+    >
+      <syn-input
+        name="search"
+        label="#1295: Focus should not be lost when hovering over the menu"
+        type="text"
+      />
+      <syn-menu>
+        <syn-menu-item value="undo">Undo</syn-menu-item>
+        <syn-menu-item value="redo">Redo</syn-menu-item>
+        <syn-divider />
+        <syn-menu-item value="cut">Cut</syn-menu-item>
+        <syn-menu-item value="copy">Copy</syn-menu-item>
       </syn-menu>
     </div>
   `,

--- a/packages/_private/e2e-demo-test/src/AllComponents/SynMenu.spec.ts
+++ b/packages/_private/e2e-demo-test/src/AllComponents/SynMenu.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { AllComponentsPage } from '../PageObjects/index.js';
+import { clickFormControl, createTestCases } from '../helpers.js';
+
+test.describe('<SynMenu />', () => {
+  createTestCases(({ name, port }) => {
+    test.describe(`Regression#1295: ${name}`, () => {
+      test('should not steal focus when hovering over the menu', async ({ page }) => {
+        const AllComponents = new AllComponentsPage(page, port);
+        await AllComponents.loadInitialPage();
+        await AllComponents.activateItem('menuLink');
+
+        const rootElement = AllComponents.getLocator('menu1295StealsFocus');
+
+        await expect(rootElement).toBeVisible();
+
+        // Focus the input before hovering over the menu
+        const input = rootElement.locator('syn-input');
+        await clickFormControl(input);
+        await expect(input).toBeFocused();
+
+        // Hover over the menu item and check if the input is still focused
+        const menuItem = rootElement.locator('syn-menu syn-menu-item:first-child');
+        await menuItem.hover();
+        await expect(input).toBeFocused();
+      });
+    }); // regression#1295
+  }); // End frameworks
+}); // </syn-menu>

--- a/packages/_private/e2e-demo-test/src/test.selector.ts
+++ b/packages/_private/e2e-demo-test/src/test.selector.ts
@@ -56,6 +56,11 @@ const AllComponentSelectors = {
   inputContent: '#tab-content-Input',
   inputLink: '#tab-Input',
 
+  // Menu
+  menu1295StealsFocus: '#tab-content-Menu [data-testid="menu-1295-steals-focus"]',
+  menuContent: '#tab-content-Menu',
+  menuLink: '#tab-Menu',
+
   // NgModelUpdateOn
   ngModelUpdateOnCheckbox: '#tab-content-NgModelUpdateOn syn-checkbox[data-testid="checkbox-808"]',
   ngModelUpdateOnCheckboxChanged: '#tab-content-NgModelUpdateOn syn-checkbox[data-testid="checkbox-changed-808"]',

--- a/packages/_private/react-demo/src/AllComponentParts/Menu.tsx
+++ b/packages/_private/react-demo/src/AllComponentParts/Menu.tsx
@@ -1,13 +1,40 @@
 export const Menu = () => (
-  <div style={{ width: 200 }}>
-    <syn-menu>
-      <syn-menu-item value="undo">Undo</syn-menu-item>
-      <syn-menu-item value="redo">Redo</syn-menu-item>
-      <syn-divider />
-      <syn-menu-item value="cut">Cut</syn-menu-item>
-      <syn-menu-item value="copy">Copy</syn-menu-item>
-      <syn-menu-item value="paste">Paste</syn-menu-item>
-      <syn-menu-item value="delete">Delete</syn-menu-item>
-    </syn-menu>
-  </div>
+  <>
+    <div style={{ width: 200 }}>
+      <syn-menu>
+        <syn-menu-item value="undo">Undo</syn-menu-item>
+        <syn-menu-item value="redo">Redo</syn-menu-item>
+        <syn-divider />
+        <syn-menu-item value="cut">Cut</syn-menu-item>
+        <syn-menu-item value="copy">Copy</syn-menu-item>
+        <syn-menu-item value="paste">Paste</syn-menu-item>
+        <syn-menu-item value="delete">Delete</syn-menu-item>
+      </syn-menu>
+    </div>
+
+    <syn-divider />
+
+    <div
+      data-testid="menu-1295-steals-focus"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--syn-spacing-small)',
+        margin: 'var(--syn-spacing-large) 0',
+      }}
+    >
+      <syn-input
+        name="search"
+        label="#1295: Focus should not be lost when hovering over the menu"
+        type="text"
+      />
+      <syn-menu>
+        <syn-menu-item value="undo">Undo</syn-menu-item>
+        <syn-menu-item value="redo">Redo</syn-menu-item>
+        <syn-divider />
+        <syn-menu-item value="cut">Cut</syn-menu-item>
+        <syn-menu-item value="copy">Copy</syn-menu-item>
+      </syn-menu>
+    </div>
+  </>
 );

--- a/packages/_private/vanilla-demo/src/AllComponentParts/Menu.ts
+++ b/packages/_private/vanilla-demo/src/AllComponentParts/Menu.ts
@@ -12,4 +12,29 @@ export const Menu = () => html`
       <syn-menu-item value="delete">Delete</syn-menu-item>
     </syn-menu>
   </div>
+
+  <syn-divider></syn-divider>
+
+  <div
+    data-testid="menu-1295-steals-focus"
+    style="
+      display: flex;
+      flex-direction: column;
+      gap: var(--syn-spacing-small);
+      margin: var(--syn-spacing-large) 0;   
+    "
+  >
+    <syn-input
+      name="search"
+      label="#1295: Focus should not be lost when hovering over the menu"
+      type="text"
+    ></syn-input>
+    <syn-menu>
+      <syn-menu-item value="undo">Undo</syn-menu-item>
+      <syn-menu-item value="redo">Redo</syn-menu-item>
+      <syn-divider></syn-divider>
+      <syn-menu-item value="cut">Cut</syn-menu-item>
+      <syn-menu-item value="copy">Copy</syn-menu-item>
+    </syn-menu>
+  </div>
 `;

--- a/packages/_private/vue-demo/src/AllComponentParts/DemoMenu.vue
+++ b/packages/_private/vue-demo/src/AllComponentParts/DemoMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { SynVueMenu, SynVueMenuItem, SynVueDivider } from '@synergy-design-system/vue';
+import { SynVueInput, SynVueMenu, SynVueMenuItem, SynVueDivider } from '@synergy-design-system/vue';
 </script>
 <template>
   <div style="width: 200px">
@@ -11,6 +11,31 @@ import { SynVueMenu, SynVueMenuItem, SynVueDivider } from '@synergy-design-syste
       <SynVueMenuItem value="copy">Copy</SynVueMenuItem>
       <SynVueMenuItem value="paste">Paste</SynVueMenuItem>
       <SynVueMenuItem value="delete">Delete</SynVueMenuItem>
+    </SynVueMenu>
+  </div>
+
+  <SynVueDivider />
+
+  <div
+    data-testid="menu-1295-steals-focus"
+    style="
+      display: flex;
+      flex-direction: column;
+      gap: var(--syn-spacing-small);
+      margin: var(--syn-spacing-large) 0;   
+    "
+  >
+    <SynVueInput
+      name="search"
+      label="#1295: Focus should not be lost when hovering over the menu"
+      type="text"
+    />
+    <SynVueMenu>
+      <SynVueMenuItem value="undo">Undo</SynVueMenuItem>
+      <SynVueMenuItem value="redo">Redo</SynVueMenuItem>
+      <SynVueDivider />
+      <SynVueMenuItem value="cut">Cut</SynVueMenuItem>
+      <SynVueMenuItem value="copy">Copy</SynVueMenuItem>
     </SynVueMenu>
   </div>
 </template>

--- a/packages/components/src/components/menu-item/menu-item.component.ts
+++ b/packages/components/src/components/menu-item/menu-item.component.ts
@@ -79,13 +79,11 @@ export default class SynMenuItem extends SynergyElement {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('click', this.handleHostClick);
-    this.addEventListener('mouseover', this.handleMouseOver);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener('click', this.handleHostClick);
-    this.removeEventListener('mouseover', this.handleMouseOver);
   }
 
   private handleDefaultSlotChange() {
@@ -110,11 +108,6 @@ export default class SynMenuItem extends SynergyElement {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
-  };
-
-  private handleMouseOver = (event: MouseEvent) => {
-    this.focus();
-    event.stopPropagation();
   };
 
   @watch('checked')

--- a/packages/components/src/components/menu-item/menu-item.test.ts
+++ b/packages/components/src/components/menu-item/menu-item.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import '../../../dist/synergy.js';
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { aTimeout } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import type { SynSelectEvent } from '../../events/syn-select.js';
@@ -120,6 +121,105 @@ describe('<syn-menu-item>', () => {
     expect(menuItem.shadowRoot!.querySelector('syn-popup')).to.be.not.null;
     const submenuSlot: HTMLElement = menuItem.shadowRoot!.querySelector('slot[name="submenu"]')!;
     expect(submenuSlot.hidden).to.be.false;
+  });
+
+  it('should not steal focus on hover', async () => {
+    const wrapper = await fixture<HTMLDivElement>(html`
+      <div>
+        <button id="before">Before</button>
+        <syn-menu>
+          <syn-menu-item>Item 1</syn-menu-item>
+          <syn-menu-item>Item 2</syn-menu-item>
+        </syn-menu>
+      </div>
+    `);
+
+    const button = wrapper.querySelector<HTMLButtonElement>('#before')!;
+    const item = wrapper.querySelector<SynMenuItem>('syn-menu-item')!;
+
+    button.focus();
+    expect(document.activeElement).to.equal(button);
+
+    item.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, composed: true }));
+    await aTimeout(0);
+
+    expect(document.activeElement).to.equal(button);
+  });
+
+  it('should close an open submenu when the window loses focus', async () => {
+    const menu = await fixture<SynMenuItem>(html`
+      <syn-menu>
+        <syn-menu-item>
+          Submenu
+          <syn-menu slot="submenu">
+            <syn-menu-item>Nested Item 1</syn-menu-item>
+          </syn-menu>
+        </syn-menu-item>
+      </syn-menu>
+    `);
+
+    const menuItem = menu.querySelector<SynMenuItem>('syn-menu-item')!;
+    const popup = menuItem.shadowRoot!.querySelector('syn-popup')!;
+
+    menuItem.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, composed: true }));
+    await waitUntil(() => popup.active);
+
+    window.dispatchEvent(new Event('blur'));
+    await waitUntil(() => !popup.active);
+
+    expect(popup.active).to.be.false;
+  });
+
+  it('should close an open submenu when hover leaves the trigger item', async () => {
+    const menu = await fixture<SynMenuItem>(html`
+      <div>
+        <syn-menu>
+          <syn-menu-item>
+            Submenu
+            <syn-menu slot="submenu">
+              <syn-menu-item>Nested Item 1</syn-menu-item>
+            </syn-menu>
+          </syn-menu-item>
+        </syn-menu>
+        <button id="outside">Outside</button>
+      </div>
+    `);
+
+    const menuItem = menu.querySelector<SynMenuItem>('syn-menu-item')!;
+    const popup = menuItem.shadowRoot!.querySelector('syn-popup')!;
+    const outside = menu.querySelector<HTMLButtonElement>('#outside')!;
+
+    menuItem.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, composed: true }));
+    await waitUntil(() => popup.active);
+
+    menuItem.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: outside }));
+    await waitUntil(() => !popup.active);
+
+    expect(popup.active).to.be.false;
+  });
+
+  it('should close an open submenu when pressing escape after hover opening', async () => {
+    const menu = await fixture<SynMenuItem>(html`
+      <syn-menu>
+        <syn-menu-item>
+          Submenu
+          <syn-menu slot="submenu">
+            <syn-menu-item>Nested Item 1</syn-menu-item>
+          </syn-menu>
+        </syn-menu-item>
+      </syn-menu>
+    `);
+
+    const menuItem = menu.querySelector<SynMenuItem>('syn-menu-item')!;
+    const popup = menuItem.shadowRoot!.querySelector('syn-popup')!;
+
+    menuItem.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, composed: true }));
+    await waitUntil(() => popup.active);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await waitUntil(() => !popup.active);
+
+    expect(popup.active).to.be.false;
   });
 
   it.skip('should focus on first menuitem of submenu if ArrowRight is pressed on parent menuitem', async () => {

--- a/packages/components/src/components/menu-item/submenu-controller.ts
+++ b/packages/components/src/components/menu-item/submenu-controller.ts
@@ -11,6 +11,7 @@ export class SubmenuController implements ReactiveController {
   private host: ReactiveControllerHost & SynMenuItem;
   private popupRef: Ref<SynPopup> = createRef();
   private enableSubmenuTimer = -1;
+  private hasGlobalDismissListeners = false;
   private isConnected = false;
   private isPopupConnected = false;
   private skidding = 0;
@@ -45,6 +46,7 @@ export class SubmenuController implements ReactiveController {
     if (!this.isConnected) {
       this.host.addEventListener('mousemove', this.handleMouseMove);
       this.host.addEventListener('mouseover', this.handleMouseOver);
+      this.host.addEventListener('mouseleave', this.handleHostMouseLeave);
       this.host.addEventListener('keydown', this.handleKeyDown);
       this.host.addEventListener('click', this.handleClick);
       this.host.addEventListener('focusout', this.handleFocusOut);
@@ -56,6 +58,7 @@ export class SubmenuController implements ReactiveController {
     if (!this.isPopupConnected) {
       if (this.popupRef.value) {
         this.popupRef.value.addEventListener('mouseover', this.handlePopupMouseover);
+        this.popupRef.value.addEventListener('mouseleave', this.handlePopupMouseLeave);
         this.popupRef.value.addEventListener('syn-reposition', this.handlePopupReposition);
         this.isPopupConnected = true;
       }
@@ -66,6 +69,7 @@ export class SubmenuController implements ReactiveController {
     if (this.isConnected) {
       this.host.removeEventListener('mousemove', this.handleMouseMove);
       this.host.removeEventListener('mouseover', this.handleMouseOver);
+      this.host.removeEventListener('mouseleave', this.handleHostMouseLeave);
       this.host.removeEventListener('keydown', this.handleKeyDown);
       this.host.removeEventListener('click', this.handleClick);
       this.host.removeEventListener('focusout', this.handleFocusOut);
@@ -74,10 +78,37 @@ export class SubmenuController implements ReactiveController {
     if (this.isPopupConnected) {
       if (this.popupRef.value) {
         this.popupRef.value.removeEventListener('mouseover', this.handlePopupMouseover);
+        this.popupRef.value.removeEventListener('mouseleave', this.handlePopupMouseLeave);
         this.popupRef.value.removeEventListener('syn-reposition', this.handlePopupReposition);
         this.isPopupConnected = false;
       }
     }
+
+    this.removeGlobalDismissListeners();
+  }
+
+  private addGlobalDismissListeners() {
+    if (this.hasGlobalDismissListeners) {
+      return;
+    }
+
+    document.addEventListener('keydown', this.handleDocumentKeyDown);
+    window.addEventListener('blur', this.handleWindowBlur);
+    window.addEventListener('pagehide', this.handlePageHide);
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    this.hasGlobalDismissListeners = true;
+  }
+
+  private removeGlobalDismissListeners() {
+    if (!this.hasGlobalDismissListeners) {
+      return;
+    }
+
+    document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    window.removeEventListener('blur', this.handleWindowBlur);
+    window.removeEventListener('pagehide', this.handlePageHide);
+    document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+    this.hasGlobalDismissListeners = false;
   }
 
   // Set the safe triangle cursor position
@@ -90,6 +121,35 @@ export class SubmenuController implements ReactiveController {
     if (this.hasSlotController.test('submenu')) {
       this.enableSubmenu();
     }
+  };
+
+  private isWithinSubmenuInteractionTree(target: EventTarget | null): boolean {
+    if (!(target instanceof Node)) {
+      return false;
+    }
+
+    if (this.host.contains(target)) {
+      return true;
+    }
+
+    if (this.popupRef.value?.contains(target)) {
+      return true;
+    }
+
+    const rootNode = target.getRootNode();
+    if (rootNode instanceof ShadowRoot) {
+      return this.isWithinSubmenuInteractionTree(rootNode.host);
+    }
+
+    return false;
+  }
+
+  private handleHostMouseLeave = (event: MouseEvent) => {
+    if (this.isWithinSubmenuInteractionTree(event.relatedTarget)) {
+      return;
+    }
+
+    this.disableSubmenu();
   };
 
   private handleSubmenuEntry(event: KeyboardEvent) {
@@ -187,9 +247,38 @@ export class SubmenuController implements ReactiveController {
     this.disableSubmenu();
   };
 
+  private handleWindowBlur = () => {
+    this.disableSubmenu();
+  };
+
+  private handlePageHide = () => {
+    this.disableSubmenu();
+  };
+
+  private handleVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      this.disableSubmenu();
+    }
+  };
+
+  private handleDocumentKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.isExpanded()) {
+      this.disableSubmenu();
+      event.stopPropagation();
+    }
+  };
+
   // Prevent the parent menu-item from getting focus on mouse movement on the submenu
   private handlePopupMouseover = (event: MouseEvent) => {
     event.stopPropagation();
+  };
+
+  private handlePopupMouseLeave = (event: MouseEvent) => {
+    if (this.isWithinSubmenuInteractionTree(event.relatedTarget)) {
+      return;
+    }
+
+    this.disableSubmenu();
   };
 
   // Set the safe triangle values for the submenu when the position changes
@@ -213,6 +302,11 @@ export class SubmenuController implements ReactiveController {
     if (this.popupRef.value) {
       if (this.popupRef.value.active !== state) {
         this.popupRef.value.active = state;
+        if (state) {
+          this.addGlobalDismissListeners();
+        } else {
+          this.removeGlobalDismissListeners();
+        }
         this.host.requestUpdate();
       }
     }

--- a/packages/components/src/components/menu/menu.component.ts
+++ b/packages/components/src/components/menu/menu.component.ts
@@ -2,7 +2,6 @@
 import { html } from 'lit';
 import { query } from 'lit/decorators.js';
 import { state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import type { SynAttributesChangedEvent } from '../../events/syn-attributes-changed.js';
 import componentStyles from '../../styles/component.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
@@ -29,11 +28,35 @@ export default class SynMenu extends SynergyElement {
 
   @query('slot') defaultSlot: HTMLSlotElement;
   @state() hasMenuItemsWithCheckmarks = false;
+  private checkmarkStyledItems = new Set<SynMenuItem>();
 
   private handleUpdateCheckmarks(items: SynMenuItem[]) {
     // #368: Treat a menu as having checkmarks if it has any checkboxes or items with loading states
     // The loading indicator has to be checked as well, as it's specially placed over the check mark
-    this.hasMenuItemsWithCheckmarks = items.some(item => item.type === 'checkbox' || item.loading);  
+    this.hasMenuItemsWithCheckmarks = items.some(item => item.type === 'checkbox' || item.loading);
+    this.syncCheckmarkVisibility(items);
+  }
+
+  private syncCheckmarkVisibility(items: SynMenuItem[]) {
+    this.checkmarkStyledItems.forEach(item => {
+      if (!items.includes(item)) {
+        item.style.removeProperty('--display-checkmark');
+        this.checkmarkStyledItems.delete(item);
+      }
+    });
+
+    if (this.hasMenuItemsWithCheckmarks) {
+      items.forEach(item => {
+        item.style.removeProperty('--display-checkmark');
+        this.checkmarkStyledItems.delete(item);
+      });
+      return;
+    }
+
+    items.forEach(item => {
+      item.style.setProperty('--display-checkmark', 'none');
+      this.checkmarkStyledItems.add(item);
+    });
   }
 
   private updateCheckMarksByChildPropChange = (e: SynAttributesChangedEvent) => {
@@ -43,6 +66,8 @@ export default class SynMenu extends SynergyElement {
   
   disconnectedCallback() {
     this.removeEventListener('syn-attributes-changed', this.updateCheckMarksByChildPropChange);
+    this.checkmarkStyledItems.forEach(item => item.style.removeProperty('--display-checkmark'));
+    this.checkmarkStyledItems.clear();
   }
 
   connectedCallback() {
@@ -51,22 +76,26 @@ export default class SynMenu extends SynergyElement {
     this.addEventListener('syn-attributes-changed', this.updateCheckMarksByChildPropChange);
   }
 
-  private handleClick(event: MouseEvent) {
-    const menuItemTypes = ['menuitem', 'menuitemcheckbox'];
-
+  private getMenuItemFromEvent(event: Event) {
     const composedPath = event.composedPath();
-    const target = composedPath.find((el: Element) => menuItemTypes.includes(el?.getAttribute?.('role') || ''));
+    const target = composedPath.find((el: EventTarget) => el instanceof HTMLElement && this.isMenuItem(el));
 
-    if (!target) return;
+    if (!target || !(target instanceof HTMLElement)) {
+      return undefined;
+    }
 
-    const closestMenu = composedPath.find((el: Element) => el?.getAttribute?.('role') === 'menu');
-    const clickHasSubmenu = closestMenu !== this;
+    const closestMenu = composedPath.find((el: EventTarget) => el instanceof Element && el.getAttribute('role') === 'menu');
+    if (closestMenu !== this) {
+      return undefined;
+    }
 
-    // Make sure we're the menu thats supposed to be handling the click event.
-    if (clickHasSubmenu) return;
+    return target as SynMenuItem;
+  }
 
-    // This isn't true. But we use it for TypeScript checks below.
-    const item = target as SynMenuItem;
+  private handleClick(event: MouseEvent) {
+    const item = this.getMenuItemFromEvent(event);
+
+    if (!item) return;
 
     if (item.type === 'checkbox') {
       item.checked = !item.checked;
@@ -120,10 +149,10 @@ export default class SynMenu extends SynergyElement {
   }
 
   private handleMouseDown(event: MouseEvent) {
-    const target = event.target as HTMLElement;
+    const target = this.getMenuItemFromEvent(event);
 
-    if (this.isMenuItem(target)) {
-      this.setCurrentItem(target as SynMenuItem);
+    if (target) {
+      this.setCurrentItem(target);
     }
   }
 
@@ -144,14 +173,25 @@ export default class SynMenu extends SynergyElement {
     );
   }
 
+  private getMenuItemsFromElement(element: HTMLElement): SynMenuItem[] {
+    if (element.inert) {
+      return [];
+    }
+
+    if (this.isMenuItem(element)) {
+      return [element as SynMenuItem];
+    }
+
+    if (element.tagName.toLowerCase() === 'syn-menu') {
+      return [];
+    }
+
+    return [...element.children].flatMap(child => this.getMenuItemsFromElement(child as HTMLElement));
+  }
+
   /** @internal Gets all slotted menu items, ignoring dividers, headers, and other elements. */
   getAllItems() {
-    return [...this.defaultSlot.assignedElements({ flatten: true })].filter((el: HTMLElement) => {
-      if (el.inert || !this.isMenuItem(el)) {
-        return false;
-      }
-      return true;
-    }) as SynMenuItem[];
+    return [...this.defaultSlot.assignedElements({ flatten: true })].flatMap(el => this.getMenuItemsFromElement(el as HTMLElement));
   }
 
   /**
@@ -178,9 +218,6 @@ export default class SynMenu extends SynergyElement {
   render() {
     return html`
       <slot
-        class=${classMap({
-          'menu--no-checkmarks': !this.hasMenuItemsWithCheckmarks,
-        })}
         @slotchange=${this.handleSlotChange}
         @click=${this.handleClick}
         @keydown=${this.handleKeyDown}

--- a/packages/components/src/components/menu/menu.custom.test.ts
+++ b/packages/components/src/components/menu/menu.custom.test.ts
@@ -50,4 +50,33 @@ describe('<syn-menu> (custom)', () => {
 
     expect(getShowCheckmarks(menu.querySelectorAll('syn-menu-item'))).to.be.false;
   });
+
+  it('should hide checkmarks for wrapped menu items when no item is checkbox or loading', async () => {
+    const menu = await fixture<SynMenu>(html`
+      <syn-menu>
+        <syn-tooltip content="something">
+          <syn-menu-item value="item-1">Item 1</syn-menu-item>
+        </syn-tooltip>
+        <syn-menu-item value="item-2">Item 2</syn-menu-item>
+      </syn-menu>
+    `);
+
+    const menuItems = menu.querySelectorAll('syn-menu-item');
+    expect(menuItems.length).to.equal(2);
+    expect(Array.from(menuItems).every(item => getComputedStyle(item).getPropertyValue('--display-checkmark') === 'none')).to
+      .be.true;
+  });
+
+  it('should show checkmarks for wrapped menu items when any item is checkbox', async () => {
+    const menu = await fixture<SynMenu>(html`
+      <syn-menu>
+        <syn-tooltip content="something">
+          <syn-menu-item value="item-1">Item 1</syn-menu-item>
+        </syn-tooltip>
+        <syn-menu-item value="item-2" type="checkbox">Item 2</syn-menu-item>
+      </syn-menu>
+    `);
+
+    expect(getShowCheckmarks(menu.querySelectorAll('syn-menu-item'))).to.be.true;
+  });
 });

--- a/packages/components/src/components/menu/menu.styles.ts
+++ b/packages/components/src/components/menu/menu.styles.ts
@@ -26,12 +26,4 @@ export default css`
   ::slotted(syn-menu-label:first-of-type) {
     --display-divider: none;
   }
-
-  /*
-   * #368: Hide the checkmarks for menu items
-   * when no syn-menu-item[checkbox] or loading is present
-   */
-  .menu--no-checkmarks::slotted(syn-menu-item) {
-    --display-checkmark: none;
-  }
 `;

--- a/packages/components/src/components/menu/menu.test.ts
+++ b/packages/components/src/components/menu/menu.test.ts
@@ -103,6 +103,31 @@ describe('<syn-menu>', () => {
     expect(selectHandler).to.not.have.been.called;
   });
 
+  it('should include wrapped menu items in roving tabindex', async () => {
+    const menu = await fixture<SynMenu>(html`
+      <syn-menu>
+        <syn-tooltip content="Tooltip">
+          <syn-menu-item value="item-1">Item 1</syn-menu-item>
+        </syn-tooltip>
+        <syn-menu-item value="item-2">Item 2</syn-menu-item>
+      </syn-menu>
+    `);
+
+    const [item1, item2] = menu.querySelectorAll<SynMenuItem>('syn-menu-item');
+
+    expect(menu.getAllItems()).to.deep.equal([item1, item2]);
+    expect(item1.getAttribute('tabindex')).to.equal('0');
+    expect(item2.getAttribute('tabindex')).to.equal('-1');
+
+    item1.focus();
+    await item1.updateComplete;
+    await sendKeys({ press: 'ArrowDown' });
+
+    expect(document.activeElement).to.equal(item2);
+    expect(item1.getAttribute('tabindex')).to.equal('-1');
+    expect(item2.getAttribute('tabindex')).to.equal('0');
+  });
+
   // @see https://github.com/shoelace-style/shoelace/issues/1596
   it('Should fire "syn-select" when clicking an element within a menu-item', async () => {
     // eslint-disable-next-line

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-05-28T08:21:08.714Z",
+  "builtAt": "2026-06-02T06:46:01.735Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset:sick2018-icons.json",

--- a/packages/metadata/data/layers/full/component/component:syn-menu-item/components/menu-item.component.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-menu-item/components/menu-item.component.ts
@@ -79,13 +79,11 @@ export default class SynMenuItem extends SynergyElement {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('click', this.handleHostClick);
-    this.addEventListener('mouseover', this.handleMouseOver);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener('click', this.handleHostClick);
-    this.removeEventListener('mouseover', this.handleMouseOver);
   }
 
   private handleDefaultSlotChange() {
@@ -110,11 +108,6 @@ export default class SynMenuItem extends SynergyElement {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
-  };
-
-  private handleMouseOver = (event: MouseEvent) => {
-    this.focus();
-    event.stopPropagation();
   };
 
   @watch('checked')

--- a/packages/metadata/data/layers/full/component/component:syn-menu-item/components/submenu-controller.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-menu-item/components/submenu-controller.ts
@@ -11,6 +11,7 @@ export class SubmenuController implements ReactiveController {
   private host: ReactiveControllerHost & SynMenuItem;
   private popupRef: Ref<SynPopup> = createRef();
   private enableSubmenuTimer = -1;
+  private hasGlobalDismissListeners = false;
   private isConnected = false;
   private isPopupConnected = false;
   private skidding = 0;
@@ -45,6 +46,7 @@ export class SubmenuController implements ReactiveController {
     if (!this.isConnected) {
       this.host.addEventListener('mousemove', this.handleMouseMove);
       this.host.addEventListener('mouseover', this.handleMouseOver);
+      this.host.addEventListener('mouseleave', this.handleHostMouseLeave);
       this.host.addEventListener('keydown', this.handleKeyDown);
       this.host.addEventListener('click', this.handleClick);
       this.host.addEventListener('focusout', this.handleFocusOut);
@@ -56,6 +58,7 @@ export class SubmenuController implements ReactiveController {
     if (!this.isPopupConnected) {
       if (this.popupRef.value) {
         this.popupRef.value.addEventListener('mouseover', this.handlePopupMouseover);
+        this.popupRef.value.addEventListener('mouseleave', this.handlePopupMouseLeave);
         this.popupRef.value.addEventListener('syn-reposition', this.handlePopupReposition);
         this.isPopupConnected = true;
       }
@@ -66,6 +69,7 @@ export class SubmenuController implements ReactiveController {
     if (this.isConnected) {
       this.host.removeEventListener('mousemove', this.handleMouseMove);
       this.host.removeEventListener('mouseover', this.handleMouseOver);
+      this.host.removeEventListener('mouseleave', this.handleHostMouseLeave);
       this.host.removeEventListener('keydown', this.handleKeyDown);
       this.host.removeEventListener('click', this.handleClick);
       this.host.removeEventListener('focusout', this.handleFocusOut);
@@ -74,10 +78,37 @@ export class SubmenuController implements ReactiveController {
     if (this.isPopupConnected) {
       if (this.popupRef.value) {
         this.popupRef.value.removeEventListener('mouseover', this.handlePopupMouseover);
+        this.popupRef.value.removeEventListener('mouseleave', this.handlePopupMouseLeave);
         this.popupRef.value.removeEventListener('syn-reposition', this.handlePopupReposition);
         this.isPopupConnected = false;
       }
     }
+
+    this.removeGlobalDismissListeners();
+  }
+
+  private addGlobalDismissListeners() {
+    if (this.hasGlobalDismissListeners) {
+      return;
+    }
+
+    document.addEventListener('keydown', this.handleDocumentKeyDown);
+    window.addEventListener('blur', this.handleWindowBlur);
+    window.addEventListener('pagehide', this.handlePageHide);
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    this.hasGlobalDismissListeners = true;
+  }
+
+  private removeGlobalDismissListeners() {
+    if (!this.hasGlobalDismissListeners) {
+      return;
+    }
+
+    document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    window.removeEventListener('blur', this.handleWindowBlur);
+    window.removeEventListener('pagehide', this.handlePageHide);
+    document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+    this.hasGlobalDismissListeners = false;
   }
 
   // Set the safe triangle cursor position
@@ -90,6 +121,35 @@ export class SubmenuController implements ReactiveController {
     if (this.hasSlotController.test('submenu')) {
       this.enableSubmenu();
     }
+  };
+
+  private isWithinSubmenuInteractionTree(target: EventTarget | null): boolean {
+    if (!(target instanceof Node)) {
+      return false;
+    }
+
+    if (this.host.contains(target)) {
+      return true;
+    }
+
+    if (this.popupRef.value?.contains(target)) {
+      return true;
+    }
+
+    const rootNode = target.getRootNode();
+    if (rootNode instanceof ShadowRoot) {
+      return this.isWithinSubmenuInteractionTree(rootNode.host);
+    }
+
+    return false;
+  }
+
+  private handleHostMouseLeave = (event: MouseEvent) => {
+    if (this.isWithinSubmenuInteractionTree(event.relatedTarget)) {
+      return;
+    }
+
+    this.disableSubmenu();
   };
 
   private handleSubmenuEntry(event: KeyboardEvent) {
@@ -187,9 +247,38 @@ export class SubmenuController implements ReactiveController {
     this.disableSubmenu();
   };
 
+  private handleWindowBlur = () => {
+    this.disableSubmenu();
+  };
+
+  private handlePageHide = () => {
+    this.disableSubmenu();
+  };
+
+  private handleVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      this.disableSubmenu();
+    }
+  };
+
+  private handleDocumentKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.isExpanded()) {
+      this.disableSubmenu();
+      event.stopPropagation();
+    }
+  };
+
   // Prevent the parent menu-item from getting focus on mouse movement on the submenu
   private handlePopupMouseover = (event: MouseEvent) => {
     event.stopPropagation();
+  };
+
+  private handlePopupMouseLeave = (event: MouseEvent) => {
+    if (this.isWithinSubmenuInteractionTree(event.relatedTarget)) {
+      return;
+    }
+
+    this.disableSubmenu();
   };
 
   // Set the safe triangle values for the submenu when the position changes
@@ -213,6 +302,11 @@ export class SubmenuController implements ReactiveController {
     if (this.popupRef.value) {
       if (this.popupRef.value.active !== state) {
         this.popupRef.value.active = state;
+        if (state) {
+          this.addGlobalDismissListeners();
+        } else {
+          this.removeGlobalDismissListeners();
+        }
         this.host.requestUpdate();
       }
     }

--- a/packages/metadata/data/layers/full/component/component:syn-menu/components/menu.component.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-menu/components/menu.component.ts
@@ -2,7 +2,6 @@
 import { html } from 'lit';
 import { query } from 'lit/decorators.js';
 import { state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import type { SynAttributesChangedEvent } from '../../events/syn-attributes-changed.js';
 import componentStyles from '../../styles/component.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
@@ -29,11 +28,35 @@ export default class SynMenu extends SynergyElement {
 
   @query('slot') defaultSlot: HTMLSlotElement;
   @state() hasMenuItemsWithCheckmarks = false;
+  private checkmarkStyledItems = new Set<SynMenuItem>();
 
   private handleUpdateCheckmarks(items: SynMenuItem[]) {
     // #368: Treat a menu as having checkmarks if it has any checkboxes or items with loading states
     // The loading indicator has to be checked as well, as it's specially placed over the check mark
-    this.hasMenuItemsWithCheckmarks = items.some(item => item.type === 'checkbox' || item.loading);  
+    this.hasMenuItemsWithCheckmarks = items.some(item => item.type === 'checkbox' || item.loading);
+    this.syncCheckmarkVisibility(items);
+  }
+
+  private syncCheckmarkVisibility(items: SynMenuItem[]) {
+    this.checkmarkStyledItems.forEach(item => {
+      if (!items.includes(item)) {
+        item.style.removeProperty('--display-checkmark');
+        this.checkmarkStyledItems.delete(item);
+      }
+    });
+
+    if (this.hasMenuItemsWithCheckmarks) {
+      items.forEach(item => {
+        item.style.removeProperty('--display-checkmark');
+        this.checkmarkStyledItems.delete(item);
+      });
+      return;
+    }
+
+    items.forEach(item => {
+      item.style.setProperty('--display-checkmark', 'none');
+      this.checkmarkStyledItems.add(item);
+    });
   }
 
   private updateCheckMarksByChildPropChange = (e: SynAttributesChangedEvent) => {
@@ -43,6 +66,8 @@ export default class SynMenu extends SynergyElement {
   
   disconnectedCallback() {
     this.removeEventListener('syn-attributes-changed', this.updateCheckMarksByChildPropChange);
+    this.checkmarkStyledItems.forEach(item => item.style.removeProperty('--display-checkmark'));
+    this.checkmarkStyledItems.clear();
   }
 
   connectedCallback() {
@@ -51,22 +76,26 @@ export default class SynMenu extends SynergyElement {
     this.addEventListener('syn-attributes-changed', this.updateCheckMarksByChildPropChange);
   }
 
-  private handleClick(event: MouseEvent) {
-    const menuItemTypes = ['menuitem', 'menuitemcheckbox'];
-
+  private getMenuItemFromEvent(event: Event) {
     const composedPath = event.composedPath();
-    const target = composedPath.find((el: Element) => menuItemTypes.includes(el?.getAttribute?.('role') || ''));
+    const target = composedPath.find((el: EventTarget) => el instanceof HTMLElement && this.isMenuItem(el));
 
-    if (!target) return;
+    if (!target || !(target instanceof HTMLElement)) {
+      return undefined;
+    }
 
-    const closestMenu = composedPath.find((el: Element) => el?.getAttribute?.('role') === 'menu');
-    const clickHasSubmenu = closestMenu !== this;
+    const closestMenu = composedPath.find((el: EventTarget) => el instanceof Element && el.getAttribute('role') === 'menu');
+    if (closestMenu !== this) {
+      return undefined;
+    }
 
-    // Make sure we're the menu thats supposed to be handling the click event.
-    if (clickHasSubmenu) return;
+    return target as SynMenuItem;
+  }
 
-    // This isn't true. But we use it for TypeScript checks below.
-    const item = target as SynMenuItem;
+  private handleClick(event: MouseEvent) {
+    const item = this.getMenuItemFromEvent(event);
+
+    if (!item) return;
 
     if (item.type === 'checkbox') {
       item.checked = !item.checked;
@@ -120,10 +149,10 @@ export default class SynMenu extends SynergyElement {
   }
 
   private handleMouseDown(event: MouseEvent) {
-    const target = event.target as HTMLElement;
+    const target = this.getMenuItemFromEvent(event);
 
-    if (this.isMenuItem(target)) {
-      this.setCurrentItem(target as SynMenuItem);
+    if (target) {
+      this.setCurrentItem(target);
     }
   }
 
@@ -144,14 +173,25 @@ export default class SynMenu extends SynergyElement {
     );
   }
 
+  private getMenuItemsFromElement(element: HTMLElement): SynMenuItem[] {
+    if (element.inert) {
+      return [];
+    }
+
+    if (this.isMenuItem(element)) {
+      return [element as SynMenuItem];
+    }
+
+    if (element.tagName.toLowerCase() === 'syn-menu') {
+      return [];
+    }
+
+    return [...element.children].flatMap(child => this.getMenuItemsFromElement(child as HTMLElement));
+  }
+
   /** @internal Gets all slotted menu items, ignoring dividers, headers, and other elements. */
   getAllItems() {
-    return [...this.defaultSlot.assignedElements({ flatten: true })].filter((el: HTMLElement) => {
-      if (el.inert || !this.isMenuItem(el)) {
-        return false;
-      }
-      return true;
-    }) as SynMenuItem[];
+    return [...this.defaultSlot.assignedElements({ flatten: true })].flatMap(el => this.getMenuItemsFromElement(el as HTMLElement));
   }
 
   /**
@@ -178,9 +218,6 @@ export default class SynMenu extends SynergyElement {
   render() {
     return html`
       <slot
-        class=${classMap({
-          'menu--no-checkmarks': !this.hasMenuItemsWithCheckmarks,
-        })}
         @slotchange=${this.handleSlotChange}
         @click=${this.handleClick}
         @keydown=${this.handleKeyDown}

--- a/packages/metadata/data/layers/full/component/component:syn-menu/components/menu.styles.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-menu/components/menu.styles.ts
@@ -26,12 +26,4 @@ export default css`
   ::slotted(syn-menu-label:first-of-type) {
     --display-divider: none;
   }
-
-  /*
-   * #368: Hide the checkmarks for menu items
-   * when no syn-menu-item[checkbox] or loading is present
-   */
-  .menu--no-checkmarks::slotted(syn-menu-item) {
-    --display-checkmark: none;
-  }
 `;

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-05-28T08:21:08.716Z",
+  "builtAt": "2026-06-02T06:46:01.735Z",
   "sources": [
     {
       "entityCount": 4,


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This release fixes multiple issues when using `<syn-menu>`:

- submenus no longer stay open when leaving the browser window (#882)
- `<syn-menu-item>` wrapped in tooltip can now be used reliably (including navigation and selection) (#1162)
- `<syn-menu-item>` no longer steals focus on hover (#1286)

### 🎫 Issues

Closes #1295
Closes #882
Closes #1162 
Closes #1286 

## 👩‍💻 Reviewer Notes

I originally wanted to move to WebAwesome for the menu, then found out that WebAwesome dropped the component completely and only allows the use in dropdowns. This made it impossible to port the issues. Because of that, I adjusted our own code because otherwise it would have been a breaking release.

The following changes where made:

- Items do not longer steal focus. This means that if you do NOT click an item, it will not get activated anymore. It also means that `<syn-menu>` is now actually usable as a standalone component
- Because of the change above, you can now use syn-tooltip anywhere
- A small change for checkmarks needed to be implemented (when using syn-tooltip > syn-menu-item, the menu-item is no longer slotted directly, so I had to move to a JS based approach for this).
- Because the focus stealing is no longer there, menus will now auto close when hovering out.

## 📑 Test Plan

Play around with the stories of syn-menu, syn-menu-item and syn-dropdown to see the difference. Also try to add a syn-tooltip anywhere in a tree/subtree.

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
