### PR TITLE
fix: 🐛 syn-select and syn-dropdown not opening correctly when slotted in syn-dialog

### DIFF
--- a/.changeset/1297-syn-select-in-syn-dialog-broken-in-chrome.md
+++ b/.changeset/1297-syn-select-in-syn-dialog-broken-in-chrome.md
@@ -1,0 +1,8 @@
+---
+"@synergy-design-system/components": patch
+"@synergy-design-system/metadata": patch
+---
+
+fix: 🐛 `<syn-select>` and `<syn-dropdown>` not opening correctly when slotted in `<syn-dialog>` (#1297)
+
+This release fixes an issue with multiple Synergy components automatically closing when opened in a `<syn-dialog>` element in Chromium based browsers. This happens because Chromium now uses a more aggressive method of checking the active focused element.

--- a/.changeset/1297-syn-select-in-syn-dialog-broken-in-chrome.md
+++ b/.changeset/1297-syn-select-in-syn-dialog-broken-in-chrome.md
@@ -3,6 +3,6 @@
 "@synergy-design-system/metadata": patch
 ---
 
-fix: 🐛 `<syn-select>` and `<syn-dropdown>` not opening correctly when slotted in `<syn-dialog>` (#1297)
+fix: 🐛 `<syn-select>` and `<syn-dropdown>` not opening correctly when slotted in `<syn-dialog>` or `<syn-drawer>` (#1297)
 
-This release fixes an issue with multiple Synergy components automatically closing when opened in a `<syn-dialog>` element in Chromium based browsers. This happens because Chromium now uses a more aggressive method of checking the active focused element.
+This release fixes an issue with multiple Synergy components automatically closing when opened in a `<syn-dialog>` or `<syn-drawer>` element in Chromium based browsers. This happens because Chromium now uses a more aggressive method of checking the active focused element when using `popover`.

--- a/packages/components/LIMITATIONS.md
+++ b/packages/components/LIMITATIONS.md
@@ -301,6 +301,57 @@ In other cases, make sure to suppress the other elements' emitted `syn-hide` eve
 
 ---
 
+<h2 id="syn-dialog-focus-trap-top-layer">Keyboard focus jumps to the dialog close button when popup components are used inside `<syn-dialog>`</h2>
+
+<h3 id="syn-dialog-focus-trap-top-layer-meta">Meta Information</h3>
+
+- Framework version: ALL
+- Synergy version: <= 3.15.2
+- Browsers: Chrome >= 149.0.7827.54, Edge >= 149.0.4022.52
+- Issues: [#1297](https://github.com/synergy-design-system/synergy-design-system/issues/1297)
+
+<h3 id="syn-dialog-focus-trap-top-layer-description">Description</h3>
+
+When using keyboard navigation in popup-based components (e.g. `<syn-select>` or `<syn-dropdown>`) inside an open `<syn-dialog>`, focus may jump to the dialog close button instead of staying on popup menu items.
+
+<h3 id="syn-dialog-focus-trap-top-layer-cause">Cause</h3>
+
+Some browsers render popup content in the top layer. In this case, the focused popup element may no longer be detected as part of the dialog subtree. The dialog's modal focus trap then treats focus as escaped and moves it back to the first tabbable dialog element (often the close button).
+
+<h3 id="syn-dialog-focus-trap-top-layer-solution">Proposed Solution</h3>
+
+When opening a popup inside a dialog, temporarily disable the dialog focus trap with `dialog.modal.activateExternal()`. Re-enable it after closing with `dialog.modal.deactivateExternal()`.
+
+<h4 id="syn-dialog-focus-trap-top-layer-problem">Problem</h4>
+
+```html
+<syn-dialog open>
+  <my-custom-popup-select></my-custom-popup-select>
+</syn-dialog>
+
+<script type="module">
+  // Inside my-custom-popup-select keyboard handling
+  // Focus may jump to the syn-dialog close button on ArrowDown
+</script>
+```
+
+<h4 id="syn-dialog-focus-trap-top-layer-solution-example">Solution</h4>
+
+```js
+// Example component logic
+const dialog = this.closest("syn-dialog");
+
+function onOpenPopup() {
+  dialog?.modal?.activateExternal();
+}
+
+function onClosePopup() {
+  dialog?.modal?.deactivateExternal();
+}
+```
+
+---
+
 <h2 id="syn-nav-item-click-events">Click events for `syn-nav-item` are not fired when clicking slotted items (e.g. icons)</h2>
 
 <h3 id="syn-nav-item-click-events-meta">Meta Information</h3>

--- a/packages/components/LIMITATIONS.md
+++ b/packages/components/LIMITATIONS.md
@@ -301,7 +301,7 @@ In other cases, make sure to suppress the other elements' emitted `syn-hide` eve
 
 ---
 
-<h2 id="syn-dialog-focus-trap-top-layer">Keyboard focus jumps to the dialog close button when popup components are used inside `<syn-dialog>`</h2>
+<h2 id="syn-dialog-focus-trap-top-layer">Keyboard focus jumps to the modal close button when popup components are used inside `<syn-dialog>` or `<syn-drawer>`</h2>
 
 <h3 id="syn-dialog-focus-trap-top-layer-meta">Meta Information</h3>
 
@@ -312,15 +312,15 @@ In other cases, make sure to suppress the other elements' emitted `syn-hide` eve
 
 <h3 id="syn-dialog-focus-trap-top-layer-description">Description</h3>
 
-When using keyboard navigation in popup-based components (e.g. `<syn-select>` or `<syn-dropdown>`) inside an open `<syn-dialog>`, focus may jump to the dialog close button instead of staying on popup menu items.
+When using keyboard navigation in popup-based components (e.g. `<syn-select>` or `<syn-dropdown>`) inside an open `<syn-dialog>` or `<syn-drawer>`, focus may jump to the modal close button instead of staying on popup menu items.
 
 <h3 id="syn-dialog-focus-trap-top-layer-cause">Cause</h3>
 
-Some browsers render popup content in the top layer. In this case, the focused popup element may no longer be detected as part of the dialog subtree. The dialog's modal focus trap then treats focus as escaped and moves it back to the first tabbable dialog element (often the close button).
+Some browsers render popup content in the top layer. In this case, the focused popup element may no longer be detected as part of the modal subtree. The modal focus trap then treats focus as escaped and moves it back to the first tabbable modal element (often the close button).
 
 <h3 id="syn-dialog-focus-trap-top-layer-solution">Proposed Solution</h3>
 
-When opening a popup inside a dialog, temporarily disable the dialog focus trap with `dialog.modal.activateExternal()`. Re-enable it after closing with `dialog.modal.deactivateExternal()`.
+When opening a popup inside a dialog or drawer, temporarily disable the host modal focus trap with `modalHost.modal.activateExternal()`. Re-enable it after closing with `modalHost.modal.deactivateExternal()`.
 
 <h4 id="syn-dialog-focus-trap-top-layer-problem">Problem</h4>
 
@@ -329,9 +329,13 @@ When opening a popup inside a dialog, temporarily disable the dialog focus trap 
   <my-custom-popup-select></my-custom-popup-select>
 </syn-dialog>
 
+<syn-drawer open>
+  <my-custom-popup-select></my-custom-popup-select>
+</syn-drawer>
+
 <script type="module">
   // Inside my-custom-popup-select keyboard handling
-  // Focus may jump to the syn-dialog close button on ArrowDown
+  // Focus may jump to the modal close button on ArrowDown
 </script>
 ```
 
@@ -339,14 +343,14 @@ When opening a popup inside a dialog, temporarily disable the dialog focus trap 
 
 ```js
 // Example component logic
-const dialog = this.closest("syn-dialog");
+const modalHost = this.closest("syn-dialog, syn-drawer");
 
 function onOpenPopup() {
-  dialog?.modal?.activateExternal();
+  modalHost?.modal?.activateExternal();
 }
 
 function onClosePopup() {
-  dialog?.modal?.deactivateExternal();
+  modalHost?.modal?.deactivateExternal();
 }
 ```
 

--- a/packages/components/src/components/dropdown/dropdown.component.ts
+++ b/packages/components/src/components/dropdown/dropdown.component.ts
@@ -17,7 +17,6 @@ import styles from './dropdown.styles.js';
 import type { CSSResultGroup } from 'lit';
 import type { SynSelectEvent } from '../../events/syn-select.js';
 import type SynButton from '../button/button.js';
-import type SynDialog from '../dialog/dialog.js';
 import type SynIconButton from '../icon-button/icon-button.js';
 import type SynMenu from '../menu/menu.js';
 
@@ -137,8 +136,10 @@ export default class SynDropdown extends SynergyElement {
     }
   }
 
-  private getContainingDialog() {
-    return this.closest('syn-dialog') as SynDialog | null;
+  private getContainingModalHost() {
+    return this.closest('syn-dialog, syn-drawer') as
+      | (HTMLElement & { modal?: { activateExternal(): void; deactivateExternal(): void } })
+      | null;
   }
 
   getMenu() {
@@ -360,9 +361,8 @@ export default class SynDropdown extends SynergyElement {
   addOpenListeners() {
     this.panel.addEventListener('syn-select', this.handlePanelSelect);
 
-    // If the dropdown is inside a dialog, temporarily disable its focus trap while the
-    // popup is open because popup content can move to the browser top layer.
-    this.getContainingDialog()?.modal?.activateExternal();
+    // #1297: If the dropdown is inside a dialog, temporarily disable its focus trap while the popup is open because popup content can move to the browser top layer.
+    this.getContainingModalHost()?.modal?.activateExternal();
 
     if ('CloseWatcher' in window) {
       this.closeWatcher?.destroy();
@@ -384,7 +384,8 @@ export default class SynDropdown extends SynergyElement {
       this.panel.removeEventListener('keydown', this.handleKeyDown);
     }
 
-    this.getContainingDialog()?.modal?.deactivateExternal();
+    // #1297: If the dropdown is inside a dialog, temporarily disable its focus trap while the popup is open because popup content can move to the browser top layer.
+    this.getContainingModalHost()?.modal?.deactivateExternal();
 
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);

--- a/packages/components/src/components/dropdown/dropdown.component.ts
+++ b/packages/components/src/components/dropdown/dropdown.component.ts
@@ -17,6 +17,7 @@ import styles from './dropdown.styles.js';
 import type { CSSResultGroup } from 'lit';
 import type { SynSelectEvent } from '../../events/syn-select.js';
 import type SynButton from '../button/button.js';
+import type SynDialog from '../dialog/dialog.js';
 import type SynIconButton from '../icon-button/icon-button.js';
 import type SynMenu from '../menu/menu.js';
 
@@ -134,6 +135,10 @@ export default class SynDropdown extends SynergyElement {
     if (typeof trigger?.focus === 'function') {
       trigger.focus();
     }
+  }
+
+  private getContainingDialog() {
+    return this.closest('syn-dialog') as SynDialog | null;
   }
 
   getMenu() {
@@ -354,6 +359,11 @@ export default class SynDropdown extends SynergyElement {
 
   addOpenListeners() {
     this.panel.addEventListener('syn-select', this.handlePanelSelect);
+
+    // If the dropdown is inside a dialog, temporarily disable its focus trap while the
+    // popup is open because popup content can move to the browser top layer.
+    this.getContainingDialog()?.modal?.activateExternal();
+
     if ('CloseWatcher' in window) {
       this.closeWatcher?.destroy();
       this.closeWatcher = new CloseWatcher();
@@ -373,6 +383,9 @@ export default class SynDropdown extends SynergyElement {
       this.panel.removeEventListener('syn-select', this.handlePanelSelect);
       this.panel.removeEventListener('keydown', this.handleKeyDown);
     }
+
+    this.getContainingDialog()?.modal?.deactivateExternal();
+
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
     this.closeWatcher?.destroy();

--- a/packages/components/src/components/dropdown/dropdown.test.ts
+++ b/packages/components/src/components/dropdown/dropdown.test.ts
@@ -207,6 +207,32 @@ describe('<syn-dropdown>', () => {
     expect(document.activeElement).to.equal(secondMenuItem);
   });
 
+  it('should keep keyboard focus on menu items when inside a dialog', async () => {
+    const dialog = await fixture<HTMLElement>(html`
+      <syn-dialog open>
+        <syn-dropdown>
+          <syn-button slot="trigger" caret>Toggle</syn-button>
+          <syn-menu>
+            <syn-menu-item>Item 1</syn-menu-item>
+            <syn-menu-item>Item 2</syn-menu-item>
+          </syn-menu>
+        </syn-dropdown>
+      </syn-dialog>
+    `);
+    const el = dialog.querySelector<SynDropdown>('syn-dropdown')!;
+    const trigger = el.querySelector('syn-button')!;
+    const firstMenuItem = el.querySelectorAll('syn-menu-item')[0];
+    const dialogCloseButton = dialog.shadowRoot!.querySelector('syn-icon-button')!;
+
+    trigger.focus();
+    await sendKeys({ press: 'ArrowDown' });
+    await el.updateComplete;
+
+    expect(el.open).to.be.true;
+    expect(document.activeElement).to.equal(firstMenuItem);
+    expect(document.activeElement).to.not.equal(dialogCloseButton);
+  });
+
   it('should navigate to first focusable item on arrow navigation', async () => {
     const el = await fixture<SynDropdown>(html`
       <syn-dropdown>

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -14,7 +14,6 @@ import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
 import formControlStyles from '../../styles/form-control.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
-import type SynDialog from '../dialog/dialog.js';
 import SynIcon from '../icon/icon.component.js';
 import SynPopup from '../popup/popup.component.js';
 import SynTag from '../tag/tag.component.js';
@@ -95,8 +94,10 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   private selectedOptionObserver: MutationObserver;
   private isUserInput: boolean = false;
 
-  private getContainingDialog() {
-    return this.closest('syn-dialog') as SynDialog | null;
+  private getContainingModalHost() {
+    return this.closest('syn-dialog, syn-drawer') as
+      | (HTMLElement & { modal?: { activateExternal(): void; deactivateExternal(): void } })
+      | null;
   }
 
   @query('.select') popup: SynPopup;
@@ -306,7 +307,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.addEventListener('mousedown', this.handleDocumentMouseDown);
 
     // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
-    this.getContainingDialog()?.modal?.activateExternal();
+    this.getContainingModalHost()?.modal?.activateExternal();
 
     // If the component is rendered in a shadow root, we need to attach the focusin listener there too
     if (this.getRootNode() !== document) {
@@ -331,7 +332,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
 
     // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
-    this.getContainingDialog()?.modal?.deactivateExternal();
+    this.getContainingModalHost()?.modal?.deactivateExternal();
 
     if (this.getRootNode() !== document) {
       this.getRootNode().removeEventListener('focusin', this.handleDocumentFocusIn);

--- a/packages/components/src/components/select/select.component.ts
+++ b/packages/components/src/components/select/select.component.ts
@@ -14,6 +14,7 @@ import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
 import formControlStyles from '../../styles/form-control.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
+import type SynDialog from '../dialog/dialog.js';
 import SynIcon from '../icon/icon.component.js';
 import SynPopup from '../popup/popup.component.js';
 import SynTag from '../tag/tag.component.js';
@@ -93,6 +94,10 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   private resizeObserver: ResizeObserver;
   private selectedOptionObserver: MutationObserver;
   private isUserInput: boolean = false;
+
+  private getContainingDialog() {
+    return this.closest('syn-dialog') as SynDialog | null;
+  }
 
   @query('.select') popup: SynPopup;
   @query('.select__combobox') combobox: HTMLSlotElement;
@@ -300,6 +305,9 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.addEventListener('keydown', this.handleDocumentKeyDown);
     document.addEventListener('mousedown', this.handleDocumentMouseDown);
 
+    // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
+    this.getContainingDialog()?.modal?.activateExternal();
+
     // If the component is rendered in a shadow root, we need to attach the focusin listener there too
     if (this.getRootNode() !== document) {
       this.getRootNode().addEventListener('focusin', this.handleDocumentFocusIn);
@@ -321,6 +329,9 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.removeEventListener('focusin', this.handleDocumentFocusIn);
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
+
+    // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
+    this.getContainingDialog()?.modal?.deactivateExternal();
 
     if (this.getRootNode() !== document) {
       this.getRootNode().removeEventListener('focusin', this.handleDocumentFocusIn);

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -119,6 +119,53 @@ describe('<syn-select>', () => {
     await waitUntil(() => submitHandler.calledOnce);
   });
 
+  it('should stay open when used inside a dialog and opened with the mouse', async () => {
+    const dialog = await fixture<HTMLElement>(html`
+      <syn-dialog open>
+        <syn-select label="Select one">
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-select>
+      </syn-dialog>
+    `);
+    const el = dialog.querySelector<SynSelect>('syn-select')!;
+
+    const showHandler = sinon.spy();
+    const hideHandler = sinon.spy();
+    const combobox = el.shadowRoot!.querySelector('.select__combobox')!;
+
+    el.addEventListener('syn-show', showHandler);
+    el.addEventListener('syn-hide', hideHandler);
+
+    await clickOnElement(combobox);
+    await aTimeout(100);
+
+    expect(showHandler).to.have.been.calledOnce;
+    expect(hideHandler).to.not.have.been.called;
+    expect(el.open).to.equal(true);
+  });
+
+  it('should stay open when used inside a dialog and opened with the keyboard', async () => {
+    const dialog = await fixture<HTMLElement>(html`
+      <syn-dialog open>
+        <syn-select label="Select one">
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-3">Option 3</syn-option>
+        </syn-select>
+      </syn-dialog>
+    `);
+    const el = dialog.querySelector<SynSelect>('syn-select')!;
+
+    el.focus();
+    await sendKeys({ press: ' ' });
+    await waitUntil(() => el.open === true);
+    await aTimeout(100);
+
+    expect(el.open).to.equal(true);
+  });
+
   describe('when the value changes', () => {
     it('should emit syn-change when the value is changed with the mouse', async () => {
       const el = await fixture<SynSelect>(html`

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-06-03T07:54:19.203Z",
+  "builtAt": "2026-06-08T07:20:08.599Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset:sick2018-icons.json",

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-06-08T07:20:08.599Z",
+  "builtAt": "2026-06-08T09:36:50.976Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset:sick2018-icons.json",

--- a/packages/metadata/data/layers/full/component/component:syn-dropdown/components/dropdown.component.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-dropdown/components/dropdown.component.ts
@@ -17,7 +17,6 @@ import styles from './dropdown.styles.js';
 import type { CSSResultGroup } from 'lit';
 import type { SynSelectEvent } from '../../events/syn-select.js';
 import type SynButton from '../button/button.js';
-import type SynDialog from '../dialog/dialog.js';
 import type SynIconButton from '../icon-button/icon-button.js';
 import type SynMenu from '../menu/menu.js';
 
@@ -137,8 +136,10 @@ export default class SynDropdown extends SynergyElement {
     }
   }
 
-  private getContainingDialog() {
-    return this.closest('syn-dialog') as SynDialog | null;
+  private getContainingModalHost() {
+    return this.closest('syn-dialog, syn-drawer') as
+      | (HTMLElement & { modal?: { activateExternal(): void; deactivateExternal(): void } })
+      | null;
   }
 
   getMenu() {
@@ -360,9 +361,8 @@ export default class SynDropdown extends SynergyElement {
   addOpenListeners() {
     this.panel.addEventListener('syn-select', this.handlePanelSelect);
 
-    // If the dropdown is inside a dialog, temporarily disable its focus trap while the
-    // popup is open because popup content can move to the browser top layer.
-    this.getContainingDialog()?.modal?.activateExternal();
+    // #1297: If the dropdown is inside a dialog, temporarily disable its focus trap while the popup is open because popup content can move to the browser top layer.
+    this.getContainingModalHost()?.modal?.activateExternal();
 
     if ('CloseWatcher' in window) {
       this.closeWatcher?.destroy();
@@ -384,7 +384,8 @@ export default class SynDropdown extends SynergyElement {
       this.panel.removeEventListener('keydown', this.handleKeyDown);
     }
 
-    this.getContainingDialog()?.modal?.deactivateExternal();
+    // #1297: If the dropdown is inside a dialog, temporarily disable its focus trap while the popup is open because popup content can move to the browser top layer.
+    this.getContainingModalHost()?.modal?.deactivateExternal();
 
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);

--- a/packages/metadata/data/layers/full/component/component:syn-dropdown/components/dropdown.component.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-dropdown/components/dropdown.component.ts
@@ -17,6 +17,7 @@ import styles from './dropdown.styles.js';
 import type { CSSResultGroup } from 'lit';
 import type { SynSelectEvent } from '../../events/syn-select.js';
 import type SynButton from '../button/button.js';
+import type SynDialog from '../dialog/dialog.js';
 import type SynIconButton from '../icon-button/icon-button.js';
 import type SynMenu from '../menu/menu.js';
 
@@ -134,6 +135,10 @@ export default class SynDropdown extends SynergyElement {
     if (typeof trigger?.focus === 'function') {
       trigger.focus();
     }
+  }
+
+  private getContainingDialog() {
+    return this.closest('syn-dialog') as SynDialog | null;
   }
 
   getMenu() {
@@ -354,6 +359,11 @@ export default class SynDropdown extends SynergyElement {
 
   addOpenListeners() {
     this.panel.addEventListener('syn-select', this.handlePanelSelect);
+
+    // If the dropdown is inside a dialog, temporarily disable its focus trap while the
+    // popup is open because popup content can move to the browser top layer.
+    this.getContainingDialog()?.modal?.activateExternal();
+
     if ('CloseWatcher' in window) {
       this.closeWatcher?.destroy();
       this.closeWatcher = new CloseWatcher();
@@ -373,6 +383,9 @@ export default class SynDropdown extends SynergyElement {
       this.panel.removeEventListener('syn-select', this.handlePanelSelect);
       this.panel.removeEventListener('keydown', this.handleKeyDown);
     }
+
+    this.getContainingDialog()?.modal?.deactivateExternal();
+
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
     this.closeWatcher?.destroy();

--- a/packages/metadata/data/layers/full/component/component:syn-select/components/select.component.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-select/components/select.component.ts
@@ -14,7 +14,6 @@ import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
 import formControlStyles from '../../styles/form-control.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
-import type SynDialog from '../dialog/dialog.js';
 import SynIcon from '../icon/icon.component.js';
 import SynPopup from '../popup/popup.component.js';
 import SynTag from '../tag/tag.component.js';
@@ -95,8 +94,10 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   private selectedOptionObserver: MutationObserver;
   private isUserInput: boolean = false;
 
-  private getContainingDialog() {
-    return this.closest('syn-dialog') as SynDialog | null;
+  private getContainingModalHost() {
+    return this.closest('syn-dialog, syn-drawer') as
+      | (HTMLElement & { modal?: { activateExternal(): void; deactivateExternal(): void } })
+      | null;
   }
 
   @query('.select') popup: SynPopup;
@@ -306,7 +307,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.addEventListener('mousedown', this.handleDocumentMouseDown);
 
     // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
-    this.getContainingDialog()?.modal?.activateExternal();
+    this.getContainingModalHost()?.modal?.activateExternal();
 
     // If the component is rendered in a shadow root, we need to attach the focusin listener there too
     if (this.getRootNode() !== document) {
@@ -331,7 +332,7 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
 
     // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
-    this.getContainingDialog()?.modal?.deactivateExternal();
+    this.getContainingModalHost()?.modal?.deactivateExternal();
 
     if (this.getRootNode() !== document) {
       this.getRootNode().removeEventListener('focusin', this.handleDocumentFocusIn);

--- a/packages/metadata/data/layers/full/component/component:syn-select/components/select.component.ts
+++ b/packages/metadata/data/layers/full/component/component:syn-select/components/select.component.ts
@@ -14,6 +14,7 @@ import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
 import formControlStyles from '../../styles/form-control.styles.js';
 import SynergyElement from '../../internal/synergy-element.js';
+import type SynDialog from '../dialog/dialog.js';
 import SynIcon from '../icon/icon.component.js';
 import SynPopup from '../popup/popup.component.js';
 import SynTag from '../tag/tag.component.js';
@@ -93,6 +94,10 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
   private resizeObserver: ResizeObserver;
   private selectedOptionObserver: MutationObserver;
   private isUserInput: boolean = false;
+
+  private getContainingDialog() {
+    return this.closest('syn-dialog') as SynDialog | null;
+  }
 
   @query('.select') popup: SynPopup;
   @query('.select__combobox') combobox: HTMLSlotElement;
@@ -300,6 +305,9 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.addEventListener('keydown', this.handleDocumentKeyDown);
     document.addEventListener('mousedown', this.handleDocumentMouseDown);
 
+    // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
+    this.getContainingDialog()?.modal?.activateExternal();
+
     // If the component is rendered in a shadow root, we need to attach the focusin listener there too
     if (this.getRootNode() !== document) {
       this.getRootNode().addEventListener('focusin', this.handleDocumentFocusIn);
@@ -321,6 +329,9 @@ export default class SynSelect extends SynergyElement implements SynergyFormCont
     document.removeEventListener('focusin', this.handleDocumentFocusIn);
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     document.removeEventListener('mousedown', this.handleDocumentMouseDown);
+
+    // #1297: If the select is inside a dialog, we need to activate the dialog's modal to prevent focus from escaping the dialog while the select is open
+    this.getContainingDialog()?.modal?.deactivateExternal();
 
     if (this.getRootNode() !== document) {
       this.getRootNode().removeEventListener('focusin', this.handleDocumentFocusIn);

--- a/packages/metadata/data/layers/full/setup/setup:components-package/components/LIMITATIONS.md
+++ b/packages/metadata/data/layers/full/setup/setup:components-package/components/LIMITATIONS.md
@@ -301,6 +301,57 @@ In other cases, make sure to suppress the other elements' emitted `syn-hide` eve
 
 ---
 
+<h2 id="syn-dialog-focus-trap-top-layer">Keyboard focus jumps to the dialog close button when popup components are used inside `<syn-dialog>`</h2>
+
+<h3 id="syn-dialog-focus-trap-top-layer-meta">Meta Information</h3>
+
+- Framework version: ALL
+- Synergy version: <= 3.15.2
+- Browsers: Chrome >= 149.0.7827.54, Edge >= 149.0.4022.52
+- Issues: [#1297](https://github.com/synergy-design-system/synergy-design-system/issues/1297)
+
+<h3 id="syn-dialog-focus-trap-top-layer-description">Description</h3>
+
+When using keyboard navigation in popup-based components (e.g. `<syn-select>` or `<syn-dropdown>`) inside an open `<syn-dialog>`, focus may jump to the dialog close button instead of staying on popup menu items.
+
+<h3 id="syn-dialog-focus-trap-top-layer-cause">Cause</h3>
+
+Some browsers render popup content in the top layer. In this case, the focused popup element may no longer be detected as part of the dialog subtree. The dialog's modal focus trap then treats focus as escaped and moves it back to the first tabbable dialog element (often the close button).
+
+<h3 id="syn-dialog-focus-trap-top-layer-solution">Proposed Solution</h3>
+
+When opening a popup inside a dialog, temporarily disable the dialog focus trap with `dialog.modal.activateExternal()`. Re-enable it after closing with `dialog.modal.deactivateExternal()`.
+
+<h4 id="syn-dialog-focus-trap-top-layer-problem">Problem</h4>
+
+```html
+<syn-dialog open>
+  <my-custom-popup-select></my-custom-popup-select>
+</syn-dialog>
+
+<script type="module">
+  // Inside my-custom-popup-select keyboard handling
+  // Focus may jump to the syn-dialog close button on ArrowDown
+</script>
+```
+
+<h4 id="syn-dialog-focus-trap-top-layer-solution-example">Solution</h4>
+
+```js
+// Example component logic
+const dialog = this.closest("syn-dialog");
+
+function onOpenPopup() {
+  dialog?.modal?.activateExternal();
+}
+
+function onClosePopup() {
+  dialog?.modal?.deactivateExternal();
+}
+```
+
+---
+
 <h2 id="syn-nav-item-click-events">Click events for `syn-nav-item` are not fired when clicking slotted items (e.g. icons)</h2>
 
 <h3 id="syn-nav-item-click-events-meta">Meta Information</h3>

--- a/packages/metadata/data/layers/full/setup/setup:components-package/components/LIMITATIONS.md
+++ b/packages/metadata/data/layers/full/setup/setup:components-package/components/LIMITATIONS.md
@@ -301,7 +301,7 @@ In other cases, make sure to suppress the other elements' emitted `syn-hide` eve
 
 ---
 
-<h2 id="syn-dialog-focus-trap-top-layer">Keyboard focus jumps to the dialog close button when popup components are used inside `<syn-dialog>`</h2>
+<h2 id="syn-dialog-focus-trap-top-layer">Keyboard focus jumps to the modal close button when popup components are used inside `<syn-dialog>` or `<syn-drawer>`</h2>
 
 <h3 id="syn-dialog-focus-trap-top-layer-meta">Meta Information</h3>
 
@@ -312,15 +312,15 @@ In other cases, make sure to suppress the other elements' emitted `syn-hide` eve
 
 <h3 id="syn-dialog-focus-trap-top-layer-description">Description</h3>
 
-When using keyboard navigation in popup-based components (e.g. `<syn-select>` or `<syn-dropdown>`) inside an open `<syn-dialog>`, focus may jump to the dialog close button instead of staying on popup menu items.
+When using keyboard navigation in popup-based components (e.g. `<syn-select>` or `<syn-dropdown>`) inside an open `<syn-dialog>` or `<syn-drawer>`, focus may jump to the modal close button instead of staying on popup menu items.
 
 <h3 id="syn-dialog-focus-trap-top-layer-cause">Cause</h3>
 
-Some browsers render popup content in the top layer. In this case, the focused popup element may no longer be detected as part of the dialog subtree. The dialog's modal focus trap then treats focus as escaped and moves it back to the first tabbable dialog element (often the close button).
+Some browsers render popup content in the top layer. In this case, the focused popup element may no longer be detected as part of the modal subtree. The modal focus trap then treats focus as escaped and moves it back to the first tabbable modal element (often the close button).
 
 <h3 id="syn-dialog-focus-trap-top-layer-solution">Proposed Solution</h3>
 
-When opening a popup inside a dialog, temporarily disable the dialog focus trap with `dialog.modal.activateExternal()`. Re-enable it after closing with `dialog.modal.deactivateExternal()`.
+When opening a popup inside a dialog or drawer, temporarily disable the host modal focus trap with `modalHost.modal.activateExternal()`. Re-enable it after closing with `modalHost.modal.deactivateExternal()`.
 
 <h4 id="syn-dialog-focus-trap-top-layer-problem">Problem</h4>
 
@@ -329,9 +329,13 @@ When opening a popup inside a dialog, temporarily disable the dialog focus trap 
   <my-custom-popup-select></my-custom-popup-select>
 </syn-dialog>
 
+<syn-drawer open>
+  <my-custom-popup-select></my-custom-popup-select>
+</syn-drawer>
+
 <script type="module">
   // Inside my-custom-popup-select keyboard handling
-  // Focus may jump to the syn-dialog close button on ArrowDown
+  // Focus may jump to the modal close button on ArrowDown
 </script>
 ```
 
@@ -339,14 +343,14 @@ When opening a popup inside a dialog, temporarily disable the dialog focus trap 
 
 ```js
 // Example component logic
-const dialog = this.closest("syn-dialog");
+const modalHost = this.closest("syn-dialog, syn-drawer");
 
 function onOpenPopup() {
-  dialog?.modal?.activateExternal();
+  modalHost?.modal?.activateExternal();
 }
 
 function onClosePopup() {
-  dialog?.modal?.deactivateExternal();
+  modalHost?.modal?.deactivateExternal();
 }
 ```
 

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-06-03T07:54:19.204Z",
+  "builtAt": "2026-06-08T07:20:08.600Z",
   "sources": [
     {
       "entityCount": 4,

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-06-08T07:20:08.600Z",
+  "builtAt": "2026-06-08T09:36:50.977Z",
   "sources": [
     {
       "entityCount": 4,


### PR DESCRIPTION
<!--
Thanks for filing a pull request 😄! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This release fixes an issue with multiple Synergy components automatically closing when opened in a `<syn-dialog>` element in Chromium based browsers. This happens because Chromium now uses a more aggressive method of checking the active focused element.

### 🎫 Issues

Closes #1297 

## 👩‍💻 Reviewer Notes

You can test the behavior by adjusting the `select.story.ts`. Just copy the content of a regular select story into a `<syn-dialog open>` and check how it behaves on an up 2 date browser version (e.g. Chrome, Chromium, Edge).

- I had to couple syn-select and syn-dropdown via a check in syn-dialog to make it possible to provide the bugfix without user interaction. This may be removed later on when we switch `<syn-dialog>` rendering to a native dialog element.

## 📑 Test Plan

<!--
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
