### PR TITLE
fix: 🐛 multiple issues with syn-combobox

### DIFF
--- a/.changeset/1358-1362-multiple-combobox-issues.md
+++ b/.changeset/1358-1362-multiple-combobox-issues.md
@@ -1,0 +1,11 @@
+---
+"@synergy-design-system/components": patch
+---
+
+fix: 🐛 `<syn-combobox>` multiple issues (#1358, #1362)
+
+This release fixes multiple issues when using `<syn-combobox>`:
+- Keeps the current typed value when restricted options are loaded asynchronously while the user is typing.
+- Prevents automatic selection changes when options are added or updated asynchronously during user input.
+- Prevents the listbox from reopening after selecting an option from dynamically created on-demand options.
+- Shows all partial matches again when opening the combobox after the value was set programmatically.

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -980,13 +980,6 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
         // This is only for non multiple
         optionValue = getValueFromOption(this.selectedOptions[0]);
       } else if (this.restricted && !this.isValidValue(this.displayLabel) && this.displayLabel !== '' && !this.isUserInput) {
-        // #1358 should not reset input if the user typed something and the slotted options are getting updated via async options (e.g. because of fetching new options while user typing)
-        const currentValue = Array.isArray(this.value) ? this.value.join(this.delimiter) : String(this.value ?? '');
-        if (this.open && currentValue === this.displayLabel) {
-          this.valueHasChanged = cachedValueHasChanged;
-          return;
-        }
-
         // if an invalid value was set via property binding for `restricted`comboboxes,
         // reset to last valid value
         this.resetToLastValidValue();
@@ -1431,8 +1424,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   }
   /* eslint-enable no-param-reassign */
 
-  private updateSelectedOptionFromValue(): void {
-    if (!this.isUserInput) {
+  private updateSelectedOptionFromValue(skipSelection = false): void {
+    if (!this.isUserInput && !skipSelection) {
       // check if the value has corresponding options via value or text content
       // for empty values use the text content, as then the values of the options are not set
       const options = this.getOptionsFromValue();
@@ -1480,8 +1473,9 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
     this.handleDelimiterChange();
     this.cacheSlottedOptionsAndOptgroups();
-
-    this.updateSelectedOptionFromValue();
+    // #1358 Prevent selection changes while the user is typing and async option updates modify the slotted options.
+    const skipSelection = this.open && this.hasFocus && this.displayLabel !== '';
+    this.updateSelectedOptionFromValue(skipSelection);
 
     // Auto-open listbox for better UX when new options are added during interaction
     let hasValue: boolean;

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -1474,7 +1474,7 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
     this.handleDelimiterChange();
     this.cacheSlottedOptionsAndOptgroups();
     // #1358 Prevent selection changes while the user is typing and async option updates modify the slotted options.
-    const skipSelection = this.open && this.hasFocus && this.displayLabel !== '';
+    const skipSelection = this.hasFocus && this.displayLabel !== '';
     this.updateSelectedOptionFromValue(skipSelection);
 
     // Auto-open listbox for better UX when new options are added during interaction
@@ -1487,7 +1487,12 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
       hasValue = this.value !== undefined && this.value !== null;
     }
 
-    if (this.hasFocus && hasValue && !this.open) {
+    const options = this.getOptionsFromValue();
+    // #1358: Do not open the listbox again, if the value is exactly the already selected option
+    // This can happen, if the stakeholders create and update options on demand from user input
+    const hasSelected = options.some(opt => opt.selected);
+
+    if (this.hasFocus && hasValue && !this.open && !hasSelected) {
       this.show();
     }
   }

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -980,6 +980,13 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
         // This is only for non multiple
         optionValue = getValueFromOption(this.selectedOptions[0]);
       } else if (this.restricted && !this.isValidValue(this.displayLabel) && this.displayLabel !== '' && !this.isUserInput) {
+        // #1358 should not reset input if the user typed something and the slotted options are getting updated via async options (e.g. because of fetching new options while user typing)
+        const currentValue = Array.isArray(this.value) ? this.value.join(this.delimiter) : String(this.value ?? '');
+        if (this.open && currentValue === this.displayLabel) {
+          this.valueHasChanged = cachedValueHasChanged;
+          return;
+        }
+
         // if an invalid value was set via property binding for `restricted`comboboxes,
         // reset to last valid value
         this.resetToLastValidValue();

--- a/packages/components/src/components/combobox/combobox.component.ts
+++ b/packages/components/src/components/combobox/combobox.component.ts
@@ -296,7 +296,9 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
       return true;
     }
 
-    return option?.value?.toString() === queryStr;
+    // #1362 do not do an equal test, as other filtered options should also be shown if they partially match
+    const value = option?.value?.toString() || '';
+    return value.includes(queryStr);
   };
 
   /**

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -2402,28 +2402,59 @@ describe('<syn-combobox>', () => {
       const el = await fixture<SynCombobox>(html`<syn-combobox restricted></syn-combobox>`);
       const data = ['Apple', 'Apricot', 'Banana'];
 
-      el.addEventListener('syn-input', (event) => {
-        const term = (event.target as SynCombobox).value?.toString().trim();
-        const matches = data.filter(item => item.toLowerCase().startsWith(term.toLowerCase()));
-        [...el.querySelectorAll('syn-option')].forEach(option => option.remove());
+      const fetchPromise = new Promise<void>((resolve) => {
+        el.addEventListener('syn-input', (event) => {
+          const term = (event.target as SynCombobox).value?.toString().trim();
+          aTimeout(200).then(() => {
+            const matches = data.filter(item => item.toLowerCase().startsWith(term.toLowerCase()));
+            [...el.querySelectorAll('syn-option')].forEach(option => option.remove());
 
-        matches.forEach(item => {
-          const option = document.createElement('syn-option');
-          option.value = item;
-          option.textContent = item;
-          el.appendChild(option);
+            matches.forEach(item => {
+              const option = document.createElement('syn-option');
+              option.value = item;
+              option.textContent = item;
+              el.appendChild(option);
+            });
+            resolve();
+          });
         });
       });
 
       el.focus();
       await sendKeys({ type: 'ap' });
       await el.updateComplete;
-      await aTimeout(200);
+      // Wait for promise
+      await fetchPromise;
+      // wait for combobox to render the new options
       await el.updateComplete;
 
       expect(el.displayInput.value).to.equal('ap');
       expect(el.value).to.equal('ap');
       expect(el.querySelectorAll('syn-option')).to.have.lengthOf(2);
+    });
+
+    it('should not auto-select an exactly matching option when the user only typed without selecting it and another option was added dynamically', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox>
+          <syn-option value="Apple">Apple</syn-option>
+          <syn-option value="Apricot">Apricot</syn-option>
+        </syn-combobox>
+      `);
+
+      el.focus();
+      await sendKeys({ type: 'Apple' });
+      await el.updateComplete;
+
+      const dynamicOption = document.createElement('syn-option');
+      dynamicOption.value = 'Banana';
+      dynamicOption.textContent = 'Banana';
+      el.appendChild(dynamicOption);
+      await el.updateComplete;
+
+      const options = el.querySelectorAll('syn-option');
+      expect(options[0].selected).to.be.false;
+      expect(options[1].selected).to.be.false;
+      expect(options[2].selected).to.be.false;
     });
   });
 

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -2398,33 +2398,55 @@ describe('<syn-combobox>', () => {
   }); // #805
 
   describe('#1358', () => {
+    const fetchMatches = (term: string) => new Promise<string[]>((resolve) => {
+      const data = ['Apple', 'Apricot', 'Banana'];
+      setTimeout(() => {
+        resolve(data.filter(item => item.toLowerCase().startsWith(term.toLowerCase())));
+      }, 200);
+    });
+
+    // Dynamically remove and add options based on the user input
+    const syncOptionsWithFetches = (term: string, element: SynCombobox) => fetchMatches(term).then(results => {
+      const resultSet = new Set(results);
+      const existingOptions = [...element.querySelectorAll<SynOption>('syn-option')];
+
+      // Remove options that are no longer present
+      existingOptions.forEach(option => {
+        const value = option.value.toString() || option.textContent || '';
+        if (!resultSet.has(value)) {
+          option.remove();
+        }
+      });
+
+      // Only add missing options
+      const existingValues = new Set(
+        [...element.querySelectorAll<SynOption>('syn-option')].map(option => option.value || option.textContent),
+      );
+
+      results.forEach(result => {
+        if (!existingValues.has(result)) {
+          const option = document.createElement('syn-option');
+          option.value = result;
+          option.textContent = result;
+          element.appendChild(option);
+        }
+      });
+    });
+
     it('should keep the current typed user value while async restricted options are added dynamically', async () => {
       const el = await fixture<SynCombobox>(html`<syn-combobox restricted></syn-combobox>`);
-      const data = ['Apple', 'Apricot', 'Banana'];
+      let pendingUpdate: Promise<void> = Promise.resolve();
 
-      const fetchPromise = new Promise<void>((resolve) => {
-        el.addEventListener('syn-input', (event) => {
-          const term = (event.target as SynCombobox).value?.toString().trim();
-          aTimeout(200).then(() => {
-            const matches = data.filter(item => item.toLowerCase().startsWith(term.toLowerCase()));
-            [...el.querySelectorAll('syn-option')].forEach(option => option.remove());
-
-            matches.forEach(item => {
-              const option = document.createElement('syn-option');
-              option.value = item;
-              option.textContent = item;
-              el.appendChild(option);
-            });
-            resolve();
-          });
-        });
+      el.addEventListener('syn-input', (event) => {
+        const term = (event.target as SynCombobox).value?.toString().trim();
+        pendingUpdate = syncOptionsWithFetches(term || '', el);
       });
 
       el.focus();
       await sendKeys({ type: 'ap' });
       await el.updateComplete;
       // Wait for promise
-      await fetchPromise;
+      await pendingUpdate;
       // wait for combobox to render the new options
       await el.updateComplete;
 
@@ -2455,6 +2477,32 @@ describe('<syn-combobox>', () => {
       expect(options[0].selected).to.be.false;
       expect(options[1].selected).to.be.false;
       expect(options[2].selected).to.be.false;
+    });
+
+    it('should not reopen the listbox if the value is already selected and options are created on user input', async () => {
+      const el = await fixture<SynCombobox>(html`<syn-combobox restricted></syn-combobox>`);
+
+      let pendingUpdate: Promise<void> = Promise.resolve();
+
+      el.addEventListener('syn-input', (event) => {
+        const term = (event.target as SynCombobox).value?.toString().trim();
+        pendingUpdate = syncOptionsWithFetches(term || '', el);
+      });
+
+      el.focus();
+      await sendKeys({ type: 'a' });
+      await pendingUpdate;
+      await el.updateComplete;
+
+      const appleOption = el.querySelector<SynOption>('syn-option[value="Apple"]');
+
+      await clickOnElement(appleOption!);
+      await pendingUpdate;
+      await el.updateComplete;
+
+      expect(el.value).to.equal('Apple');
+      expect(el.displayInput.value).to.equal('Apple');
+      expect(el.open).to.be.false;
     });
   });
 

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -2397,5 +2397,35 @@ describe('<syn-combobox>', () => {
     });
   }); // #805
 
+  describe('#1358', () => {
+    it('should keep the current typed user value while async restricted options are added dynamically', async () => {
+      const el = await fixture<SynCombobox>(html`<syn-combobox restricted></syn-combobox>`);
+      const data = ['Apple', 'Apricot', 'Banana'];
+
+      el.addEventListener('syn-input', (event) => {
+        const term = (event.target as SynCombobox).value?.toString().trim();
+        const matches = data.filter(item => item.toLowerCase().startsWith(term.toLowerCase()));
+        [...el.querySelectorAll('syn-option')].forEach(option => option.remove());
+
+        matches.forEach(item => {
+          const option = document.createElement('syn-option');
+          option.value = item;
+          option.textContent = item;
+          el.appendChild(option);
+        });
+      });
+
+      el.focus();
+      await sendKeys({ type: 'ap' });
+      await el.updateComplete;
+      await aTimeout(200);
+      await el.updateComplete;
+
+      expect(el.displayInput.value).to.equal('ap');
+      expect(el.value).to.equal('ap');
+      expect(el.querySelectorAll('syn-option')).to.have.lengthOf(2);
+    });
+  });
+
   runFormControlBaseTests('syn-combobox');
 });

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -1272,6 +1272,7 @@ describe('<syn-combobox>', () => {
     expect(thirdOption).to.be.displayed;
 
     secondOption.textContent = 'updated';
+    secondOption.value = 'updated';
     await nextFrame();
 
     expect(firstOption).to.be.displayed;
@@ -2503,6 +2504,60 @@ describe('<syn-combobox>', () => {
       expect(el.value).to.equal('Apple');
       expect(el.displayInput.value).to.equal('Apple');
       expect(el.open).to.be.false;
+    });
+  });
+
+  describe('#1362', () => {
+    it('should show all possible matches when the value was set programmatically and the combobox is opened (textContent)', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox value="Option 1">
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-11">Option 11</syn-option>
+        </syn-combobox>
+      `);
+
+      await el.updateComplete;
+      // Waiting for the updateComplete is not enough for the option rendering cycle to be finished
+      await aTimeout(0);
+
+      expect(el.value).to.equal('option-1');
+      expect(el.displayInput.value).to.equal('Option 1');
+
+      el.open = true;
+      await el.updateComplete;
+
+      const options = el.querySelectorAll<SynOption>('syn-option');
+
+      expect(options[0].hidden).to.be.false;
+      expect(options[1].hidden).to.be.true;
+      expect(options[2].hidden).to.be.false;
+    });
+
+    it('should show all possible matches when the value was set programmatically and the combobox is opened (value)', async () => {
+      const el = await fixture<SynCombobox>(html`
+        <syn-combobox value="option-1">
+          <syn-option value="option-1">Option 1</syn-option>
+          <syn-option value="option-2">Option 2</syn-option>
+          <syn-option value="option-11">Option 11</syn-option>
+        </syn-combobox>
+      `);
+
+      await el.updateComplete;
+      // Waiting for the updateComplete is not enough for the option rendering cycle to be finished
+      await aTimeout(0);
+
+      expect(el.value).to.equal('option-1');
+      expect(el.displayInput.value).to.equal('Option 1');
+
+      el.open = true;
+      await el.updateComplete;
+
+      const options = el.querySelectorAll<SynOption>('syn-option');
+
+      expect(options[0].hidden).to.be.false;
+      expect(options[1].hidden).to.be.true;
+      expect(options[2].hidden).to.be.false;
     });
   });
 

--- a/packages/metadata/data/index.json
+++ b/packages/metadata/data/index.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-08-31T09:30:22.398Z",
+  "builtAt": "2026-09-10T09:46:49.600Z",
   "entities": [
     {
       "corePath": "data/core/asset/asset__sick2018-icons.json",

--- a/packages/metadata/data/layers/full/component/component__syn-combobox/components/combobox.component.ts
+++ b/packages/metadata/data/layers/full/component/component__syn-combobox/components/combobox.component.ts
@@ -296,7 +296,9 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
       return true;
     }
 
-    return option?.value?.toString() === queryStr;
+    // #1362 do not do an equal test, as other filtered options should also be shown if they partially match
+    const value = option?.value?.toString() || '';
+    return value.includes(queryStr);
   };
 
   /**
@@ -1424,8 +1426,8 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
   }
   /* eslint-enable no-param-reassign */
 
-  private updateSelectedOptionFromValue(): void {
-    if (!this.isUserInput) {
+  private updateSelectedOptionFromValue(skipSelection = false): void {
+    if (!this.isUserInput && !skipSelection) {
       // check if the value has corresponding options via value or text content
       // for empty values use the text content, as then the values of the options are not set
       const options = this.getOptionsFromValue();
@@ -1473,8 +1475,9 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
 
     this.handleDelimiterChange();
     this.cacheSlottedOptionsAndOptgroups();
-
-    this.updateSelectedOptionFromValue();
+    // #1358 Prevent selection changes while the user is typing and async option updates modify the slotted options.
+    const skipSelection = this.hasFocus && this.displayLabel !== '';
+    this.updateSelectedOptionFromValue(skipSelection);
 
     // Auto-open listbox for better UX when new options are added during interaction
     let hasValue: boolean;
@@ -1486,7 +1489,12 @@ export default class SynCombobox extends SynergyElement implements SynergyFormCo
       hasValue = this.value !== undefined && this.value !== null;
     }
 
-    if (this.hasFocus && hasValue && !this.open) {
+    const options = this.getOptionsFromValue();
+    // #1358: Do not open the listbox again, if the value is exactly the already selected option
+    // This can happen, if the stakeholders create and update options on demand from user input
+    const hasSelected = options.some(opt => opt.selected);
+
+    if (this.hasFocus && hasValue && !this.open && !hasSelected) {
       this.show();
     }
   }

--- a/packages/metadata/data/manifest.json
+++ b/packages/metadata/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "builtAt": "2026-08-31T09:30:22.399Z",
+  "builtAt": "2026-09-10T09:46:49.600Z",
   "sources": [
     {
       "entityCount": 4,


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes multiple issues when using `<syn-combobox>`:
- Keeps the current typed value when restricted options are loaded asynchronously while the user is typing. (#1358)
- Prevents automatic selection changes when options are added or updated asynchronously during user input. (#1358)
- Prevents the listbox from reopening after selecting an option from dynamically created on-demand options. (#1358)
- Shows all partial matches again when opening the combobox after the value was set programmatically. (#1362)

### 🎫 Issues
Closes #1362
Closes #1358

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Do everything as usual.

### Reproducible steps for issue 1362:
Example story: 
```js
export const CodeFor1362: Story = {
  render: () => html`
    <syn-combobox value="Option 1">
      <syn-option value="option-1">Option 1</syn-option>
      <syn-option value="option-2">Option 2</syn-option>
      <syn-option value="option-11">Option 11</syn-option>
    </syn-combobox>
  `,
};
```

Steps:

1. Open combobox and have a look at the options in the listbox
Result before fix: only "Option 1" is visible in the listbox
Result after fix: "Option 1" and "Option 11" are visible in the listbox

### Reproducible steps for issue 1358:
Example story:
```js
export const CodeFor1358: Story = {
  render: () => html`
    <syn-combobox restricted></syn-combobox>
    <script type="module">
      const fetchMatches = (term) => new Promise((resolve) => {
        const data = ['Apple', 'Apricot', 'Banana'];
        setTimeout(() => {
          resolve(data.filter(item => item.toLowerCase().startsWith(term.toLowerCase())));
        }, 200);
      });

    // Dynamically remove and add options based on the user input
    const syncOptionsWithFetches = (term, element) => fetchMatches(term).then(results => {
      const resultSet = new Set(results);
      const existingOptions = [...element.querySelectorAll('syn-option')];

      // Remove options that are no longer present
      existingOptions.forEach(option => {
        const value = option.value.toString() || option.textContent || '';
        if (!resultSet.has(value)) {
          option.remove();
        }
      });

      // Only add missing options
      const existingValues = new Set(
        [...element.querySelectorAll('syn-option')].map(option => option.value || option.textContent),
      );

      results.forEach(result => {
        if (!existingValues.has(result)) {
          const option = document.createElement('syn-option');
          option.value = result;
          option.textContent = result;
          element.appendChild(option);
        }
      });
    });

    const combobox = document.querySelector('syn-combobox');
    combobox.addEventListener('syn-input', (event) => {
      const inputValue = event.target.value;
      syncOptionsWithFetches(inputValue, combobox);
    });
    </script>
  `,
};
```
#### User input is removed
Steps:
1. type `a` and see that options with `a` are shown after a short time and user input is removed (after fix the `a` should stay)

#### Option is automatically selected while user is typing and has not yet actively selected an option
Steps: 
1. Copy "Apple" and paste it into the combobox. When the options have loaded, the "Apple" option is automatically selected. (After fix the "Apple" option is not automatically selected)

#### The listbox is opened again, after an option is selected
Steps:
1. type `a`
2. select the option `Apple` (e.g. via click or keys). The listbox opens up again after a short time (after the fix the listbox is not opened again)



## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [x] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
