### PR TITLE
fix: 🐛 Indentation of nav-items in side-nav not shown correctly for chrome >149

### DIFF
--- a/.changeset/1348-nav-item-indentation-nan-chromium.md
+++ b/.changeset/1348-nav-item-indentation-nan-chromium.md
@@ -1,0 +1,6 @@
+---
+"@synergy-design-system/components": patch
+"@synergy-design-system/metadata": patch
+---
+
+fix: 🐛 Indentation of nested nav-items in side-nav was not shown correctly in newer Chrome versions (>149) (#1348)

--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -401,20 +401,20 @@ export default class SynNavItem extends SynergyElement {
         aria-disabled=${this.disabled}
         @blur=${this.handleBlur}
         class=${classMap({
-      'nav-item': true,
-      'nav-item--current': this.current || showCurrentIndicatorForNested,
-      'nav-item--disabled': this.disabled,
-      'nav-item--focused': this.hasFocus,
-      'nav-item--has-content': this.hasSlotController.test('[default]'),
-      'nav-item--has-prefix': this.hasSlotController.test('prefix'),
-      'nav-item--has-suffix': this.hasSlotController.test('suffix'),
-      'nav-item--horizontal': this.horizontal,
-      'nav-item--is-link': isLink,
-      'nav-item--multi-line': this.isMultiLine,
-      'nav-item--show-prefix-only': this.showPrefixOnly,
-      'nav-item--vertical': !this.horizontal,
-      'nav-item-is-accordion': isAccordion,
-    })}
+          'nav-item': true,
+          'nav-item--current': this.current || showCurrentIndicatorForNested,
+          'nav-item--disabled': this.disabled,
+          'nav-item--focused': this.hasFocus,
+          'nav-item--has-content': this.hasSlotController.test('[default]'),
+          'nav-item--has-prefix': this.hasSlotController.test('prefix'),
+          'nav-item--has-suffix': this.hasSlotController.test('suffix'),
+          'nav-item--horizontal': this.horizontal,
+          'nav-item--is-link': isLink,
+          'nav-item--multi-line': this.isMultiLine,
+          'nav-item--show-prefix-only': this.showPrefixOnly,
+          'nav-item--vertical': !this.horizontal,
+          'nav-item-is-accordion': isAccordion,
+        })}
         @click=${clickAction}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
         @focus=${this.handleFocus}
@@ -427,9 +427,9 @@ export default class SynNavItem extends SynergyElement {
       >
 
         ${this.divider && !this.horizontal
-        ? html`<syn-divider class="divider" part="divider"></syn-divider>`
-        : ''
-      }
+          ? html`<syn-divider class="divider" part="divider"></syn-divider>`
+          : ''
+        }
 
         <div class="nav-item__content" part="content-wrapper">
           <slot name="prefix" part="prefix" class="nav-item__prefix"></slot>
@@ -443,21 +443,21 @@ export default class SynNavItem extends SynergyElement {
           ${hasChevron ? html`
             <syn-icon
               class=${classMap({
-        'nav-item__chevron': true,
-        'nav-item__chevron-open': this.open,
-      })}
+                'nav-item__chevron': true,
+                'nav-item__chevron-open': this.open,
+              })}
               library="system"
               name="chevron-down"
               part="chevron"
             /></syn-icon>`
-        : ''}
+          : ''}
 
           <div
             class=${classMap({
-          'current-indicator': true,
-          'current-indicator--disabled': this.disabled,
-          'current-indicator--visible': this.current || showCurrentIndicatorForNested,
-        })}
+              'current-indicator': true,
+              'current-indicator--disabled': this.disabled,
+              'current-indicator--visible': this.current || showCurrentIndicatorForNested,
+            })}
             part="current-indicator"
           >
           </div>

--- a/packages/components/src/components/nav-item/nav-item.component.ts
+++ b/packages/components/src/components/nav-item/nav-item.component.ts
@@ -243,24 +243,21 @@ export default class SynNavItem extends SynergyElement {
    */
   private handleSlotChange() {
     const computedStyle = getComputedStyle(this);
-    const lengthStyle = computedStyle.length;
+    // Use the current level of the component
+    const level = computedStyle.getPropertyValue('--indentation');
 
-    // This workaround is needed for firefox.
+    // This workaround is needed for firefox and chrome (version > 149 https://github.com/synergy-design-system/synergy-design-system/issues/1348).
     // When the nav-item is used inside a custom-element with a custom-element in it
-    // (e.g syn-side-nav with integrated syn-drawer), the getComputedStyle property is not yet there
+    // (e.g syn-side-nav with integrated syn-drawer), the styles of getComputedStyle are not yet there
     // Moving it in the next render cycle works.
-    // Probably related to the firefox special behavior. See: https://caniuse.com/mdn-api_window_getcomputedstyle
-    if (lengthStyle === 0) {
-      setTimeout(() => {
+    if (level === '') {
+      requestAnimationFrame(() => {
         this.handleSlotChange();
       });
       return;
     }
 
     this.handleCurrentMarkedChild();
-
-    // Use the current level of the component
-    const level = computedStyle.getPropertyValue('--indentation');
 
     // We allow at most 3 levels
     const nextLevel = Math.min(parseInt(level, 10) + 1, 2);
@@ -404,20 +401,20 @@ export default class SynNavItem extends SynergyElement {
         aria-disabled=${this.disabled}
         @blur=${this.handleBlur}
         class=${classMap({
-          'nav-item': true,
-          'nav-item--current': this.current || showCurrentIndicatorForNested,
-          'nav-item--disabled': this.disabled,
-          'nav-item--focused': this.hasFocus,
-          'nav-item--has-content': this.hasSlotController.test('[default]'),
-          'nav-item--has-prefix': this.hasSlotController.test('prefix'),
-          'nav-item--has-suffix': this.hasSlotController.test('suffix'),
-          'nav-item--horizontal': this.horizontal,
-          'nav-item--is-link': isLink,
-          'nav-item--multi-line': this.isMultiLine,
-          'nav-item--show-prefix-only': this.showPrefixOnly,
-          'nav-item--vertical': !this.horizontal,
-          'nav-item-is-accordion': isAccordion,
-        })}
+      'nav-item': true,
+      'nav-item--current': this.current || showCurrentIndicatorForNested,
+      'nav-item--disabled': this.disabled,
+      'nav-item--focused': this.hasFocus,
+      'nav-item--has-content': this.hasSlotController.test('[default]'),
+      'nav-item--has-prefix': this.hasSlotController.test('prefix'),
+      'nav-item--has-suffix': this.hasSlotController.test('suffix'),
+      'nav-item--horizontal': this.horizontal,
+      'nav-item--is-link': isLink,
+      'nav-item--multi-line': this.isMultiLine,
+      'nav-item--show-prefix-only': this.showPrefixOnly,
+      'nav-item--vertical': !this.horizontal,
+      'nav-item-is-accordion': isAccordion,
+    })}
         @click=${clickAction}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
         @focus=${this.handleFocus}
@@ -430,9 +427,9 @@ export default class SynNavItem extends SynergyElement {
       >
 
         ${this.divider && !this.horizontal
-          ? html`<syn-divider class="divider" part="divider"></syn-divider>`
-          : ''
-        }
+        ? html`<syn-divider class="divider" part="divider"></syn-divider>`
+        : ''
+      }
 
         <div class="nav-item__content" part="content-wrapper">
           <slot name="prefix" part="prefix" class="nav-item__prefix"></slot>
@@ -446,21 +443,21 @@ export default class SynNavItem extends SynergyElement {
           ${hasChevron ? html`
             <syn-icon
               class=${classMap({
-                'nav-item__chevron': true,
-                'nav-item__chevron-open': this.open,
-              })}
+        'nav-item__chevron': true,
+        'nav-item__chevron-open': this.open,
+      })}
               library="system"
               name="chevron-down"
               part="chevron"
             /></syn-icon>`
-          : ''}
+        : ''}
 
           <div
             class=${classMap({
-              'current-indicator': true,
-              'current-indicator--disabled': this.disabled,
-              'current-indicator--visible': this.current || showCurrentIndicatorForNested,
-            })}
+          'current-indicator': true,
+          'current-indicator--disabled': this.disabled,
+          'current-indicator--visible': this.current || showCurrentIndicatorForNested,
+        })}
             part="current-indicator"
           >
           </div>

--- a/packages/components/src/components/side-nav/side-nav.test.ts
+++ b/packages/components/src/components/side-nav/side-nav.test.ts
@@ -440,15 +440,7 @@ describe('<syn-side-nav>', () => {
     });
   });
 
-  it('should show an indentation for nested nav-items (#708)', async () => {
-    // TODO: for now this test is skipped for chromium, as since version 151 there is a bug that causes the indentation to be NAN for all nav-items. See https://github.com/synergy-design-system/synergy-design-system/issues/1348
-    // remove the skip as soon as the bug is fixed
-    if (navigator.userAgent.includes('Chrome')) {
-      // eslint-disable-next-line no-console
-      console.warn('Skipping Chrome test for indentation due to bug in Chromium 151+');
-      return;
-    }
-
+  it('should show an indentation for nested nav-items (#708, #1348)', async () => {
     const sideNav = await fixture<SynSideNav>(html`
       <syn-side-nav>
         <syn-nav-item id="first">

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-08-04T12:08:32.993Z",
+  "builtAt": "2026-08-05T08:53:49.871Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset__sick2018-icons.json",

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-08-05T08:53:49.871Z",
+  "builtAt": "2026-08-05T09:19:10.467Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset__sick2018-icons.json",

--- a/packages/metadata/data/layers/full/component/component__syn-nav-item/components/nav-item.component.ts
+++ b/packages/metadata/data/layers/full/component/component__syn-nav-item/components/nav-item.component.ts
@@ -401,20 +401,20 @@ export default class SynNavItem extends SynergyElement {
         aria-disabled=${this.disabled}
         @blur=${this.handleBlur}
         class=${classMap({
-      'nav-item': true,
-      'nav-item--current': this.current || showCurrentIndicatorForNested,
-      'nav-item--disabled': this.disabled,
-      'nav-item--focused': this.hasFocus,
-      'nav-item--has-content': this.hasSlotController.test('[default]'),
-      'nav-item--has-prefix': this.hasSlotController.test('prefix'),
-      'nav-item--has-suffix': this.hasSlotController.test('suffix'),
-      'nav-item--horizontal': this.horizontal,
-      'nav-item--is-link': isLink,
-      'nav-item--multi-line': this.isMultiLine,
-      'nav-item--show-prefix-only': this.showPrefixOnly,
-      'nav-item--vertical': !this.horizontal,
-      'nav-item-is-accordion': isAccordion,
-    })}
+          'nav-item': true,
+          'nav-item--current': this.current || showCurrentIndicatorForNested,
+          'nav-item--disabled': this.disabled,
+          'nav-item--focused': this.hasFocus,
+          'nav-item--has-content': this.hasSlotController.test('[default]'),
+          'nav-item--has-prefix': this.hasSlotController.test('prefix'),
+          'nav-item--has-suffix': this.hasSlotController.test('suffix'),
+          'nav-item--horizontal': this.horizontal,
+          'nav-item--is-link': isLink,
+          'nav-item--multi-line': this.isMultiLine,
+          'nav-item--show-prefix-only': this.showPrefixOnly,
+          'nav-item--vertical': !this.horizontal,
+          'nav-item-is-accordion': isAccordion,
+        })}
         @click=${clickAction}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
         @focus=${this.handleFocus}
@@ -427,9 +427,9 @@ export default class SynNavItem extends SynergyElement {
       >
 
         ${this.divider && !this.horizontal
-        ? html`<syn-divider class="divider" part="divider"></syn-divider>`
-        : ''
-      }
+          ? html`<syn-divider class="divider" part="divider"></syn-divider>`
+          : ''
+        }
 
         <div class="nav-item__content" part="content-wrapper">
           <slot name="prefix" part="prefix" class="nav-item__prefix"></slot>
@@ -443,21 +443,21 @@ export default class SynNavItem extends SynergyElement {
           ${hasChevron ? html`
             <syn-icon
               class=${classMap({
-        'nav-item__chevron': true,
-        'nav-item__chevron-open': this.open,
-      })}
+                'nav-item__chevron': true,
+                'nav-item__chevron-open': this.open,
+              })}
               library="system"
               name="chevron-down"
               part="chevron"
             /></syn-icon>`
-        : ''}
+          : ''}
 
           <div
             class=${classMap({
-          'current-indicator': true,
-          'current-indicator--disabled': this.disabled,
-          'current-indicator--visible': this.current || showCurrentIndicatorForNested,
-        })}
+              'current-indicator': true,
+              'current-indicator--disabled': this.disabled,
+              'current-indicator--visible': this.current || showCurrentIndicatorForNested,
+            })}
             part="current-indicator"
           >
           </div>

--- a/packages/metadata/data/layers/full/component/component__syn-nav-item/components/nav-item.component.ts
+++ b/packages/metadata/data/layers/full/component/component__syn-nav-item/components/nav-item.component.ts
@@ -243,24 +243,21 @@ export default class SynNavItem extends SynergyElement {
    */
   private handleSlotChange() {
     const computedStyle = getComputedStyle(this);
-    const lengthStyle = computedStyle.length;
+    // Use the current level of the component
+    const level = computedStyle.getPropertyValue('--indentation');
 
-    // This workaround is needed for firefox.
+    // This workaround is needed for firefox and chrome (version > 149 https://github.com/synergy-design-system/synergy-design-system/issues/1348).
     // When the nav-item is used inside a custom-element with a custom-element in it
-    // (e.g syn-side-nav with integrated syn-drawer), the getComputedStyle property is not yet there
+    // (e.g syn-side-nav with integrated syn-drawer), the styles of getComputedStyle are not yet there
     // Moving it in the next render cycle works.
-    // Probably related to the firefox special behavior. See: https://caniuse.com/mdn-api_window_getcomputedstyle
-    if (lengthStyle === 0) {
-      setTimeout(() => {
+    if (level === '') {
+      requestAnimationFrame(() => {
         this.handleSlotChange();
       });
       return;
     }
 
     this.handleCurrentMarkedChild();
-
-    // Use the current level of the component
-    const level = computedStyle.getPropertyValue('--indentation');
 
     // We allow at most 3 levels
     const nextLevel = Math.min(parseInt(level, 10) + 1, 2);
@@ -404,20 +401,20 @@ export default class SynNavItem extends SynergyElement {
         aria-disabled=${this.disabled}
         @blur=${this.handleBlur}
         class=${classMap({
-          'nav-item': true,
-          'nav-item--current': this.current || showCurrentIndicatorForNested,
-          'nav-item--disabled': this.disabled,
-          'nav-item--focused': this.hasFocus,
-          'nav-item--has-content': this.hasSlotController.test('[default]'),
-          'nav-item--has-prefix': this.hasSlotController.test('prefix'),
-          'nav-item--has-suffix': this.hasSlotController.test('suffix'),
-          'nav-item--horizontal': this.horizontal,
-          'nav-item--is-link': isLink,
-          'nav-item--multi-line': this.isMultiLine,
-          'nav-item--show-prefix-only': this.showPrefixOnly,
-          'nav-item--vertical': !this.horizontal,
-          'nav-item-is-accordion': isAccordion,
-        })}
+      'nav-item': true,
+      'nav-item--current': this.current || showCurrentIndicatorForNested,
+      'nav-item--disabled': this.disabled,
+      'nav-item--focused': this.hasFocus,
+      'nav-item--has-content': this.hasSlotController.test('[default]'),
+      'nav-item--has-prefix': this.hasSlotController.test('prefix'),
+      'nav-item--has-suffix': this.hasSlotController.test('suffix'),
+      'nav-item--horizontal': this.horizontal,
+      'nav-item--is-link': isLink,
+      'nav-item--multi-line': this.isMultiLine,
+      'nav-item--show-prefix-only': this.showPrefixOnly,
+      'nav-item--vertical': !this.horizontal,
+      'nav-item-is-accordion': isAccordion,
+    })}
         @click=${clickAction}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
         @focus=${this.handleFocus}
@@ -430,9 +427,9 @@ export default class SynNavItem extends SynergyElement {
       >
 
         ${this.divider && !this.horizontal
-          ? html`<syn-divider class="divider" part="divider"></syn-divider>`
-          : ''
-        }
+        ? html`<syn-divider class="divider" part="divider"></syn-divider>`
+        : ''
+      }
 
         <div class="nav-item__content" part="content-wrapper">
           <slot name="prefix" part="prefix" class="nav-item__prefix"></slot>
@@ -446,21 +443,21 @@ export default class SynNavItem extends SynergyElement {
           ${hasChevron ? html`
             <syn-icon
               class=${classMap({
-                'nav-item__chevron': true,
-                'nav-item__chevron-open': this.open,
-              })}
+        'nav-item__chevron': true,
+        'nav-item__chevron-open': this.open,
+      })}
               library="system"
               name="chevron-down"
               part="chevron"
             /></syn-icon>`
-          : ''}
+        : ''}
 
           <div
             class=${classMap({
-              'current-indicator': true,
-              'current-indicator--disabled': this.disabled,
-              'current-indicator--visible': this.current || showCurrentIndicatorForNested,
-            })}
+          'current-indicator': true,
+          'current-indicator--disabled': this.disabled,
+          'current-indicator--visible': this.current || showCurrentIndicatorForNested,
+        })}
             part="current-indicator"
           >
           </div>

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-08-04T12:08:32.994Z",
+  "builtAt": "2026-08-05T08:53:49.871Z",
   "sources": [
     {
       "entityCount": 4,

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-08-05T08:53:49.871Z",
+  "builtAt": "2026-08-05T09:19:10.467Z",
   "sources": [
     {
       "entityCount": 4,


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes an issue in Chromium (>149) where nested nav items could get NaN indentation on initial render. The component now defers child indentation handling until the --indentation CSS custom property is available.
It is a similar problem, we already had with firefox and needed a fix for (see #708 )

### 🎫 Issues
Closes #1348 

## 👩‍💻 Reviewer Notes
For the root cause analysis see the comment in #1348 

## 📑 Test Plan

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
