### PR TITLE
fix: 🐛 fixes scroll issue with details in dialog

### DIFF
--- a/.changeset/1373-dialog-with-details-scroll-issue.md
+++ b/.changeset/1373-dialog-with-details-scroll-issue.md
@@ -1,0 +1,7 @@
+---
+"@synergy-design-system/components": patch
+---
+
+fix: 🐛 dialog with details scroll issue in Chrome (#1373)
+
+- Fixes a Chrome-specific regression where collapsing a details section inside a dialog could leave the content area at its previous expanded height.

--- a/packages/components/src/components/details/details.component.ts
+++ b/packages/components/src/components/details/details.component.ts
@@ -171,7 +171,11 @@ export default class SynDetails extends SynergyElement {
 
       const { keyframes, options } = getAnimation(this, 'details.hide', { dir: this.localize.dir() });
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-      this.body.style.height = 'auto';
+      // #1373: Chrome can keep the body at the previous expanded height after the hide animation completes,
+      // leaving the content area stale and preventing the scrollable region from being recalculated correctly.
+      // Resetting the height to 0 forces the element to collapse cleanly and avoids the bug where the details
+      // content is clipped or the scrollable area is not sized correctly.
+      this.body.style.height = '0';
 
       this.details.open = false;
       this.emit('syn-after-hide');

--- a/packages/metadata/data/layers/full/component/component__syn-details/components/details.component.ts
+++ b/packages/metadata/data/layers/full/component/component__syn-details/components/details.component.ts
@@ -171,7 +171,11 @@ export default class SynDetails extends SynergyElement {
 
       const { keyframes, options } = getAnimation(this, 'details.hide', { dir: this.localize.dir() });
       await animateTo(this.body, shimKeyframesHeightAuto(keyframes, this.body.scrollHeight), options);
-      this.body.style.height = 'auto';
+      // #1373: Chrome can keep the body at the previous expanded height after the hide animation completes,
+      // leaving the content area stale and preventing the scrollable region from being recalculated correctly.
+      // Resetting the height to 0 forces the element to collapse cleanly and avoids the bug where the details
+      // content is clipped or the scrollable area is not sized correctly.
+      this.body.style.height = '0';
 
       this.details.open = false;
       this.emit('syn-after-hide');


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes a bug in Chromium based browsers (chrome and edge).
When opening and closing syn-details with scrollable content, it happens, that at some point the dialog can no longer scroll to the bottom of the last syn-details.

### 🎫 Issues

Closes #1373 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

### Steps to reproduce (most of the times, sometimes it is a bit random):

1. Click on third syn-details and scroll the dialog to the bottom
2. Click on the second detail and scroll its content down
3. Click on the first detail
4. Click on third syn-details and scroll the dialog to the bottom
5. Click on the second detail
6. click on the first detail
7. Click on the third detail --> it can not be scrolled completely to the bottom

<img width="484" height="678" alt="dialog-details-bug" src="https://github.com/user-attachments/assets/3925b76f-6537-4c3f-9e43-d71448cb503f" />

### Example code:

```js
export const DialogWithDetailsBug: Story = {
  render: () => html`
  <syn-dialog id="my-dialog" label="Dialog" open>
    <syn-details summary="Toggle">
      <div class="bla">
        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
      </div>
    </syn-details>
    <syn-details summary="Toggle">
      <div class="bla">
        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
      </div>
    </syn-details>
    <syn-details summary="Toggle">
      <div>
      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.  
      Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.  
      Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.  
      Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet doming id quod mazim placerat facer possim assum. Lorem
    </div>
    </syn-details>
</syn-dialog>

<script type="module">
  const dialog = document.querySelector('#my-dialog');
  const details = dialog.querySelectorAll('syn-details');

  details.forEach((currentDetails) => {
    currentDetails.addEventListener('syn-show', () => {
      details.forEach((otherDetails) => {
        if (otherDetails !== currentDetails && otherDetails.open) {
          otherDetails.hide();
        }
      });
    });
  });
</script>
<style>
  syn-dialog::part(panel) {
    height: 600px;
  }

  .bla {
    height: 150px;
    overflow: auto;
  }
</style>
`,
};
```

## ✅ DoD

<!-- Please review the list and make sure every item is fulfilled. Place a check (x) for each fulfilled item. -->

- [x] I have tested my changes manually.
- [ ] I have added automatic tests for my changes (unit- and visual regression tests).
- [x] I have updated the project documentation to reflect my changes (e.g. CHANGELOG, Storybook, ...).
- [x] I have made sure to follow the projects coding and contribution guides.
- [x] I have made sure that the bundle size has changed appropriately.
- [x] I have validated that there are no accessibility errors.
- [x] I have added a changeset, describing my changes (e.g. via `pnpm release.create`).
- [x] I have used design tokens instead of fix css values
